### PR TITLE
Removal of esinterlop to prefer namespace imports over default exports

### DIFF
--- a/packages/gitbeaker-browser/src/KyRequester.ts
+++ b/packages/gitbeaker-browser/src/KyRequester.ts
@@ -1,4 +1,4 @@
-import Ky from 'ky';
+import ky from 'ky';
 import { Agent } from 'https';
 import {
   Service,
@@ -52,7 +52,7 @@ export async function handler(endpoint, options) {
   let response;
 
   try {
-    response = await Ky(endpoint, options);
+    response = await ky(endpoint, options);
   } catch (e) {
     if (e.response) {
       const output = await e.response.json();

--- a/packages/gitbeaker-browser/test/unit/KyRequester.ts
+++ b/packages/gitbeaker-browser/test/unit/KyRequester.ts
@@ -1,5 +1,5 @@
-import ky from 'ky';
-import fetch from 'node-fetch';
+import * as ky from 'ky';
+import * as fetch from 'node-fetch';
 import { Agent } from 'https';
 import { processBody, handler, defaultRequest } from '../../src/KyRequester';
 

--- a/packages/gitbeaker-browser/tsconfig.json
+++ b/packages/gitbeaker-browser/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "esModuleInterop": true,
     "outDir": "./dist",
     "declaration": true,
     "declarationDir": "dist/types"

--- a/packages/gitbeaker-cli/src/cli.ts
+++ b/packages/gitbeaker-cli/src/cli.ts
@@ -1,19 +1,19 @@
-import program, { Options } from 'sywac';
-import chalk from 'chalk';
+import * as Sywac from 'sywac';
+import * as Chalk from 'chalk';
 import { camelize, decamelize, depascalize } from 'xcase';
 import * as Gitbeaker from '@gitbeaker/node';
 import * as map from '@gitbeaker/core/dist/map.json';
 
 // Styling settings
-const commandStyle = chalk.hex('#e34329').bold;
-const groupStyle = chalk.hex('#fca325').bold;
-const usageStyle = chalk.hex('#fc6e26').bold;
-const optionStyle = chalk.white.bold;
-const descriptionStyle = chalk.hex('#848484');
-const hintStyle = chalk.hex('#6a5f88');
+const commandStyle = Chalk.hex('#e34329').bold;
+const groupStyle = Chalk.hex('#fca325').bold;
+const usageStyle = Chalk.hex('#fc6e26').bold;
+const optionStyle = Chalk.white.bold;
+const descriptionStyle = Chalk.hex('#848484');
+const hintStyle = Chalk.hex('#6a5f88');
 
 // Globally configurable arguments
-function globalConfig(env = process.env): { [name: string]: Options } {
+function globalConfig(env = process.env): { [name: string]: Sywac.Options } {
   return {
     'gb-token': {
       alias: 'gl-token',
@@ -159,8 +159,7 @@ function setupAPIs(setupArgs, apiName, methods) {
 }
 
 // Add default settings
-const cli = program
-  .version('-v, --version')
+const cli = Sywac.version('-v, --version')
   .help('-h, --help')
   .showHelpByDefault()
   .epilogue('Copyright 2019')

--- a/packages/gitbeaker-cli/test/unit/index.ts
+++ b/packages/gitbeaker-cli/test/unit/index.ts
@@ -1,4 +1,4 @@
-import pkg from '../../package.json';
+import * as pkg from '../../package.json';
 
 jest.mock('@gitbeaker/node');
 jest.mock('ora', () => ({

--- a/packages/gitbeaker-core/scripts/tsconfig.json
+++ b/packages/gitbeaker-core/scripts/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
-    "esModuleInterop": true,
+    // "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
     "allowJs": true,
     "target": "es6",
     "module": "esnext",

--- a/packages/gitbeaker-core/src/infrastructure/RequestHelper.ts
+++ b/packages/gitbeaker-core/src/infrastructure/RequestHelper.ts
@@ -1,4 +1,4 @@
-import Li from 'li';
+import { parse as parseLink } from 'li';
 import { camelizeKeys } from 'xcase';
 import { BaseService } from './BaseService';
 import { appendFormFromObject } from './Utils';
@@ -75,7 +75,7 @@ async function get(
 
   // Rescurse through pagination results
   if (!query.page && underLimit && pagination.next) {
-    const { next } = Li.parse(headers.link);
+    const { next } = parseLink(headers.link);
     const leaf = service.url.split('/').pop() || '';
     const regex = new RegExp(`.+/api/v\\d(/${leaf})?/`);
     const more = (await get(service, next.replace(regex, ''), {

--- a/packages/gitbeaker-core/src/infrastructure/Utils.ts
+++ b/packages/gitbeaker-core/src/infrastructure/Utils.ts
@@ -1,4 +1,4 @@
-import FormData from 'form-data';
+import * as FormData from 'form-data';
 
 /* eslint @typescript-eslint/no-explicit-any: 0 */
 interface Constructor {

--- a/packages/gitbeaker-core/test/unit/infrastructure/RequestHelper.ts
+++ b/packages/gitbeaker-core/test/unit/infrastructure/RequestHelper.ts
@@ -1,4 +1,4 @@
-import FormData from 'form-data';
+import * as FormData from 'form-data';
 import { RequestHelper, BaseService } from '../../../src/infrastructure';
 
 /* eslint no-empty-pattern: 0 */

--- a/packages/gitbeaker-node/src/GotRequester.ts
+++ b/packages/gitbeaker-node/src/GotRequester.ts
@@ -1,5 +1,5 @@
 import Got from 'got';
-import FormData from 'form-data';
+import * as FormData from 'form-data';
 import { decamelizeKeys } from 'xcase';
 import { Agent } from 'https';
 import {

--- a/packages/gitbeaker-node/test/unit/GotRequester.ts
+++ b/packages/gitbeaker-node/test/unit/GotRequester.ts
@@ -1,5 +1,5 @@
-import got from 'got';
-import FormData from 'form-data';
+import * as got from 'got';
+import * as FormData from 'form-data';
 import { Agent } from 'https';
 import { processBody, handler, defaultRequest } from '../../src/GotRequester';
 

--- a/packages/gitbeaker-requester-utils/src/RequesterUtils.ts
+++ b/packages/gitbeaker-requester-utils/src/RequesterUtils.ts
@@ -1,7 +1,7 @@
 import { Agent } from 'https';
 import { decamelizeKeys } from 'xcase';
 import { stringify } from 'query-string';
-import FormDataC from 'form-data';
+import * as FormData from 'form-data';
 
 // Types
 export interface RequesterType {
@@ -41,7 +41,7 @@ export function defaultRequest(
 
   if (sudo) headers.sudo = sudo;
 
-  if (typeof body === 'object' && !(body instanceof FormDataC)) {
+  if (typeof body === 'object' && !(body instanceof FormData)) {
     bod = JSON.stringify(decamelizeKeys(body));
     headers['content-type'] = 'application/json';
   } else {

--- a/packages/gitbeaker-requester-utils/test/unit/RequesterUtils.ts
+++ b/packages/gitbeaker-requester-utils/test/unit/RequesterUtils.ts
@@ -1,4 +1,4 @@
-import FormData from 'form-data';
+import * as FormData from 'form-data';
 import { createInstance, defaultRequest, modifyServices } from '../../src/RequesterUtils';
 
 const methods = ['get', 'put', 'delete', 'stream', 'post'];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
     /* Module Resolution Options */
 
     "moduleResolution": "node",
-    "esModuleInterop": true,
+    // "esModuleInterop": true,
     "resolveJsonModule": true,
     "baseUrl": ".",
     "paths": {


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>21.5.1-canary.893.156520485.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @gitbeaker/browser@21.5.1-canary.893.156520485.0
  npm install @gitbeaker/cli@21.5.1-canary.893.156520485.0
  npm install @gitbeaker/core@21.5.1-canary.893.156520485.0
  npm install @gitbeaker/node@21.5.1-canary.893.156520485.0
  npm install @gitbeaker/requester-utils@21.5.1-canary.893.156520485.0
  # or 
  yarn add @gitbeaker/browser@21.5.1-canary.893.156520485.0
  yarn add @gitbeaker/cli@21.5.1-canary.893.156520485.0
  yarn add @gitbeaker/core@21.5.1-canary.893.156520485.0
  yarn add @gitbeaker/node@21.5.1-canary.893.156520485.0
  yarn add @gitbeaker/requester-utils@21.5.1-canary.893.156520485.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
