### PR TITLE
fix(browser): return early if response headers empty

### DIFF
--- a/packages/gitbeaker-browser/src/KyRequester.ts
+++ b/packages/gitbeaker-browser/src/KyRequester.ts
@@ -8,6 +8,10 @@ import {
 } from '@gitbeaker/requester-utils';
 
 function responseHeadersAsObject(response): Record<string, string> {
+  if (!response.headers.entries().length) {
+    return {};
+  }
+  
   const headers = {};
   const keyVals = [...response.headers.entries()];
 


### PR DESCRIPTION
When performing simple requests, such as

```ts
import { Gitlab } from "@gitbeaker/browser";

const api = new Gitlab({ token, host });

const res = await api.Issues.show(projectId, issueIid);
```

I used to get errors, such as

```console
index.js:11539 RangeError: Invalid array length
    at ./gitbeaker/packages/gitbeaker-browser/src/KyRequester.ts.__spreadArrays (index.js:155)
    at responseHeadersAsObject (index.js:169)
    at index.js:224
    at step (index.js:148)
    at Object.next (index.js:129)
    at fulfilled (index.js:120)
(anonymous) @ index.js:11539
step @ index.js:11488
(anonymous) @ index.js:11469
rejected @ index.js:11461
Promise.then (async)
step @ index.js:11462
(anonymous) @ index.js:11463
./source/features/add-grid-for-current-column-label.tsx.__awaiter @ index.js:11459
addGridForCurrentColumnLabel @ index.js:11520
(anonymous) @ index.js:11375
step @ index.js:11345
(anonymous) @ index.js:11326
fulfilled @ index.js:11317
Promise.then (async)
step @ index.js:11319
(anonymous) @ index.js:11320
./source/Features.ts.__awaiter @ index.js:11316
(anonymous) @ index.js:11369
(anonymous) @ index.js:11380
./source/Features.ts.Features.loadAll @ index.js:11363
globalInit @ index.js:11810
./source/refined-gitlab.ts @ index.js:11667
__webpack_require__ @ index.js:20
./source/index.ts @ index.js:11637
__webpack_require__ @ index.js:20
(anonymous) @ index.js:84
(anonymous) @ index.js:87
```

and this fixed it.

---

`__spreadArrays` refers to the `const keyVals = [...response.headers.entries()]` line's array spread when the headers are empty (`{}`)

(I'm using `gitbeaker`'s direct source code as a git submodule instead of via npm because I tried both rollup & webpack and couldn't compile `gitbeaker` to work inside a [browser extension](https://github.com/kiprasmel/refined-gitlab). It's generally better to **not** compile libraries and leave it up to the final application, but whatever, I don't mind, and was able to fix this quicker - cheers)