### PR TITLE
Fixing import errors within the CLI release

### DIFF
--- a/.lintstagedrc.yml
+++ b/.lintstagedrc.yml
@@ -1,4 +1,4 @@
-'*.{ts,js,json,md,yml}':
+'**/*.{ts,js,json,md,yml}':
   - 'prettier --write'
-'*.{ts,js}':
+'**/*.{ts,js}':
   - 'eslint --fix'

--- a/packages/gitbeaker-cli/src/cli.ts
+++ b/packages/gitbeaker-cli/src/cli.ts
@@ -1,5 +1,5 @@
-import * as Sywac from 'sywac';
-import * as Chalk from 'chalk';
+import Sywac from 'sywac';
+import Chalk from 'chalk';
 import { camelize, decamelize, depascalize } from 'xcase';
 import * as Gitbeaker from '@gitbeaker/node';
 import { getAPIMap } from '@gitbeaker/core';
@@ -91,9 +91,16 @@ const ignoreOptions = ['_', '$0', 'v', 'version', 'h', 'help', 'g', 'global-args
 
 // Helper function to param case strings
 function param(string) {
-  const attempt = decamelize(string, '-');
+  let cleaned = string;
 
-  return attempt !== string ? attempt : depascalize(string, '-');
+  // Handle exceptions
+  if(string.includes('GitLabCI')) cleaned = cleaned.replace('GitLabCI', 'Gitlabci');
+  if(string.includes('YML')) cleaned = cleaned.replace('YML', 'Yml');
+  if(string.includes('GPG')) cleaned = cleaned.replace('GPG', 'Gpg');
+
+  const attempt = decamelize(cleaned, '-');
+
+  return attempt !== cleaned ? attempt : depascalize(cleaned, '-');
 }
 
 function setupAPIMethods(setupArgs, methodArgs) {

--- a/packages/gitbeaker-cli/src/cli.ts
+++ b/packages/gitbeaker-cli/src/cli.ts
@@ -94,9 +94,9 @@ function param(string) {
   let cleaned = string;
 
   // Handle exceptions
-  if(string.includes('GitLabCI')) cleaned = cleaned.replace('GitLabCI', 'Gitlabci');
-  if(string.includes('YML')) cleaned = cleaned.replace('YML', 'Yml');
-  if(string.includes('GPG')) cleaned = cleaned.replace('GPG', 'Gpg');
+  if (string.includes('GitLabCI')) cleaned = cleaned.replace('GitLabCI', 'Gitlabci');
+  if (string.includes('YML')) cleaned = cleaned.replace('YML', 'Yml');
+  if (string.includes('GPG')) cleaned = cleaned.replace('GPG', 'Gpg');
 
   const attempt = decamelize(cleaned, '-');
 

--- a/packages/gitbeaker-cli/test/integration/services/Projects.ts
+++ b/packages/gitbeaker-cli/test/integration/services/Projects.ts
@@ -1,0 +1,12 @@
+const { TEST_ID } = process.env;
+
+describe('gitbeaker projects create', () => {
+  it('should create a valid project', async () => {
+    // eslint-disable-next-line
+    const { cli } = require('../../../dist/index');
+    const { output } = await cli.parse(`gitbeaker projects create --name="CLI Project ${TEST_ID}" --gb-token="${process.env.PERSONAL_ACCESS_TOKEN}" --gb-host="${process.env.GITLAB_URL}"`);
+    const data = JSON.parse(output)
+
+    expect(data.name).toBe(`CLI Project ${TEST_ID}`);
+  });
+});

--- a/packages/gitbeaker-cli/test/integration/services/Projects.ts
+++ b/packages/gitbeaker-cli/test/integration/services/Projects.ts
@@ -4,8 +4,10 @@ describe('gitbeaker projects create', () => {
   it('should create a valid project', async () => {
     // eslint-disable-next-line
     const { cli } = require('../../../dist/index');
-    const { output } = await cli.parse(`gitbeaker projects create --name="CLI Project ${TEST_ID}" --gb-token="${process.env.PERSONAL_ACCESS_TOKEN}" --gb-host="${process.env.GITLAB_URL}"`);
-    const data = JSON.parse(output)
+    const { output } = await cli.parse(
+      `gitbeaker projects create --name="CLI Project ${TEST_ID}" --gb-token="${process.env.PERSONAL_ACCESS_TOKEN}" --gb-host="${process.env.GITLAB_URL}"`,
+    );
+    const data = JSON.parse(output);
 
     expect(data.name).toBe(`CLI Project ${TEST_ID}`);
   });

--- a/packages/gitbeaker-cli/tsconfig.json
+++ b/packages/gitbeaker-cli/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "esModuleInterop": true,
     "outDir": "./dist"
   },
   "include": ["src"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     /* Basic Options */
 
     "target": "es5",
-    "module": "ESNext",
+    "module": "es6",
     "noEmit": true,
     "pretty": true,
     "lib": ["es2015", "es2016", "es2017", "dom"],


### PR DESCRIPTION
## Summary
The import clause for Sywac and chalk were incorrect but wasnt caught because unit tests only look at the source and not the released code.

1. Fixed the clause
2. Added integration tests that also test the release code for basic functionality **These will be activated in #1604 where a substantial amount of the test pipeline was updated**

fixes #1676 