### PR TITLE
Add YouTrack to the supported services

### DIFF
--- a/packages/gitbeaker-core/src/services/Services.ts
+++ b/packages/gitbeaker-core/src/services/Services.ts
@@ -31,7 +31,8 @@ export type SupportedService =
   | 'teamcity'
   | 'jenkins'
   | 'jenkins-deprecated'
-  | 'mock-ci';
+  | 'mock-ci'
+  | 'youtrack';
 
 export class Services extends BaseService {
   edit(projectId: string | number, serviceName: SupportedService, options?: BaseRequestOptions) {


### PR DESCRIPTION
YouTrack is one of GitLab's supported services, but it's missing here.