### PR TITLE
Feature: Arbitrary parameters for Projects.search

### DIFF
--- a/packages/gitbeaker-core/src/services/Projects.ts
+++ b/packages/gitbeaker-core/src/services/Projects.ts
@@ -124,8 +124,10 @@ export class Projects extends BaseService {
     return RequestHelper.del(this, `projects/${pId}/fork`, options);
   }
 
-  search(projectName: string) {
-    return RequestHelper.get(this, 'projects', { search: projectName });
+  search(projectName: string, options?: BaseRequestOptions) {
+    return RequestHelper.get(this, 'projects', { search: projectName, ...options }) as Promise<
+      ProjectSchema[]
+    >;
   }
 
   share(


### PR DESCRIPTION
As discussed in #800, the Projects API's search method was missing optional query parameters. This MR allows one to put other optional parameters such as `search_namespaces`.

In #800, I discussed the possibility of URI-encode the search parameter. Turns out it's already done by the RequestHelper and the `query-string` package :smile: 

So, here is my small contribution to the project.