### PR TITLE
feat: Updated an API parameter for GitLab 12.9

### DIFF
--- a/packages/gitbeaker-core/src/services/ContainerRegistry.ts
+++ b/packages/gitbeaker-core/src/services/ContainerRegistry.ts
@@ -32,13 +32,13 @@ export class ContainerRegistry extends BaseService {
   removeTags(
     projectId: string | number,
     repositoryId: number,
-    nameRegex: string,
-    options?: Sudo & { keepN: string; olderThan: string },
+    nameRegexDelete: string,
+    options?: Sudo & { nameRegexKeep: string; keepN: string; olderThan: string },
   ) {
     const [pId, rId] = [projectId, repositoryId].map(encodeURIComponent);
 
     return RequestHelper.del(this, `projects/${pId}/registry/repositories/${rId}/tags`, {
-      nameRegex,
+      nameRegexDelete,
       ...options,
     });
   }


### PR DESCRIPTION
fix(core): 🐛 Updated variable name for registry `removeTags` method, as per https://docs.gitlab.com/12.9/ee/api/container_registry.html#delete-registry-repository-tags-in-bulk

BREAKING CHANGE: 🧨 A `removeTags` method parameter name changed from nameRegex to nameRegexDelete. Works with GitLab 12.9+.

Added nameRegexKeep parameter.