### PR TITLE
Typings update

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gitlab",
   "description": "Full NodeJS implementation of the GitLab API. Supports Promises, Async/Await.",
-  "version": "14.1.1",
+  "version": "14.1.2",
   "author": {
     "name": "Justin Dalrymple",
     "email": "justin.s.dalrymple@gmail.com"

--- a/src/core/services/Commits.ts
+++ b/src/core/services/Commits.ts
@@ -11,15 +11,15 @@ export interface CommitSchema {
   id: string;
   short_id: string;
   created_at: Date;
-  parent_ids: string[];
+  parent_ids?: string[];
   title: string;
   message: string;
   author_name: string;
   author_email: string;
-  authored_date: Date;
-  committer_name: string;
-  committer_email: string;
-  committed_date: Date;
+  authored_date?: Date;
+  committer_name?: string;
+  committer_email?: string;
+  committed_date?: Date;
 }
 
 interface CommitAction {

--- a/src/core/services/Commits.ts
+++ b/src/core/services/Commits.ts
@@ -6,6 +6,22 @@ import {
   Sudo,
 } from '../infrastructure';
 
+// As of GitLab v12.6.2
+export interface CommitSchema {
+  id: string;
+  short_id: string;
+  created_at: Date;
+  parent_ids: string[];
+  title: string;
+  message: string;
+  author_name: string;
+  author_email: string;
+  authored_date: Date;
+  committer_name: string;
+  committer_email: string;
+  committed_date: Date;
+}
+
 interface CommitAction {
   /** The action to perform */
   action: 'create' | 'delete' | 'move' | 'update';

--- a/src/core/services/Deployments.ts
+++ b/src/core/services/Deployments.ts
@@ -1,5 +1,38 @@
 import { BaseService, RequestHelper, PaginatedRequestOptions, Sudo } from '../infrastructure';
 
+import { CommitSchema } from './Commits';
+import { PipelineSchema } from './Pipelines';
+import { UserSchema } from './Users';
+import { RunnerSchema } from './Runners';
+
+export type DeploymentStatus = 'created' | 'running' | 'success' | 'failed' | 'canceled';
+
+// Ref: https://docs.gitlab.com/12.6/ee/api/deployments.html#list-project-deployments
+export interface DeploymentSchema {
+  id: number;
+  iid: number;
+  ref: string;
+  sha: string;
+  user: UserSchema;
+}
+
+export interface Deployable {
+  id: number;
+  ref: string;
+  name: string;
+  runner?: RunnerSchema;
+  stage?: string;
+  started_at?: Date;
+  status?: DeploymentStatus;
+  tag: boolean;
+  commit?: CommitSchema;
+  coverage?: string;
+  created_at?: Date;
+  finished_at?: Date;
+  user?: UserSchema;
+  pipeline?: PipelineSchema;
+}
+
 export class Deployments extends BaseService {
   all(projectId: string | number, options?: PaginatedRequestOptions) {
     const pId = encodeURIComponent(projectId);

--- a/src/core/services/Environments.ts
+++ b/src/core/services/Environments.ts
@@ -18,16 +18,24 @@ export interface EnvironmentSchema {
 }
 
 export class Environments extends BaseService {
-  all(projectId: string | number, options?: PaginatedRequestOptions) {
+  all(projectId: string | number, options?: PaginatedRequestOptions): Promise<EnvironmentSchema[]> {
     const pId = encodeURIComponent(projectId);
 
-    return RequestHelper.get(this, `projects/${pId}/environments`, options);
+    return RequestHelper.get(this, `projects/${pId}/environments`, options) as Promise<
+      EnvironmentSchema[]
+    >;
   }
 
-  show(projectId: string | number, environmentId: number, options?: Sudo) {
+  show(
+    projectId: string | number,
+    environmentId: number,
+    options?: Sudo,
+  ): Promise<EnvironmentSchema> {
     const [pId, eId] = [projectId, environmentId].map(encodeURIComponent);
 
-    return RequestHelper.get(this, `projects/${pId}/environments/${eId}`, options);
+    return RequestHelper.get(this, `projects/${pId}/environments/${eId}`, options) as Promise<
+      EnvironmentSchema
+    >;
   }
 
   create(projectId: string | number, options?: BaseRequestOptions) {

--- a/src/core/services/Environments.ts
+++ b/src/core/services/Environments.ts
@@ -5,16 +5,22 @@ import {
   RequestHelper,
   Sudo,
 } from '../infrastructure';
+import { DeploymentSchema } from './Deployments';
 import { ProjectSchema } from './Projects';
 
-// As of GitLab v12.6.2
+// ref: https://docs.gitlab.com/12.6/ee/api/environments.html#list-environments
 export interface EnvironmentSchema {
   id: number;
   name: string;
-  slug: string;
-  external_url: string;
-  project: ProjectSchema;
-  state: string;
+  slug?: string;
+  external_url?: string;
+  project?: ProjectSchema;
+  state?: string;
+}
+
+export interface EnvironmentDetailSchema extends EnvironmentSchema {
+  last_deployment?: DeploymentSchema;
+  deployable?: DeploymentSchema;
 }
 
 export class Environments extends BaseService {
@@ -30,11 +36,10 @@ export class Environments extends BaseService {
     projectId: string | number,
     environmentId: number,
     options?: Sudo,
-  ): Promise<EnvironmentSchema> {
+  ): Promise<EnvironmentDetailSchema> {
     const [pId, eId] = [projectId, environmentId].map(encodeURIComponent);
-
     return RequestHelper.get(this, `projects/${pId}/environments/${eId}`, options) as Promise<
-      EnvironmentSchema
+      EnvironmentDetailSchema
     >;
   }
 

--- a/src/core/services/Environments.ts
+++ b/src/core/services/Environments.ts
@@ -5,6 +5,17 @@ import {
   RequestHelper,
   Sudo,
 } from '../infrastructure';
+import { ProjectSchema } from './Projects';
+
+// As of GitLab v12.6.2
+export interface EnvironmentSchema {
+  id: number;
+  name: string;
+  slug: string;
+  external_url: string;
+  project: ProjectSchema;
+  state: string;
+}
 
 export class Environments extends BaseService {
   all(projectId: string | number, options?: PaginatedRequestOptions) {

--- a/src/core/services/Groups.ts
+++ b/src/core/services/Groups.ts
@@ -7,20 +7,34 @@ import {
 } from '../infrastructure';
 import { ProjectSchema } from './Projects';
 
+// As of GitLab v12.6.2
 export interface GroupSchema {
   id: number;
+  web_url: string;
   name: string;
   path: string;
+  description: string;
+  visibility: string;
+  share_with_group_lock: boolean;
+  require_two_factor_authentication: boolean;
+  two_factor_grace_period: number;
+  project_creation_level: string;
+  auto_devops_enabled?: boolean;
+  subgroup_creation_level: string;
+  emails_disabled?: boolean;
+  lfs_enabled: boolean;
+  avatar_url: string;
+  request_access_enabled: boolean;
   full_name: string;
   full_path: string;
-  parent_id: number;
-  visibility: string;
-  avatar_url: string;
-  web_url: string;
+  parent_id?: number;
 }
 
+// As of GitLab v12.6.2
 export interface GroupDetailSchema extends GroupSchema {
   projects: ProjectSchema[];
+  shared_projects: ProjectSchema[];
+  runners_token: string;
 }
 
 export class Groups extends BaseService {

--- a/src/core/services/Groups.ts
+++ b/src/core/services/Groups.ts
@@ -99,10 +99,15 @@ export class Groups extends BaseService {
     return RequestHelper.get(this, `groups/${gId}`, options) as Promise<GroupDetailSchema>;
   }
 
-  subgroups(groupId: string | number, options?: PaginatedRequestOptions) {
+  subgroups(
+    groupId: string | number,
+    options?: PaginatedRequestOptions,
+  ): Promise<GroupDetailSchema[]> {
     const gId = encodeURIComponent(groupId);
 
-    return RequestHelper.get(this, `groups/${gId}/subgroups`, options);
+    return RequestHelper.get(this, `groups/${gId}/subgroups`, options) as Promise<
+      GroupDetailSchema[]
+    >;
   }
 
   syncLDAP(groupId: string | number, options?: Sudo) {

--- a/src/core/services/Jobs.ts
+++ b/src/core/services/Jobs.ts
@@ -5,6 +5,10 @@ import {
   RequestHelper,
   Sudo,
 } from '../infrastructure';
+import { CommitSchema } from './Commits';
+import { PipelineSchema } from './Pipelines';
+import { RunnerSchema } from './Runners';
+import { UserSchema } from './Users';
 
 export type JobScope =
   | 'created'
@@ -15,6 +19,37 @@ export type JobScope =
   | 'canceled'
   | 'skipped'
   | 'manual';
+
+// As of GitLab v12.6.2
+export interface ArtifactSchema {
+  file_type: string;
+  size: number;
+  filename: string;
+  file_format?: string;
+}
+
+// As of GitLab v12.6.2
+export interface JobSchema {
+  id: number;
+  status: string;
+  stage: string;
+  name: string;
+  ref: string;
+  tag: boolean;
+  coverage?: string;
+  allow_failure: boolean;
+  created_at: Date;
+  started_at?: Date;
+  finished_at?: Date;
+  duration?: number;
+  user: UserSchema;
+  commit: CommitSchema;
+  pipeline: PipelineSchema;
+  web_url: string;
+  artifacts: ArtifactSchema[];
+  runner: RunnerSchema;
+  artifacts_expire_at?: Date;
+}
 
 export class Jobs extends BaseService {
   all(projectId: string | number, options?: PaginatedRequestOptions) {

--- a/src/core/services/Pipelines.ts
+++ b/src/core/services/Pipelines.ts
@@ -5,8 +5,18 @@ import {
   RequestHelper,
   Sudo,
 } from '../infrastructure';
-
 import { JobScope } from './Jobs';
+
+// As of GitLab v12.6.2
+export interface PipelineSchema {
+  id: number;
+  sha: string;
+  ref: string;
+  status: string;
+  created_at: Date;
+  updated_at: Date;
+  web_url: string;
+}
 
 export class Pipelines extends BaseService {
   all(projectId: string | number, options?: PaginatedRequestOptions) {

--- a/src/core/services/ProjectVariables.ts
+++ b/src/core/services/ProjectVariables.ts
@@ -1,6 +1,8 @@
 import { ResourceVariables } from '../templates';
 import { BaseServiceOptions } from '../infrastructure';
 
+export { ResourceVariableSchema } from '../templates';
+
 export class ProjectVariables extends ResourceVariables {
   constructor(options: BaseServiceOptions) {
     super('projects', options);

--- a/src/core/services/Projects.ts
+++ b/src/core/services/Projects.ts
@@ -7,7 +7,9 @@ import {
   Sudo,
 } from '../infrastructure';
 import { EventOptions } from './Events';
+import { GroupSchema } from './Groups';
 import { UploadMetadata } from './ProjectImportExport';
+import { UserSchema } from './Users';
 
 export interface NamespaceInfoSchema {
   id: number;
@@ -15,21 +17,68 @@ export interface NamespaceInfoSchema {
   path: string;
   kind: string;
   full_path: string;
+  parent_id?: number;
+  avatar_url: string;
+  web_url: string;
 }
 
+// As of GitLab v12.6.2
 export interface ProjectSchema {
   id: number;
-
+  description: string;
   name: string;
   name_with_namespace: string;
   path: string;
   path_with_namespace: string;
-
-  namespace: NamespaceInfoSchema;
-
+  created_at: Date;
+  default_branch: string;
+  tag_list: string[];
   ssh_url_to_repo: string;
   http_url_to_repo: string;
+  web_url: string;
+  readme_url: string;
+  avatar_url: string;
+  star_count: number;
+  forks_count: number;
+  last_activity_at: Date;
+  empty_repo: boolean;
   archived: boolean;
+  visibility: string;
+  resolve_outdated_diff_discussions: boolean;
+  container_registry_enabled: boolean;
+  issues_enabled: boolean;
+  merge_requests_enabled: boolean;
+  wiki_enabled: boolean;
+  jobs_enabled: boolean;
+  snippets_enabled: boolean;
+  issues_access_level: string;
+  repository_access_level: string;
+  merge_requests_access_level: string;
+  wiki_access_level: string;
+  builds_access_level: string;
+  snippets_access_level: string;
+  shared_runners_enabled: boolean;
+  lfs_enabled: boolean;
+  creator_id: number;
+  import_status: string;
+  open_issues_count: number;
+  ci_default_git_depth: number;
+  public_jobs: boolean;
+  build_timeout: number;
+  auto_cancel_pending_pipelines?: string;
+  build_coverage_regex?: string;
+  ci_config_path?: string;
+  shared_with_groups: GroupSchema[];
+  only_allow_merge_if_pipeline_succeeds: boolean;
+  request_access_enabled: boolean;
+  only_allow_merge_if_all_discussions_are_resolved: boolean;
+  remove_source_branch_after_merge: boolean;
+  printing_merge_request_link_enabled: boolean;
+  merge_method: string;
+  auto_devops_enabled: boolean;
+  auto_devops_deploy_strategy: string;
+  namespace: NamespaceInfoSchema;
+  owner: UserSchema;
 }
 
 export class Projects extends BaseService {

--- a/src/core/services/Projects.ts
+++ b/src/core/services/Projects.ts
@@ -11,6 +11,7 @@ import { GroupSchema } from './Groups';
 import { UploadMetadata } from './ProjectImportExport';
 import { UserSchema } from './Users';
 
+// ref: https://docs.gitlab.com/12.6/ee/api/namespaces.html#list-namespaces
 export interface NamespaceInfoSchema {
   id: number;
   name: string;
@@ -22,7 +23,7 @@ export interface NamespaceInfoSchema {
   web_url: string;
 }
 
-// As of GitLab v12.6.2
+// Ref: https://docs.gitlab.com/12.6/ee/api/projects.html#list-all-projects
 export interface ProjectSchema {
   id: number;
   description: string;
@@ -63,8 +64,8 @@ export interface ProjectSchema {
   import_status: string;
   open_issues_count: number;
   ci_default_git_depth: number;
-  public_jobs: boolean;
   build_timeout: number;
+  public_jobs: boolean;
   auto_cancel_pending_pipelines?: string;
   build_coverage_regex?: string;
   ci_config_path?: string;
@@ -82,8 +83,8 @@ export interface ProjectSchema {
 }
 
 export class Projects extends BaseService {
-  all(options?: PaginatedRequestOptions) {
-    return RequestHelper.get(this, 'projects', options);
+  all(options?: PaginatedRequestOptions): Promise<ProjectSchema[]> {
+    return RequestHelper.get(this, 'projects', options) as Promise<ProjectSchema[]>;
   }
 
   archive(projectId: string | number, options?: Sudo) {
@@ -167,10 +168,10 @@ export class Projects extends BaseService {
     return RequestHelper.post(this, `projects/${pId}/share`, { groupId, groupAccess, ...options });
   }
 
-  show(projectId: string | number, options?: BaseRequestOptions) {
+  show(projectId: string | number, options?: BaseRequestOptions): Promise<ProjectSchema> {
     const pId = encodeURIComponent(projectId);
 
-    return RequestHelper.get(this, `projects/${pId}`, options);
+    return RequestHelper.get(this, `projects/${pId}`, options) as Promise<ProjectSchema>;
   }
 
   star(projectId: string | number, options?: Sudo) {

--- a/src/core/services/Runners.ts
+++ b/src/core/services/Runners.ts
@@ -6,6 +6,18 @@ import {
   Sudo,
 } from '../infrastructure';
 
+// As of GitLab v12.6.2
+export interface RunnerSchema {
+  id: number;
+  description: string;
+  ip_address: string;
+  active: boolean;
+  is_shared: boolean;
+  name: string;
+  online: boolean;
+  status: string;
+}
+
 export class Runners extends BaseService {
   all({ projectId, ...options }: { projectId: string | number } & PaginatedRequestOptions) {
     const url = projectId ? `projects/${encodeURIComponent(projectId)}/runners` : 'runners/all';

--- a/src/core/services/Users.ts
+++ b/src/core/services/Users.ts
@@ -21,14 +21,14 @@ export interface UserSchema {
 // As of GitLab v12.6.2
 export interface UserDetailSchema extends UserSchema {
   created_at: Date;
-  bio?: any;
-  location?: any;
+  bio?: string;
+  location?: string;
   public_email: string;
   skype: string;
   linkedin: string;
   twitter: string;
-  website_url: string;
-  organization?: any;
+  website_url?: string;
+  organization?: string;
 }
 
 export class Users extends BaseService {

--- a/src/core/services/Users.ts
+++ b/src/core/services/Users.ts
@@ -8,6 +8,29 @@ import {
 
 import { EventOptions } from './Events';
 
+// As of GitLab v12.6.2
+export interface UserSchema {
+  id: number;
+  name: string;
+  username: string;
+  state: string;
+  avatar_url: string;
+  web_url: string;
+}
+
+// As of GitLab v12.6.2
+export interface UserDetailSchema extends UserSchema {
+  created_at: Date;
+  bio?: any;
+  location?: any;
+  public_email: string;
+  skype: string;
+  linkedin: string;
+  twitter: string;
+  website_url: string;
+  organization?: any;
+}
+
 export class Users extends BaseService {
   all(options?: PaginatedRequestOptions) {
     return RequestHelper.get(this, 'users', options);

--- a/src/core/templates/ResourceVariables.ts
+++ b/src/core/templates/ResourceVariables.ts
@@ -6,15 +6,26 @@ import {
   BaseRequestOptions,
 } from '../infrastructure';
 
+export interface ResourceVariableSchema {
+  key: string;
+  variable_type: 'env_var' | 'file';
+  value: string;
+}
+
 export class ResourceVariables extends BaseService {
   constructor(resourceType: string, options: BaseServiceOptions) {
     super({ url: resourceType, ...options });
   }
 
-  all(resourceId: string | number, options?: PaginatedRequestOptions) {
+  all(
+    resourceId: string | number,
+    options?: PaginatedRequestOptions,
+  ): Promise<ResourceVariableSchema[]> {
     const rId = encodeURIComponent(resourceId);
 
-    return RequestHelper.get(this, `${rId}/variables`, options);
+    return RequestHelper.get(this, `${rId}/variables`, options) as Promise<
+      ResourceVariableSchema[]
+    >;
   }
 
   create(resourceId: string | number, options?: BaseRequestOptions) {
@@ -29,10 +40,16 @@ export class ResourceVariables extends BaseService {
     return RequestHelper.put(this, `${rId}/variables/${kId}`, options);
   }
 
-  show(resourceId: string | number, keyId: string, options?: PaginatedRequestOptions) {
+  show(
+    resourceId: string | number,
+    keyId: string,
+    options?: PaginatedRequestOptions,
+  ): Promise<ResourceVariableSchema> {
     const [rId, kId] = [resourceId, keyId].map(encodeURIComponent);
 
-    return RequestHelper.get(this, `${rId}/variables/${kId}`, options);
+    return RequestHelper.get(this, `${rId}/variables/${kId}`, options) as Promise<
+      ResourceVariableSchema
+    >;
   }
 
   remove(resourceId: string | number, keyId: string, options?: PaginatedRequestOptions) {


### PR DESCRIPTION
Related to #492 

- Updates ProjectSchema / GroupSchema interfaces to include all fields returned by GitLab API v4
- Adds some new Interfaces: CommitSchema, RunnerSchema, UserSchema, UserDetailSchema, EnvironmentSchema, ArtifactSchema, JobSchema, PipelineSchema.
- Updated some return types accordingly
