### PR TITLE
fix: Incorrect request method in MergeRequests.approvalState() method

### DIFF
--- a/src/core/services/MergeRequests.ts
+++ b/src/core/services/MergeRequests.ts
@@ -141,7 +141,7 @@ export class MergeRequests extends BaseService {
   ) {
     const [pId, mIId] = [projectId, mergerequestIId].map(encodeURIComponent);
 
-    return RequestHelper.post(
+    return RequestHelper.get(
       this,
       `projects/${pId}/merge_requests/${mIId}/approval_state`,
       options,


### PR DESCRIPTION
In current version approvalState method always returns 404 Error.
According to [Gitlab API Documentation](https://docs.gitlab.com/ee/api/merge_request_approvals.html#get-the-approval-state-of-merge-requests), approval_state should use GET method instead of POST.