### PR TITLE
Handling nesting of not query parameter

### DIFF
--- a/packages/gitbeaker-requester-utils/src/RequesterUtils.ts
+++ b/packages/gitbeaker-requester-utils/src/RequesterUtils.ts
@@ -38,10 +38,12 @@ export type DefaultRequestReturn = {
 };
 
 // Utility methods
-export function formatQuery(options?: Record<string, unknown>) {
-  return stringify(decamelizeKeys(options || {}), {
-    arrayFormat: 'bracket',
-  });
+export function formatQuery(params: Record<string, unknown> = {}) {
+  const decamelized = decamelizeKeys(params);
+
+  if (decamelized.not) decamelized.not = JSON.stringify(decamelized.not);
+
+  return stringify(decamelized, { arrayFormat: 'bracket' });
 }
 
 export function defaultRequest(


### PR DESCRIPTION
fixes #1158 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>24.0.3-canary.1223.201108695.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @gitbeaker/browser@24.0.3-canary.1223.201108695.0
  npm install @gitbeaker/cli@24.0.3-canary.1223.201108695.0
  npm install @gitbeaker/core@24.0.3-canary.1223.201108695.0
  npm install @gitbeaker/node@24.0.3-canary.1223.201108695.0
  npm install @gitbeaker/requester-utils@24.0.3-canary.1223.201108695.0
  # or 
  yarn add @gitbeaker/browser@24.0.3-canary.1223.201108695.0
  yarn add @gitbeaker/cli@24.0.3-canary.1223.201108695.0
  yarn add @gitbeaker/core@24.0.3-canary.1223.201108695.0
  yarn add @gitbeaker/node@24.0.3-canary.1223.201108695.0
  yarn add @gitbeaker/requester-utils@24.0.3-canary.1223.201108695.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
