### PR TITLE
Rewrite HTTP method for `stream` requests in GotRequester

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 #### ⚠️ Pushed to `master`
 
-- Use HTTP GET for `stream` requests in @gitbeaker/node ([@Vogel612](https://github.com/Vogel612))
 - Remove module test ([@jdalrymple](https://github.com/jdalrymple))
 - Move into pkg script ([@jdalrymple](https://github.com/jdalrymple))
 - Updating image being used ([@jdalrymple](https://github.com/jdalrymple))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### ⚠️ Pushed to `master`
 
+- Use HTTP GET for `stream` requests in @gitbeaker/node ([@Vogel612](https://github.com/Vogel612))
 - Remove module test ([@jdalrymple](https://github.com/jdalrymple))
 - Move into pkg script ([@jdalrymple](https://github.com/jdalrymple))
 - Updating image being used ([@jdalrymple](https://github.com/jdalrymple))

--- a/packages/gitbeaker-node/src/GotRequester.ts
+++ b/packages/gitbeaker-node/src/GotRequester.ts
@@ -74,7 +74,11 @@ export async function handler(endpoint: string, options: Record<string, unknown>
   for (let i = 0; i < maxRetries; i += 1) {
     const waitTime = 2 ** i * 0.1;
     try {
-      if (options.method === 'stream') return Got(endpoint, options);
+      if (options.method === 'stream') {
+        options.method = 'get';
+        options.isStream = true;
+        return Got(endpoint, options);
+      }
       response = await Got(endpoint, options); // eslint-disable-line
       break;
     } catch (e) {


### PR DESCRIPTION
This patches the problematic HTTP method behaviour observed in [this comment](https://github.com/jdalrymple/gitbeaker/issues/1515#issuecomment-797599664) for the gitbeaker-node package