### PR TITLE
feat: apply exponental backoff for 429 errros

### DIFF
--- a/packages/gitbeaker-requester-utils/src/RequesterUtils.ts
+++ b/packages/gitbeaker-requester-utils/src/RequesterUtils.ts
@@ -101,3 +101,7 @@ export function modifyServices<T extends { [name: string]: Constructable }>(
 
   return updated as T;
 }
+
+export async function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}


### PR DESCRIPTION
This was implemented similarly to https://github.com/python-gitlab/python-gitlab/blob/1606310a880f8a8a2a370db27511b57732caf178/gitlab/__init__.py#L549
Gitlab sadly doesn't send out `Retry-After` headers anymore, so we need this workaround

Fixes #960
