### PR TITLE
chore: Override arguments in all services inheriting from templates

### DIFF
--- a/packages/gitbeaker-core/src/services/CommitDiscussions.ts
+++ b/packages/gitbeaker-core/src/services/CommitDiscussions.ts
@@ -1,5 +1,54 @@
 import { ResourceDiscussions } from '../templates';
-import { BaseServiceOptions } from '../infrastructure';
+import {
+  BaseRequestOptions,
+  BaseServiceOptions,
+  PaginatedRequestOptions,
+  Sudo,
+} from '../infrastructure';
+
+export interface CommitDiscussions extends ResourceDiscussions {
+  addNote(
+    projectId: string | number,
+    commitId: string | number,
+    discussionId: string | number,
+    noteId: number,
+    content: string,
+    options?: BaseRequestOptions,
+  );
+
+  all(projectId: string | number, commitId: string | number, options?: PaginatedRequestOptions);
+
+  create(
+    projectId: string | number,
+    commitId: string | number,
+    content: string,
+    options?: BaseRequestOptions,
+  );
+
+  editNote(
+    projectId: string | number,
+    commitId: string | number,
+    discussionId: string | number,
+    noteId: number,
+    content: string,
+    options?: BaseRequestOptions,
+  );
+
+  removeNote(
+    projectId: string | number,
+    commitId: string | number,
+    discussionId: string | number,
+    noteId: number,
+    options?: Sudo,
+  );
+
+  show(
+    projectId: string | number,
+    commitId: string | number,
+    discussionId: string | number,
+    options?: Sudo,
+  );
+}
 
 export class CommitDiscussions extends ResourceDiscussions {
   constructor(options: BaseServiceOptions = {}) {

--- a/packages/gitbeaker-core/src/services/EpicDiscussions.ts
+++ b/packages/gitbeaker-core/src/services/EpicDiscussions.ts
@@ -1,5 +1,54 @@
 import { ResourceDiscussions } from '../templates';
-import { BaseServiceOptions } from '../infrastructure';
+import {
+  BaseRequestOptions,
+  BaseServiceOptions,
+  PaginatedRequestOptions,
+  Sudo,
+} from '../infrastructure';
+
+export interface EpicDiscussions extends ResourceDiscussions {
+  addNote(
+    groupId: string | number,
+    epicId: string | number,
+    discussionId: string | number,
+    noteId: number,
+    content: string,
+    options?: BaseRequestOptions,
+  );
+
+  all(groupId: string | number, epicId: string | number, options?: PaginatedRequestOptions);
+
+  create(
+    groupId: string | number,
+    epicId: string | number,
+    content: string,
+    options?: BaseRequestOptions,
+  );
+
+  editNote(
+    groupId: string | number,
+    epicId: string | number,
+    discussionId: string | number,
+    noteId: number,
+    content: string,
+    options?: BaseRequestOptions,
+  );
+
+  removeNote(
+    groupId: string | number,
+    epicId: string | number,
+    discussionId: string | number,
+    noteId: number,
+    options?: Sudo,
+  );
+
+  show(
+    groupId: string | number,
+    epicId: string | number,
+    discussionId: string | number,
+    options?: Sudo,
+  );
+}
 
 export class EpicDiscussions extends ResourceDiscussions {
   constructor(options: BaseServiceOptions = {}) {

--- a/packages/gitbeaker-core/src/services/EpicNotes.ts
+++ b/packages/gitbeaker-core/src/services/EpicNotes.ts
@@ -1,5 +1,48 @@
 import { ResourceNotes } from '../templates';
-import { BaseServiceOptions } from '../infrastructure';
+import { GetResponse } from '../infrastructure/RequestHelper';
+import {
+  BaseServiceOptions,
+  PaginatedRequestOptions,
+  BaseRequestOptions,
+  Sudo,
+} from '../infrastructure';
+
+export interface EpicNotes extends ResourceNotes {
+  all(
+    groupId: string | number,
+    epicId: string | number,
+    options: PaginatedRequestOptions,
+  ): Promise<GetResponse>;
+
+  create(
+    groupId: string | number,
+    epicId: string | number,
+    body: string,
+    options?: BaseRequestOptions,
+  ): Promise<object>;
+
+  edit(
+    groupId: string | number,
+    epicId: string | number,
+    noteId: number,
+    body: string,
+    options?: BaseRequestOptions,
+  ): Promise<object>;
+
+  remove(
+    groupId: string | number,
+    epicId: string | number,
+    noteId: number,
+    options?: Sudo,
+  ): Promise<object>;
+
+  show(
+    groupId: string | number,
+    epicId: string | number,
+    noteId: number,
+    options?: Sudo,
+  ): Promise<GetResponse>;
+}
 
 export class EpicNotes extends ResourceNotes {
   constructor(options: BaseServiceOptions = {}) {

--- a/packages/gitbeaker-core/src/services/GroupBadges.ts
+++ b/packages/gitbeaker-core/src/services/GroupBadges.ts
@@ -1,5 +1,24 @@
 import { ResourceBadges } from '../templates';
-import { BaseServiceOptions } from '../infrastructure';
+import {
+  BaseRequestOptions,
+  BaseServiceOptions,
+  PaginatedRequestOptions,
+  Sudo,
+} from '../infrastructure';
+
+export interface GroupBadges extends ResourceBadges {
+  add(groupId: string | number, options?: BaseRequestOptions);
+
+  all(groupId: string | number, options?: PaginatedRequestOptions);
+
+  edit(groupId: string | number, badgeId: number, options?: BaseRequestOptions);
+
+  preview(groupId: string | number, linkUrl: string, imageUrl: string, options?: Sudo);
+
+  remove(groupId: string | number, badgeId: number, options?: Sudo);
+
+  show(groupId: string | number, badgeId: number, options?: Sudo);
+}
 
 export class GroupBadges extends ResourceBadges {
   constructor(options: BaseServiceOptions = {}) {

--- a/packages/gitbeaker-core/src/services/GroupCustomAttributes.ts
+++ b/packages/gitbeaker-core/src/services/GroupCustomAttributes.ts
@@ -1,5 +1,15 @@
 import { ResourceCustomAttributes } from '../templates';
-import { BaseServiceOptions } from '../infrastructure';
+import { BaseServiceOptions, PaginatedRequestOptions, Sudo } from '../infrastructure';
+
+export interface GroupCustomAttributes extends ResourceCustomAttributes {
+  all(groupId: string | number, options?: PaginatedRequestOptions);
+
+  set(groupId: string | number, customAttributeId: number, value: string, options?: Sudo);
+
+  remove(groupId: string | number, customAttributeId: number, options?: Sudo);
+
+  show(groupId: string | number, customAttributeId: number, options?: Sudo);
+}
 
 export class GroupCustomAttributes extends ResourceCustomAttributes {
   constructor(options: BaseServiceOptions = {}) {

--- a/packages/gitbeaker-core/src/services/GroupIssueBoards.ts
+++ b/packages/gitbeaker-core/src/services/GroupIssueBoards.ts
@@ -1,5 +1,38 @@
 import { ResourceIssueBoards } from '../templates';
-import { BaseServiceOptions } from '../infrastructure';
+import {
+  BaseServiceOptions,
+  BaseRequestOptions,
+  PaginatedRequestOptions,
+  Sudo,
+} from '../infrastructure';
+
+export interface GroupIssueBoards extends ResourceIssueBoards {
+  all(groupId: string | number, options?: PaginatedRequestOptions);
+
+  create(groupId: string | number, name: string, options?: Sudo);
+
+  createList(groupId: string | number, boardId: number, labelId: number, options?: Sudo);
+
+  edit(groupId: string | number, boardId: number, options?: BaseRequestOptions);
+
+  editList(
+    groupId: string | number,
+    boardId: number,
+    listId: number,
+    position: number,
+    options?: Sudo,
+  );
+
+  lists(groupId: string | number, boardId: number, options?: Sudo);
+
+  remove(groupId: string | number, boardId: number, options?: Sudo);
+
+  removeList(groupId: string | number, boardId: number, listId: number, options?: Sudo);
+
+  show(groupId: string | number, boardId: number, options?: Sudo);
+
+  showList(groupId: string | number, boardId: number, listId: number, options?: Sudo);
+}
 
 export class GroupIssueBoards extends ResourceIssueBoards {
   constructor(options: BaseServiceOptions = {}) {

--- a/packages/gitbeaker-core/src/services/GroupLabels.ts
+++ b/packages/gitbeaker-core/src/services/GroupLabels.ts
@@ -1,5 +1,24 @@
-import { BaseServiceOptions } from '../infrastructure';
+import {
+  BaseRequestOptions,
+  BaseServiceOptions,
+  PaginatedRequestOptions,
+  Sudo,
+} from '../infrastructure';
 import { ResourceLabels } from '../templates';
+
+export interface GroupLabels extends ResourceLabels {
+  all(groupId: string | number, options?: PaginatedRequestOptions);
+
+  create(groupId: string | number, labelName: string, color: string, options?: BaseRequestOptions);
+
+  edit(groupId: string | number, labelName: string, options?: BaseRequestOptions);
+
+  remove(groupId: string | number, labelName: string, options?: Sudo);
+
+  subscribe(groupId: string | number, labelId: number, options?: Sudo);
+
+  unsubscribe(groupId: string | number, labelId: number, options?: Sudo);
+}
 
 export class GroupLabels extends ResourceLabels {
   constructor(options: BaseServiceOptions = {}) {

--- a/packages/gitbeaker-core/src/services/GroupMilestones.ts
+++ b/packages/gitbeaker-core/src/services/GroupMilestones.ts
@@ -1,5 +1,24 @@
 import { ResourceMilestones } from '../templates';
-import { BaseServiceOptions } from '../infrastructure';
+import {
+  BaseServiceOptions,
+  PaginatedRequestOptions,
+  BaseRequestOptions,
+  Sudo,
+} from '../infrastructure';
+
+export interface GroupMilestones extends ResourceMilestones {
+  all(groupId: string | number, options?: PaginatedRequestOptions);
+
+  create(groupId: string | number, title: string, options?: BaseRequestOptions);
+
+  edit(groupId: string | number, milestoneId: number, options?: BaseRequestOptions);
+
+  issues(groupId: string | number, milestoneId: number, options?: Sudo);
+
+  mergeRequests(groupId: string | number, milestoneId: number, options?: Sudo);
+
+  show(groupId: string | number, milestoneId: number, options?: Sudo);
+}
 
 export class GroupMilestones extends ResourceMilestones {
   constructor(options: BaseServiceOptions = {}) {

--- a/packages/gitbeaker-core/src/services/GroupVariables.ts
+++ b/packages/gitbeaker-core/src/services/GroupVariables.ts
@@ -1,5 +1,24 @@
-import { ResourceVariables } from '../templates';
-import { BaseServiceOptions } from '../infrastructure';
+import { ResourceVariables, ResourceVariableSchema } from '../templates';
+import { BaseServiceOptions, PaginatedRequestOptions, BaseRequestOptions } from '../infrastructure';
+
+export interface GroupVariables extends ResourceVariables {
+  all(
+    groupId: string | number,
+    options?: PaginatedRequestOptions,
+  ): Promise<ResourceVariableSchema[]>;
+
+  create(groupId: string | number, options?: BaseRequestOptions);
+
+  edit(groupId: string | number, keyId: string, options?: BaseRequestOptions);
+
+  show(
+    groupId: string | number,
+    keyId: string,
+    options?: PaginatedRequestOptions,
+  ): Promise<ResourceVariableSchema>;
+
+  remove(groupId: string | number, keyId: string, options?: PaginatedRequestOptions);
+}
 
 export class GroupVariables extends ResourceVariables {
   constructor(options: BaseServiceOptions = {}) {

--- a/packages/gitbeaker-core/src/services/IssueAwardEmojis.ts
+++ b/packages/gitbeaker-core/src/services/IssueAwardEmojis.ts
@@ -1,5 +1,38 @@
 import { ResourceAwardEmojis } from '../templates';
-import { BaseServiceOptions } from '../infrastructure';
+import { BaseServiceOptions, PaginatedRequestOptions, Sudo } from '../infrastructure';
+
+export interface IssueAwardEmojis extends ResourceAwardEmojis {
+  all(
+    projectId: string | number,
+    issueId: string | number,
+    noteId: number,
+    options?: PaginatedRequestOptions,
+  );
+
+  award(
+    projectId: string | number,
+    issueId: string | number,
+    name: string,
+    noteId: number,
+    options?: Sudo,
+  );
+
+  remove(
+    projectId: string | number,
+    issueId: string | number,
+    awardId: number,
+    noteId: number,
+    options?: Sudo,
+  );
+
+  show(
+    projectId: string | number,
+    issueId: string | number,
+    awardId: number,
+    noteId: number,
+    options?: Sudo,
+  );
+}
 
 export class IssueAwardEmojis extends ResourceAwardEmojis {
   constructor(options: BaseServiceOptions = {}) {

--- a/packages/gitbeaker-core/src/services/IssueDiscussions.ts
+++ b/packages/gitbeaker-core/src/services/IssueDiscussions.ts
@@ -1,5 +1,54 @@
 import { ResourceDiscussions } from '../templates';
-import { BaseServiceOptions } from '../infrastructure';
+import {
+  BaseRequestOptions,
+  BaseServiceOptions,
+  PaginatedRequestOptions,
+  Sudo,
+} from '../infrastructure';
+
+export interface IssueDiscussions extends ResourceDiscussions {
+  addNote(
+    projectId: string | number,
+    issueId: string | number,
+    discussionId: string | number,
+    noteId: number,
+    content: string,
+    options?: BaseRequestOptions,
+  );
+
+  all(projectId: string | number, issueId: string | number, options?: PaginatedRequestOptions);
+
+  create(
+    projectId: string | number,
+    issueId: string | number,
+    content: string,
+    options?: BaseRequestOptions,
+  );
+
+  editNote(
+    projectId: string | number,
+    issueId: string | number,
+    discussionId: string | number,
+    noteId: number,
+    content: string,
+    options?: BaseRequestOptions,
+  );
+
+  removeNote(
+    projectId: string | number,
+    issueId: string | number,
+    discussionId: string | number,
+    noteId: number,
+    options?: Sudo,
+  );
+
+  show(
+    projectId: string | number,
+    issueId: string | number,
+    discussionId: string | number,
+    options?: Sudo,
+  );
+}
 
 export class IssueDiscussions extends ResourceDiscussions {
   constructor(options: BaseServiceOptions = {}) {

--- a/packages/gitbeaker-core/src/services/IssueNotes.ts
+++ b/packages/gitbeaker-core/src/services/IssueNotes.ts
@@ -1,5 +1,48 @@
 import { ResourceNotes } from '../templates';
-import { BaseServiceOptions } from '../infrastructure';
+import { GetResponse } from '../infrastructure/RequestHelper';
+import {
+  BaseServiceOptions,
+  PaginatedRequestOptions,
+  BaseRequestOptions,
+  Sudo,
+} from '../infrastructure';
+
+export interface IssueNotes extends ResourceNotes {
+  all(
+    projectId: string | number,
+    issueId: string | number,
+    options: PaginatedRequestOptions,
+  ): Promise<GetResponse>;
+
+  create(
+    projectId: string | number,
+    issueId: string | number,
+    body: string,
+    options?: BaseRequestOptions,
+  ): Promise<object>;
+
+  edit(
+    projectId: string | number,
+    issueId: string | number,
+    noteId: number,
+    body: string,
+    options?: BaseRequestOptions,
+  ): Promise<object>;
+
+  remove(
+    projectId: string | number,
+    issueId: string | number,
+    noteId: number,
+    options?: Sudo,
+  ): Promise<object>;
+
+  show(
+    projectId: string | number,
+    issueId: string | number,
+    noteId: number,
+    options?: Sudo,
+  ): Promise<GetResponse>;
+}
 
 export class IssueNotes extends ResourceNotes {
   constructor(options: BaseServiceOptions = {}) {

--- a/packages/gitbeaker-core/src/services/Labels.ts
+++ b/packages/gitbeaker-core/src/services/Labels.ts
@@ -1,5 +1,29 @@
-import { BaseServiceOptions } from '../infrastructure';
+import {
+  BaseRequestOptions,
+  BaseServiceOptions,
+  PaginatedRequestOptions,
+  Sudo,
+} from '../infrastructure';
 import { ResourceLabels } from '../templates';
+
+export interface Labels extends ResourceLabels {
+  all(projectId: string | number, options?: PaginatedRequestOptions);
+
+  create(
+    projectId: string | number,
+    labelName: string,
+    color: string,
+    options?: BaseRequestOptions,
+  );
+
+  edit(projectId: string | number, labelName: string, options?: BaseRequestOptions);
+
+  remove(projectId: string | number, labelName: string, options?: Sudo);
+
+  subscribe(projectId: string | number, labelId: number, options?: Sudo);
+
+  unsubscribe(projectId: string | number, labelId: number, options?: Sudo);
+}
 
 export class Labels extends ResourceLabels {
   constructor(options: BaseServiceOptions = {}) {

--- a/packages/gitbeaker-core/src/services/MergeRequestAwardEmojis.ts
+++ b/packages/gitbeaker-core/src/services/MergeRequestAwardEmojis.ts
@@ -1,5 +1,38 @@
 import { ResourceAwardEmojis } from '../templates';
-import { BaseServiceOptions } from '../infrastructure';
+import { BaseServiceOptions, PaginatedRequestOptions, Sudo } from '../infrastructure';
+
+export interface MergeRequestAwardEmojis extends ResourceAwardEmojis {
+  all(
+    projectId: string | number,
+    mergerequestId: string | number,
+    noteId: number,
+    options?: PaginatedRequestOptions,
+  );
+
+  award(
+    projectId: string | number,
+    mergerequestId: string | number,
+    name: string,
+    noteId: number,
+    options?: Sudo,
+  );
+
+  remove(
+    projectId: string | number,
+    mergerequestId: string | number,
+    awardId: number,
+    noteId: number,
+    options?: Sudo,
+  );
+
+  show(
+    projectId: string | number,
+    mergerequestId: string | number,
+    awardId: number,
+    noteId: number,
+    options?: Sudo,
+  );
+}
 
 export class MergeRequestAwardEmojis extends ResourceAwardEmojis {
   constructor(options: BaseServiceOptions = {}) {

--- a/packages/gitbeaker-core/src/services/MergeRequestDiscussions.ts
+++ b/packages/gitbeaker-core/src/services/MergeRequestDiscussions.ts
@@ -1,5 +1,58 @@
 import { ResourceDiscussions } from '../templates';
-import { BaseServiceOptions } from '../infrastructure';
+import {
+  BaseRequestOptions,
+  BaseServiceOptions,
+  PaginatedRequestOptions,
+  Sudo,
+} from '../infrastructure';
+
+export interface MergeRequestDiscussions extends ResourceDiscussions {
+  addNote(
+    projectId: string | number,
+    mergerequestId: string | number,
+    discussionId: string | number,
+    noteId: number,
+    content: string,
+    options?: BaseRequestOptions,
+  );
+
+  all(
+    projectId: string | number,
+    mergerequestId: string | number,
+    options?: PaginatedRequestOptions,
+  );
+
+  create(
+    projectId: string | number,
+    mergerequestId: string | number,
+    content: string,
+    options?: BaseRequestOptions,
+  );
+
+  editNote(
+    projectId: string | number,
+    mergerequestId: string | number,
+    discussionId: string | number,
+    noteId: number,
+    content: string,
+    options?: BaseRequestOptions,
+  );
+
+  removeNote(
+    projectId: string | number,
+    mergerequestId: string | number,
+    discussionId: string | number,
+    noteId: number,
+    options?: Sudo,
+  );
+
+  show(
+    projectId: string | number,
+    mergerequestId: string | number,
+    discussionId: string | number,
+    options?: Sudo,
+  );
+}
 
 export class MergeRequestDiscussions extends ResourceDiscussions {
   constructor(options: BaseServiceOptions = {}) {

--- a/packages/gitbeaker-core/src/services/MergeRequestNotes.ts
+++ b/packages/gitbeaker-core/src/services/MergeRequestNotes.ts
@@ -1,5 +1,48 @@
 import { ResourceNotes } from '../templates';
-import { BaseServiceOptions } from '../infrastructure';
+import { GetResponse } from '../infrastructure/RequestHelper';
+import {
+  BaseServiceOptions,
+  PaginatedRequestOptions,
+  BaseRequestOptions,
+  Sudo,
+} from '../infrastructure';
+
+export interface MergeRequestNotes extends ResourceNotes {
+  all(
+    projectId: string | number,
+    mergerequestIId: string | number,
+    options: PaginatedRequestOptions,
+  ): Promise<GetResponse>;
+
+  create(
+    projectId: string | number,
+    mergerequestIId: string | number,
+    body: string,
+    options?: BaseRequestOptions,
+  ): Promise<object>;
+
+  edit(
+    projectId: string | number,
+    mergerequestIId: string | number,
+    noteId: number,
+    body: string,
+    options?: BaseRequestOptions,
+  ): Promise<object>;
+
+  remove(
+    projectId: string | number,
+    mergerequestIId: string | number,
+    noteId: number,
+    options?: Sudo,
+  ): Promise<object>;
+
+  show(
+    projectId: string | number,
+    mergerequestIId: string | number,
+    noteId: number,
+    options?: Sudo,
+  ): Promise<GetResponse>;
+}
 
 export class MergeRequestNotes extends ResourceNotes {
   constructor(options: BaseServiceOptions = {}) {

--- a/packages/gitbeaker-core/src/services/ProjectBadges.ts
+++ b/packages/gitbeaker-core/src/services/ProjectBadges.ts
@@ -1,5 +1,24 @@
 import { ResourceBadges } from '../templates';
-import { BaseServiceOptions } from '../infrastructure';
+import {
+  BaseRequestOptions,
+  BaseServiceOptions,
+  PaginatedRequestOptions,
+  Sudo,
+} from '../infrastructure';
+
+export interface ProjectBadges extends ResourceBadges {
+  add(projectId: string | number, options?: BaseRequestOptions);
+
+  all(projectId: string | number, options?: PaginatedRequestOptions);
+
+  edit(projectId: string | number, badgeId: number, options?: BaseRequestOptions);
+
+  preview(projectId: string | number, linkUrl: string, imageUrl: string, options?: Sudo);
+
+  remove(projectId: string | number, badgeId: number, options?: Sudo);
+
+  show(projectId: string | number, badgeId: number, options?: Sudo);
+}
 
 export class ProjectBadges extends ResourceBadges {
   constructor(options: BaseServiceOptions = {}) {

--- a/packages/gitbeaker-core/src/services/ProjectCustomAttributes.ts
+++ b/packages/gitbeaker-core/src/services/ProjectCustomAttributes.ts
@@ -1,5 +1,15 @@
 import { ResourceCustomAttributes } from '../templates';
-import { BaseServiceOptions } from '../infrastructure';
+import { BaseServiceOptions, PaginatedRequestOptions, Sudo } from '../infrastructure';
+
+export interface ProjectCustomAttributes extends ResourceCustomAttributes {
+  all(projectId: string | number, options?: PaginatedRequestOptions);
+
+  set(projectId: string | number, customAttributeId: number, value: string, options?: Sudo);
+
+  remove(projectId: string | number, customAttributeId: number, options?: Sudo);
+
+  show(projectId: string | number, customAttributeId: number, options?: Sudo);
+}
 
 export class ProjectCustomAttributes extends ResourceCustomAttributes {
   constructor(options: BaseServiceOptions = {}) {

--- a/packages/gitbeaker-core/src/services/ProjectIssueBoards.ts
+++ b/packages/gitbeaker-core/src/services/ProjectIssueBoards.ts
@@ -1,5 +1,38 @@
 import { ResourceIssueBoards } from '../templates';
-import { BaseServiceOptions } from '../infrastructure';
+import {
+  BaseServiceOptions,
+  BaseRequestOptions,
+  PaginatedRequestOptions,
+  Sudo,
+} from '../infrastructure';
+
+export interface ProjectIssueBoards extends ResourceIssueBoards {
+  all(projectId: string | number, options?: PaginatedRequestOptions);
+
+  create(projectId: string | number, name: string, options?: Sudo);
+
+  createList(projectId: string | number, boardId: number, labelId: number, options?: Sudo);
+
+  edit(projectId: string | number, boardId: number, options?: BaseRequestOptions);
+
+  editList(
+    projectId: string | number,
+    boardId: number,
+    listId: number,
+    position: number,
+    options?: Sudo,
+  );
+
+  lists(projectId: string | number, boardId: number, options?: Sudo);
+
+  remove(projectId: string | number, boardId: number, options?: Sudo);
+
+  removeList(projectId: string | number, boardId: number, listId: number, options?: Sudo);
+
+  show(projectId: string | number, boardId: number, options?: Sudo);
+
+  showList(projectId: string | number, boardId: number, listId: number, options?: Sudo);
+}
 
 export class ProjectIssueBoards extends ResourceIssueBoards {
   constructor(options: BaseServiceOptions = {}) {

--- a/packages/gitbeaker-core/src/services/ProjectMilestones.ts
+++ b/packages/gitbeaker-core/src/services/ProjectMilestones.ts
@@ -1,5 +1,24 @@
 import { ResourceMilestones } from '../templates';
-import { BaseServiceOptions } from '../infrastructure';
+import {
+  BaseServiceOptions,
+  PaginatedRequestOptions,
+  BaseRequestOptions,
+  Sudo,
+} from '../infrastructure';
+
+export interface ProjectMilestones extends ResourceMilestones {
+  all(projectId: string | number, options?: PaginatedRequestOptions);
+
+  create(projectId: string | number, title: string, options?: BaseRequestOptions);
+
+  edit(projectId: string | number, milestoneId: number, options?: BaseRequestOptions);
+
+  issues(projectId: string | number, milestoneId: number, options?: Sudo);
+
+  mergeRequests(projectId: string | number, milestoneId: number, options?: Sudo);
+
+  show(projectId: string | number, milestoneId: number, options?: Sudo);
+}
 
 export class ProjectMilestones extends ResourceMilestones {
   constructor(options: BaseServiceOptions = {}) {

--- a/packages/gitbeaker-core/src/services/ProjectSnippetAwardEmojis.ts
+++ b/packages/gitbeaker-core/src/services/ProjectSnippetAwardEmojis.ts
@@ -1,5 +1,38 @@
 import { ResourceAwardEmojis } from '../templates';
-import { BaseServiceOptions } from '../infrastructure';
+import { BaseServiceOptions, PaginatedRequestOptions, Sudo } from '../infrastructure';
+
+export interface ProjectSnippetAwardEmojis extends ResourceAwardEmojis {
+  all(
+    projectId: string | number,
+    issueId: string | number,
+    noteId: number,
+    options?: PaginatedRequestOptions,
+  );
+
+  award(
+    projectId: string | number,
+    issueId: string | number,
+    name: string,
+    noteId: number,
+    options?: Sudo,
+  );
+
+  remove(
+    projectId: string | number,
+    issueId: string | number,
+    awardId: number,
+    noteId: number,
+    options?: Sudo,
+  );
+
+  show(
+    projectId: string | number,
+    issueId: string | number,
+    awardId: number,
+    noteId: number,
+    options?: Sudo,
+  );
+}
 
 export class ProjectSnippetAwardEmojis extends ResourceAwardEmojis {
   constructor(options: BaseServiceOptions = {}) {

--- a/packages/gitbeaker-core/src/services/ProjectSnippetDiscussions.ts
+++ b/packages/gitbeaker-core/src/services/ProjectSnippetDiscussions.ts
@@ -1,5 +1,54 @@
 import { ResourceDiscussions } from '../templates';
-import { BaseServiceOptions } from '../infrastructure';
+import {
+  BaseRequestOptions,
+  BaseServiceOptions,
+  PaginatedRequestOptions,
+  Sudo,
+} from '../infrastructure';
+
+export interface ProjectSnippetDiscussions extends ResourceDiscussions {
+  addNote(
+    projectId: string | number,
+    snippetId: string | number,
+    discussionId: string | number,
+    noteId: number,
+    content: string,
+    options?: BaseRequestOptions,
+  );
+
+  all(projectId: string | number, snippetId: string | number, options?: PaginatedRequestOptions);
+
+  create(
+    projectId: string | number,
+    snippetId: string | number,
+    content: string,
+    options?: BaseRequestOptions,
+  );
+
+  editNote(
+    projectId: string | number,
+    snippetId: string | number,
+    discussionId: string | number,
+    noteId: number,
+    content: string,
+    options?: BaseRequestOptions,
+  );
+
+  removeNote(
+    projectId: string | number,
+    snippetId: string | number,
+    discussionId: string | number,
+    noteId: number,
+    options?: Sudo,
+  );
+
+  show(
+    projectId: string | number,
+    snippetId: string | number,
+    discussionId: string | number,
+    options?: Sudo,
+  );
+}
 
 export class ProjectSnippetDiscussions extends ResourceDiscussions {
   constructor(options: BaseServiceOptions = {}) {

--- a/packages/gitbeaker-core/src/services/ProjectSnippetNotes.ts
+++ b/packages/gitbeaker-core/src/services/ProjectSnippetNotes.ts
@@ -1,5 +1,48 @@
 import { ResourceNotes } from '../templates';
-import { BaseServiceOptions } from '../infrastructure';
+import { GetResponse } from '../infrastructure/RequestHelper';
+import {
+  BaseServiceOptions,
+  PaginatedRequestOptions,
+  BaseRequestOptions,
+  Sudo,
+} from '../infrastructure';
+
+export interface ProjectSnippetNotes extends ResourceNotes {
+  all(
+    projectId: string | number,
+    snippetId: string | number,
+    options: PaginatedRequestOptions,
+  ): Promise<GetResponse>;
+
+  create(
+    projectId: string | number,
+    snippetId: string | number,
+    body: string,
+    options?: BaseRequestOptions,
+  ): Promise<object>;
+
+  edit(
+    projectId: string | number,
+    snippetId: string | number,
+    noteId: number,
+    body: string,
+    options?: BaseRequestOptions,
+  ): Promise<object>;
+
+  remove(
+    projectId: string | number,
+    snippetId: string | number,
+    noteId: number,
+    options?: Sudo,
+  ): Promise<object>;
+
+  show(
+    projectId: string | number,
+    snippetId: string | number,
+    noteId: number,
+    options?: Sudo,
+  ): Promise<GetResponse>;
+}
 
 export class ProjectSnippetNotes extends ResourceNotes {
   constructor(options: BaseServiceOptions = {}) {

--- a/packages/gitbeaker-core/src/services/ProjectVariables.ts
+++ b/packages/gitbeaker-core/src/services/ProjectVariables.ts
@@ -1,7 +1,24 @@
-import { ResourceVariables } from '../templates';
-import { BaseServiceOptions } from '../infrastructure';
+import { ResourceVariables, ResourceVariableSchema } from '../templates';
+import { BaseServiceOptions, PaginatedRequestOptions, BaseRequestOptions } from '../infrastructure';
 
-export { ResourceVariableSchema } from '../templates';
+export interface ProjectVariables extends ResourceVariables {
+  all(
+    projectId: string | number,
+    options?: PaginatedRequestOptions,
+  ): Promise<ResourceVariableSchema[]>;
+
+  create(projectId: string | number, options?: BaseRequestOptions);
+
+  edit(projectId: string | number, keyId: string, options?: BaseRequestOptions);
+
+  show(
+    projectId: string | number,
+    keyId: string,
+    options?: PaginatedRequestOptions,
+  ): Promise<ResourceVariableSchema>;
+
+  remove(projectId: string | number, keyId: string, options?: PaginatedRequestOptions);
+}
 
 export class ProjectVariables extends ResourceVariables {
   constructor(options: BaseServiceOptions = {}) {

--- a/packages/gitbeaker-core/src/services/UserCustomAttributes.ts
+++ b/packages/gitbeaker-core/src/services/UserCustomAttributes.ts
@@ -1,5 +1,15 @@
 import { ResourceCustomAttributes } from '../templates';
-import { BaseServiceOptions } from '../infrastructure';
+import { BaseServiceOptions, PaginatedRequestOptions, Sudo } from '../infrastructure';
+
+export interface UserCustomAttributes extends ResourceCustomAttributes {
+  all(userId: string | number, options?: PaginatedRequestOptions);
+
+  set(userId: string | number, customAttributeId: number, value: string, options?: Sudo);
+
+  remove(userId: string | number, customAttributeId: number, options?: Sudo);
+
+  show(userId: string | number, customAttributeId: number, options?: Sudo);
+}
 
 export class UserCustomAttributes extends ResourceCustomAttributes {
   constructor(options: BaseServiceOptions = {}) {


### PR DESCRIPTION
**Problem - Code Readability**

- When using `MergeRequestNotes` `all` method it's not explicit what its parameters consist. The only thing we know is that it receives two parameters -> resourceId; and resource2Id. 
(just as depicted in the image bellow)
![image](https://user-images.githubusercontent.com/9274567/74085691-a0576d00-4a73-11ea-8b70-1bfb80c465d0.png)

- So here lies the problem, what really is resourceId and resource2Id, is it projectId and merge-requestId, or the other way around?

**Solution Proposal**
- Override ResourceNotes methods just to rename the arguments.