### PR TITLE
Add types field to node and browser package.json

### DIFF
--- a/packages/gitbeaker-browser/package.json
+++ b/packages/gitbeaker-browser/package.json
@@ -49,6 +49,7 @@
   ],
   "license": "MIT",
   "browser": "dist/index.js",
+  "types": "dist/index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/jdalrymple/gitbeaker"

--- a/packages/gitbeaker-core/package.json
+++ b/packages/gitbeaker-core/package.json
@@ -41,6 +41,7 @@
   "license": "MIT",
   "main": "dist/index.js",
   "module": "dist/index.es.js",
+  "types": "dist/types/index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/jdalrymple/gitbeaker"
@@ -51,6 +52,5 @@
     "generate-map": "ESM_DISABLE_CACHE=true TS_NODE_PROJECT=scripts/tsconfig.json node -r esm -r ts-node/register scripts/generate.ts",
     "test:integration": "jest test/integration",
     "test:unit": "jest test/unit"
-  },
-  "types": "dist/types/index.d.ts"
+  }
 }

--- a/packages/gitbeaker-node/package.json
+++ b/packages/gitbeaker-node/package.json
@@ -41,6 +41,7 @@
   "license": "MIT",
   "main": "dist/index.js",
   "module": "dist/index.es.js",
+  "types": "dist/types/index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/jdalrymple/gitbeaker"


### PR DESCRIPTION
Typings for `@gitbeaker/{node,browser}@>= 15` do not work because the `index.d.ts` is in a non-standard location and the `types` field is not set in `package.json`. Interestingly, the `types` field _is_ set in `@gitbeaker/core`.

This change brings all three packages into alignment with the `types` field in both relative location in `package.json` as well as value.