### PR TITLE
Agent-Type error for GotRequester

### DIFF
--- a/packages/gitbeaker-node/src/GotRequester.ts
+++ b/packages/gitbeaker-node/src/GotRequester.ts
@@ -13,10 +13,13 @@ import {
 export function defaultRequest(
   service: DefaultRequestService,
   { body, query, sudo, method }: DefaultRequestOptions = {},
-): DefaultRequestReturn & { json?: Record<string, unknown>; agent?: { https: Agent } } {
+): DefaultRequestReturn & {
+  json?: Record<string, unknown>;
+  https?: { rejectUnauthorized: boolean };
+} {
   const options: DefaultRequestReturn & {
     json?: Record<string, unknown>;
-    agent?: { https: Agent };
+    https?: { rejectUnauthorized: boolean };
   } = baseDefaultRequest(service, { body, query, sudo, method });
 
   // FIXME: Not the best comparison, but...it will have to do for now.
@@ -26,11 +29,9 @@ export function defaultRequest(
     delete options.body;
   }
 
-  if (service.url.includes('https')) {
-    options.agent = {
-      https: new Agent({
-        rejectUnauthorized: service.rejectUnauthorized,
-      }),
+  if (service.url.includes('https') && service.rejectUnauthorized) {
+    options.https = {
+      rejectUnauthorized: service.rejectUnauthorized,
     };
   }
 

--- a/packages/gitbeaker-node/src/GotRequester.ts
+++ b/packages/gitbeaker-node/src/GotRequester.ts
@@ -1,6 +1,5 @@
 import Got from 'got';
 import { decamelizeKeys } from 'xcase';
-import { Agent } from 'https';
 import {
   DefaultRequestService,
   DefaultRequestReturn,

--- a/packages/gitbeaker-node/test/unit/GotRequester.ts
+++ b/packages/gitbeaker-node/test/unit/GotRequester.ts
@@ -1,6 +1,5 @@
 import * as got from 'got';
 import * as FormData from 'form-data';
-import { Agent } from 'https';
 import { processBody, handler, defaultRequest } from '../../src/GotRequester';
 
 jest.mock('got');
@@ -141,13 +140,24 @@ describe('defaultRequest', () => {
     expect(output2.json).toBeUndefined();
   });
 
-  it('should assign the agent property if given https url', async () => {
-    const { agent = { https: {} } } = defaultRequest(
-      { ...service, url: 'https://test.com' },
+  it('should not assign the https property if given https url and not rejectUnauthorized', async () => {
+    const { https } = defaultRequest({ ...service, url: 'https://test.com' }, { method: 'post' });
+
+    expect(https).toBeUndefined();
+  });
+
+  it('should not assign the https property if given http url and rejectUnauthorized', async () => {
+    const { https } = defaultRequest({ ...service, url: 'http://test.com' }, { method: 'post' });
+
+    expect(https).toBeUndefined();
+  });
+
+  it('should assign the https property if given https url and rejectUnauthorized', async () => {
+    const { https } = defaultRequest(
+      { ...service, url: 'https://test.com', rejectUnauthorized: true },
       { method: 'post' },
     );
 
-    expect(agent.https).toBeInstanceOf(Agent);
-    expect(agent.https.rejectUnauthorized).toBeFalsy();
+    expect(https).toMatchObject({ rejectUnauthorized: true });
   });
 });


### PR DESCRIPTION
fixes #1161 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>24.0.3-canary.1224.201118535.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @gitbeaker/browser@24.0.3-canary.1224.201118535.0
  npm install @gitbeaker/cli@24.0.3-canary.1224.201118535.0
  npm install @gitbeaker/core@24.0.3-canary.1224.201118535.0
  npm install @gitbeaker/node@24.0.3-canary.1224.201118535.0
  npm install @gitbeaker/requester-utils@24.0.3-canary.1224.201118535.0
  # or 
  yarn add @gitbeaker/browser@24.0.3-canary.1224.201118535.0
  yarn add @gitbeaker/cli@24.0.3-canary.1224.201118535.0
  yarn add @gitbeaker/core@24.0.3-canary.1224.201118535.0
  yarn add @gitbeaker/node@24.0.3-canary.1224.201118535.0
  yarn add @gitbeaker/requester-utils@24.0.3-canary.1224.201118535.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
