### PR TITLE
refactor: export CommitAction interface

### DIFF
--- a/packages/gitbeaker-core/src/services/Commits.ts
+++ b/packages/gitbeaker-core/src/services/Commits.ts
@@ -39,7 +39,7 @@ export interface CommitSchemaCamelized {
 
 export type CommitSchema = CommitSchemaDefault | CommitSchemaCamelized;
 
-interface CommitAction {
+export interface CommitAction {
   /** The action to perform */
   action: 'create' | 'delete' | 'move' | 'update';
   /** Full path to the file. Ex. lib/class.rb */


### PR DESCRIPTION
Small PR to export `CommitAction` interface from `gitbeaker/core` package.
See no meaningful reason for not exporting this interface, please correct/guide me if I just don't get them 😉 

_It actually used to be exported in some early versions of this package (in those old days when it was a single `gitlab` npm package)._
