### PR TITLE
Add example code into README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,14 +401,16 @@ const api = new Gitlab({
 // Listing users
 let users = await api.Users.all();
 
-// Listing project members(including inherited members)
-// see. https://docs.gitlab.com/ee/api/members.html#list-all-members-of-a-group-or-project-including-inherited-members
-const projectId = 9999;
-let members = await api.ProjectMembers.all(projectId, { includeInherited: true } );
-
 // Or using Promise-Then notation
-api.Projects.all().then((projects) => {
+api.Projects.all().then(projects => {
   console.log(projects);
+  for (let project of projects) {
+    // Listing project members(including inherited members)
+    // see. https://docs.gitlab.com/ee/api/members.html#list-all-members-of-a-group-or-project-including-inherited-members
+    api.ProjectMembers.all(project.id, { includeInherited: true }).then(members => {
+      console.log(members);
+    });
+  }
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -401,6 +401,11 @@ const api = new Gitlab({
 // Listing users
 let users = await api.Users.all();
 
+// Listing project members(including inherited members)
+// see. https://docs.gitlab.com/ee/api/members.html#list-all-members-of-a-group-or-project-including-inherited-members
+const projectId = 9999;
+let members = await api.ProjectMembers.all(projectId, { includeInherited: true } );
+
 // Or using Promise-Then notation
 api.Projects.all().then((projects) => {
   console.log(projects);


### PR DESCRIPTION
Hi.
The sample code in the Readme does not appear to have any examples that include inherited members.
Added example using hidden option ``` includeInherited ```.

