### PR TITLE
fix(node): response body needs parse firstly when it's type is json

### DIFF
--- a/packages/gitbeaker-node/src/GotRequester.ts
+++ b/packages/gitbeaker-node/src/GotRequester.ts
@@ -56,8 +56,12 @@ export async function handler(endpoint, options) {
   try {
     response = await Got(endpoint, options);
   } catch (e) {
-    if (e.response) {
-      const output = e.response.body;
+    if (
+      e.response &&
+      typeof e.response.body === 'string' &&
+      e.response.body.length > 0
+    ) {
+      const output = JSON.parse(e.response.body);
 
       e.description = output.error || output.message;
     }


### PR DESCRIPTION
If the `Content-Type` is `application/json` in response headers, we can't get the error message without parse it.
https://github.com/jdalrymple/gitbeaker/blob/949171bd23bbcfc815c8d8af3ec0fd9a7be5f6eb/packages/gitbeaker-node/src/GotRequester.ts#L62