### PR TITLE
fix: call `buildMap` dynamically instead of using json file

### DIFF
--- a/packages/gitbeaker-cli/src/cli.ts
+++ b/packages/gitbeaker-cli/src/cli.ts
@@ -2,7 +2,7 @@ import * as Sywac from 'sywac';
 import * as Chalk from 'chalk';
 import { camelize, decamelize, depascalize } from 'xcase';
 import * as Gitbeaker from '@gitbeaker/node';
-import * as map from '@gitbeaker/core/dist/map.json';
+import { buildMap } from "@gitbeaker/core/../scripts/generate"
 
 // Styling settings
 const commandStyle = Chalk.hex('#e34329').bold;
@@ -200,7 +200,7 @@ cli.command('*', (argv, ctx) => {
 });
 
 // Add all supported API's
-Object.entries(map).forEach(([apiName, methods]) => {
+Object.entries(buildMap()).forEach(([apiName, methods]) => {
   cli.command(param(apiName), {
     desc: `The ${apiName} API`,
     setup: (setupArgs) => setupAPIs(setupArgs, apiName, methods),

--- a/packages/gitbeaker-core/scripts/generate.ts
+++ b/packages/gitbeaker-core/scripts/generate.ts
@@ -35,7 +35,7 @@ function removeOptionalArg(list) {
   return list;
 }
 
-function buildMap() {
+export function buildMap() {
   const map = {};
   const baseArgs = Object.keys(getParamNames(BaseService)[0]);
 


### PR DESCRIPTION
questionable change.

I suppose the static json file is used to create it once to avoid extra startup cost?

I changed this because I'm trying my hardest to setup webpack to compile both my project and your's as a git submodule, and I somehow made it work, but I do need this work-around for it. I am fine as I have my fork, but ideally I could base on top of the original repo.

Any thoughts?