### PR TITLE
refactor: remove camelization from type system

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,9 +41,11 @@
     "lint:doc": "prettier --check './*.json' './*.yml' './*.js'",
     "lint:doc:fix": "prettier --write './*.json' './*.yml' './*.md' './*.js'",
     "lint:fix": "prettier --write 'packages/**/{src,test}/**/*.ts' && eslint 'packages/**/{src,test}/**/*/*.ts' --fix",
+    "test:int": "yarn test:integration",
     "test:integration": "jest test/integration",
     "test:integration:node": "TEST_ID=$(uuid) yarn jest node/test/integration",
     "test:unit": "jest test/unit",
+    "test": "yarn test:unit && yarn:integration",
     "release": "auto shipit --verbose --verbose"
   },
   "author": "Justin Dalrymple <justin.s.dalrymple@gmail.com>",

--- a/packages/gitbeaker-core/src/services/ApplicationSettings.ts
+++ b/packages/gitbeaker-core/src/services/ApplicationSettings.ts
@@ -65,7 +65,7 @@ export interface SettingsSchema extends Record<string, unknown> {
   keep_latest_artifact: boolean;
 }
 
-export class ApplicationSettings<C extends boolean = false> extends BaseService<C> {
+export class ApplicationSettings extends BaseService {
   all(options?: Sudo) {
     return RequestHelper.get<SettingsSchema>()(this, 'application/settings', options);
   }

--- a/packages/gitbeaker-core/src/services/Branches.ts
+++ b/packages/gitbeaker-core/src/services/Branches.ts
@@ -14,7 +14,7 @@ export interface BranchSchema extends Record<string, unknown> {
   commit: Omit<CommitSchema, 'web_url' | 'created_at'>;
 }
 
-export class Branches<C extends boolean = false> extends BaseService<C> {
+export class Branches extends BaseService {
   all(projectId: string | number, options?: PaginatedRequestOptions) {
     const pId = encodeURIComponent(projectId);
 

--- a/packages/gitbeaker-core/src/services/BroadcastMessages.ts
+++ b/packages/gitbeaker-core/src/services/BroadcastMessages.ts
@@ -20,7 +20,7 @@ export interface BroadcastMessageSchema extends Record<string, unknown> {
   dismissable: boolean;
 }
 
-export class BroadcastMessages<C extends boolean = false> extends BaseService<C> {
+export class BroadcastMessages extends BaseService {
   all(options?: PaginatedRequestOptions) {
     return RequestHelper.get<BroadcastMessageSchema[]>()(this, 'broadcast_messages', options);
   }

--- a/packages/gitbeaker-core/src/services/CommitDiscussions.ts
+++ b/packages/gitbeaker-core/src/services/CommitDiscussions.ts
@@ -1,13 +1,8 @@
 import { BaseServiceOptions } from '@gitbeaker/requester-utils';
 import { ResourceDiscussions, DiscussionSchema } from '../templates';
-import {
-  BaseRequestOptions,
-  PaginatedRequestOptions,
-  Sudo,
-  CamelizedRecord,
-} from '../infrastructure';
+import { BaseRequestOptions, PaginatedRequestOptions, Sudo } from '../infrastructure';
 
-export interface CommitDiscussions<C extends boolean = false> extends ResourceDiscussions<C> {
+export interface CommitDiscussions extends ResourceDiscussions {
   addNote(
     projectId: string | number,
     commitId: number,
@@ -15,20 +10,20 @@ export interface CommitDiscussions<C extends boolean = false> extends ResourceDi
     noteId: number,
     body: string,
     options?: BaseRequestOptions,
-  ): Promise<CamelizedRecord<C, DiscussionSchema>>;
+  ): Promise<DiscussionSchema>;
 
   all(
     projectId: string | number,
     commitId: number,
     options?: PaginatedRequestOptions,
-  ): Promise<CamelizedRecord<C, DiscussionSchema>[]>;
+  ): Promise<DiscussionSchema[]>;
 
   create(
     projectId: string | number,
     commitId: number,
     body: string,
     options?: BaseRequestOptions,
-  ): Promise<CamelizedRecord<C, DiscussionSchema>>;
+  ): Promise<DiscussionSchema>;
 
   editNote(
     projectId: string | number,
@@ -36,7 +31,7 @@ export interface CommitDiscussions<C extends boolean = false> extends ResourceDi
     discussionId: number,
     noteId: number,
     options: BaseRequestOptions & { body: string },
-  ): Promise<CamelizedRecord<C, DiscussionSchema>>;
+  ): Promise<DiscussionSchema>;
 
   removeNote(
     projectId: string | number,
@@ -51,11 +46,11 @@ export interface CommitDiscussions<C extends boolean = false> extends ResourceDi
     commitId: number,
     discussionId: number,
     options?: Sudo,
-  ): Promise<CamelizedRecord<C, DiscussionSchema>>;
+  ): Promise<DiscussionSchema>;
 }
 
-export class CommitDiscussions<C extends boolean = false> extends ResourceDiscussions<C> {
-  constructor(options: BaseServiceOptions<C>) {
+export class CommitDiscussions extends ResourceDiscussions {
+  constructor(options: BaseServiceOptions) {
     /* istanbul ignore next */
     super('projects', 'repository/commits', options);
   }

--- a/packages/gitbeaker-core/src/services/Commits.ts
+++ b/packages/gitbeaker-core/src/services/Commits.ts
@@ -134,7 +134,7 @@ export interface CommitReferenceSchema extends Record<string, unknown> {
   name: string;
 }
 
-export class Commits<C extends boolean = false> extends BaseService<C> {
+export class Commits extends BaseService {
   all(projectId: string | number, options?: PaginatedRequestOptions) {
     const pId = encodeURIComponent(projectId);
 

--- a/packages/gitbeaker-core/src/services/ContainerRegistry.ts
+++ b/packages/gitbeaker-core/src/services/ContainerRegistry.ts
@@ -24,7 +24,7 @@ export interface RepositorySchema extends Record<string, unknown> {
   tags?: Pick<TagSchema, 'name' | 'path' | 'location'>[];
 }
 
-export class ContainerRegistry<C extends boolean = false> extends BaseService<C> {
+export class ContainerRegistry extends BaseService {
   projectRepositories(projectId: string | number, options?: PaginatedRequestOptions) {
     const pId = encodeURIComponent(projectId);
 

--- a/packages/gitbeaker-core/src/services/DeployKeys.ts
+++ b/packages/gitbeaker-core/src/services/DeployKeys.ts
@@ -14,7 +14,7 @@ export interface DeployKey extends Record<string, unknown> {
   created_at: string;
 }
 
-export class DeployKeys<C extends boolean = false> extends BaseService<C> {
+export class DeployKeys extends BaseService {
   add(projectId: string | number, options?: Sudo) {
     const pId = encodeURIComponent(projectId);
 

--- a/packages/gitbeaker-core/src/services/Deployments.ts
+++ b/packages/gitbeaker-core/src/services/Deployments.ts
@@ -39,7 +39,7 @@ export type DeploymentSchema = {
   environment: EnvironmentSchema;
 };
 
-export class Deployments<C extends boolean = false> extends BaseService<C> {
+export class Deployments extends BaseService {
   all(projectId: string | number, options?: PaginatedRequestOptions) {
     const pId = encodeURIComponent(projectId);
 

--- a/packages/gitbeaker-core/src/services/DockerfileTemplates.ts
+++ b/packages/gitbeaker-core/src/services/DockerfileTemplates.ts
@@ -1,8 +1,8 @@
 import { BaseServiceOptions } from '@gitbeaker/requester-utils';
 import { ResourceTemplates } from '../templates';
 
-export class DockerfileTemplates<C extends boolean = false> extends ResourceTemplates<C> {
-  constructor(options: BaseServiceOptions<C>) {
+export class DockerfileTemplates extends ResourceTemplates {
+  constructor(options: BaseServiceOptions) {
     /* istanbul ignore next */
     super('dockerfiles', options);
   }

--- a/packages/gitbeaker-core/src/services/Environments.ts
+++ b/packages/gitbeaker-core/src/services/Environments.ts
@@ -19,7 +19,7 @@ export interface EnvironmentSchema extends Record<string, unknown> {
   deployable?: DeployableSchema;
 }
 
-export class Environments<C extends boolean = false> extends BaseService<C> {
+export class Environments extends BaseService {
   all(projectId: string | number, options?: PaginatedRequestOptions) {
     const pId = encodeURIComponent(projectId);
 

--- a/packages/gitbeaker-core/src/services/EpicDiscussions.ts
+++ b/packages/gitbeaker-core/src/services/EpicDiscussions.ts
@@ -1,13 +1,8 @@
 import { BaseServiceOptions } from '@gitbeaker/requester-utils';
 import { ResourceDiscussions, DiscussionSchema } from '../templates';
-import {
-  BaseRequestOptions,
-  PaginatedRequestOptions,
-  Sudo,
-  CamelizedRecord,
-} from '../infrastructure';
+import { BaseRequestOptions, PaginatedRequestOptions, Sudo } from '../infrastructure';
 
-export interface EpicDiscussions<C extends boolean = false> extends ResourceDiscussions<C> {
+export interface EpicDiscussions extends ResourceDiscussions {
   addNote(
     groupId: string | number,
     epicId: number,
@@ -15,20 +10,20 @@ export interface EpicDiscussions<C extends boolean = false> extends ResourceDisc
     noteId: number,
     body: string,
     options?: BaseRequestOptions,
-  ): Promise<CamelizedRecord<C, DiscussionSchema>>;
+  ): Promise<DiscussionSchema>;
 
   all(
     groupId: string | number,
     epicId: number,
     options?: PaginatedRequestOptions,
-  ): Promise<CamelizedRecord<C, DiscussionSchema>[]>;
+  ): Promise<DiscussionSchema[]>;
 
   create(
     groupId: string | number,
     epicId: number,
     body: string,
     options?: BaseRequestOptions,
-  ): Promise<CamelizedRecord<C, DiscussionSchema>>;
+  ): Promise<DiscussionSchema>;
 
   editNote(
     groupId: string | number,
@@ -36,7 +31,7 @@ export interface EpicDiscussions<C extends boolean = false> extends ResourceDisc
     discussionId: number,
     noteId: number,
     options: BaseRequestOptions & { body: string },
-  ): Promise<CamelizedRecord<C, DiscussionSchema>>;
+  ): Promise<DiscussionSchema>;
 
   removeNote(
     groupId: string | number,
@@ -51,11 +46,11 @@ export interface EpicDiscussions<C extends boolean = false> extends ResourceDisc
     epicId: number,
     discussionId: number,
     options?: Sudo,
-  ): Promise<CamelizedRecord<C, DiscussionSchema>>;
+  ): Promise<DiscussionSchema>;
 }
 
-export class EpicDiscussions<C extends boolean = false> extends ResourceDiscussions<C> {
-  constructor(options: BaseServiceOptions<C>) {
+export class EpicDiscussions extends ResourceDiscussions {
+  constructor(options: BaseServiceOptions) {
     /* istanbul ignore next */
     super('groups', 'epics', options);
   }

--- a/packages/gitbeaker-core/src/services/EpicIssues.ts
+++ b/packages/gitbeaker-core/src/services/EpicIssues.ts
@@ -12,7 +12,7 @@ export interface EpicIssueSchema
   epic_issue_id: number;
 }
 
-export class EpicIssues<C extends boolean = false> extends BaseService<C> {
+export class EpicIssues extends BaseService {
   all(groupId: string | number, epicIId: number, options?: PaginatedRequestOptions) {
     const [gId, eId] = [groupId, epicIId].map(encodeURIComponent);
 

--- a/packages/gitbeaker-core/src/services/EpicNotes.ts
+++ b/packages/gitbeaker-core/src/services/EpicNotes.ts
@@ -1,30 +1,25 @@
 import { BaseServiceOptions } from '@gitbeaker/requester-utils';
 import { ResourceNotes, NoteSchema } from '../templates';
-import {
-  PaginatedRequestOptions,
-  BaseRequestOptions,
-  Sudo,
-  CamelizedRecord,
-} from '../infrastructure';
+import { PaginatedRequestOptions, BaseRequestOptions, Sudo } from '../infrastructure';
 
 export interface EpicNoteSchema extends NoteSchema {
   file_name: string;
   expires_at: string;
 }
 
-export interface EpicNotes<C extends boolean = false> extends ResourceNotes<C> {
+export interface EpicNotes extends ResourceNotes {
   all(
     groupId: string | number,
     epicId: number,
     options?: PaginatedRequestOptions,
-  ): Promise<CamelizedRecord<C, EpicNoteSchema>[]>;
+  ): Promise<EpicNoteSchema[]>;
 
   create(
     groupId: string | number,
     epicId: number,
     body: string,
     options?: BaseRequestOptions,
-  ): Promise<CamelizedRecord<C, EpicNoteSchema>>;
+  ): Promise<EpicNoteSchema>;
 
   edit(
     groupId: string | number,
@@ -32,7 +27,7 @@ export interface EpicNotes<C extends boolean = false> extends ResourceNotes<C> {
     noteId: number,
     body: string,
     options?: BaseRequestOptions,
-  ): Promise<CamelizedRecord<C, EpicNoteSchema>>;
+  ): Promise<EpicNoteSchema>;
 
   remove(groupId: string | number, epicId: number, noteId: number, options?: Sudo): Promise<void>;
 
@@ -41,11 +36,11 @@ export interface EpicNotes<C extends boolean = false> extends ResourceNotes<C> {
     epicId: number,
     noteId: number,
     options?: Sudo,
-  ): Promise<CamelizedRecord<C, EpicNoteSchema>>;
+  ): Promise<EpicNoteSchema>;
 }
 
-export class EpicNotes<C extends boolean = false> extends ResourceNotes<C> {
-  constructor(options: BaseServiceOptions<C>) {
+export class EpicNotes extends ResourceNotes {
+  constructor(options: BaseServiceOptions) {
     /* istanbul ignore next */
     super('groups', 'epics', options);
   }

--- a/packages/gitbeaker-core/src/services/Epics.ts
+++ b/packages/gitbeaker-core/src/services/Epics.ts
@@ -45,7 +45,7 @@ export interface EpicSchema extends Record<string, unknown> {
   };
 }
 
-export class Epics<C extends boolean = false> extends BaseService<C> {
+export class Epics extends BaseService {
   all(groupId: string | number, options?: PaginatedRequestOptions) {
     const gId = encodeURIComponent(groupId);
 

--- a/packages/gitbeaker-core/src/services/Events.ts
+++ b/packages/gitbeaker-core/src/services/Events.ts
@@ -36,7 +36,7 @@ export interface EventSchema extends Record<string, unknown> {
   author_username: string;
 }
 
-export class Events<C extends boolean = false> extends BaseService<C> {
+export class Events extends BaseService {
   all({
     projectId,
     ...options

--- a/packages/gitbeaker-core/src/services/FeatureFlags.ts
+++ b/packages/gitbeaker-core/src/services/FeatureFlags.ts
@@ -30,7 +30,7 @@ export interface FeatureFlagSchema extends Record<string, unknown> {
   strategies?: StrategySchema[];
 }
 
-export class FeatureFlags<C extends boolean = false> extends BaseService<C> {
+export class FeatureFlags extends BaseService {
   all(
     projectId: string | number,
     options: { scopes?: 'enabled' | 'disabled' } & PaginatedRequestOptions = {},

--- a/packages/gitbeaker-core/src/services/FreezePeriods.ts
+++ b/packages/gitbeaker-core/src/services/FreezePeriods.ts
@@ -10,7 +10,7 @@ export interface FreezePeriodSchema extends Record<string, unknown> {
   updated_at: string;
 }
 
-export class FreezePeriods<C extends boolean = false> extends BaseService<C> {
+export class FreezePeriods extends BaseService {
   all(projectId: string | number, options?: BaseRequestOptions) {
     const pId = encodeURIComponent(projectId);
 

--- a/packages/gitbeaker-core/src/services/GeoNodes.ts
+++ b/packages/gitbeaker-core/src/services/GeoNodes.ts
@@ -139,7 +139,7 @@ export interface GeoNodeStatusSchema extends Record<string, unknown> {
   group_wiki_repositories_failed_count: number;
 }
 
-export class GeoNodes<C extends boolean = false> extends BaseService<C> {
+export class GeoNodes extends BaseService {
   all(options?: PaginatedRequestOptions) {
     return RequestHelper.get<GeoNodeSchema[]>()(this, 'geo_nodes', options);
   }

--- a/packages/gitbeaker-core/src/services/GitLabCIYMLTemplates.ts
+++ b/packages/gitbeaker-core/src/services/GitLabCIYMLTemplates.ts
@@ -1,8 +1,8 @@
 import { BaseServiceOptions } from '@gitbeaker/requester-utils';
 import { ResourceTemplates } from '../templates';
 
-export class GitLabCIYMLTemplates<C extends boolean = false> extends ResourceTemplates<C> {
-  constructor(options: BaseServiceOptions<C>) {
+export class GitLabCIYMLTemplates extends ResourceTemplates {
+  constructor(options: BaseServiceOptions) {
     /* istanbul ignore next */
     super('gitlab_ci_ymls', options);
   }

--- a/packages/gitbeaker-core/src/services/GitignoreTemplates.ts
+++ b/packages/gitbeaker-core/src/services/GitignoreTemplates.ts
@@ -1,8 +1,8 @@
 import { BaseServiceOptions } from '@gitbeaker/requester-utils';
 import { ResourceTemplates } from '../templates';
 
-export class GitignoreTemplates<C extends boolean = false> extends ResourceTemplates<C> {
-  constructor(options: BaseServiceOptions<C>) {
+export class GitignoreTemplates extends ResourceTemplates {
+  constructor(options: BaseServiceOptions) {
     /* istanbul ignore next */
     super('gitignores', options);
   }

--- a/packages/gitbeaker-core/src/services/GroupAccessRequests.ts
+++ b/packages/gitbeaker-core/src/services/GroupAccessRequests.ts
@@ -1,23 +1,23 @@
 import { BaseServiceOptions } from '@gitbeaker/requester-utils';
 import { ResourceAccessRequests, AccessRequestSchema, AccessLevel } from '../templates';
-import { Sudo, CamelizedRecord } from '../infrastructure';
+import { Sudo } from '../infrastructure';
 
-export interface GroupAccessRequests<C extends boolean = false> extends ResourceAccessRequests<C> {
-  all(groupId: string | number): Promise<CamelizedRecord<C, AccessRequestSchema>[]>;
+export interface GroupAccessRequests extends ResourceAccessRequests {
+  all(groupId: string | number): Promise<AccessRequestSchema[]>;
 
-  request(groupId: string | number): Promise<CamelizedRecord<C, AccessRequestSchema>>;
+  request(groupId: string | number): Promise<AccessRequestSchema>;
 
   approve(
     groupId: string | number,
     userId: number,
     options?: { accessLevel?: AccessLevel } & Sudo,
-  ): Promise<CamelizedRecord<C, AccessRequestSchema>>;
+  ): Promise<AccessRequestSchema>;
 
   deny(groupId: string | number, userId: number): Promise<void>;
 }
 
-export class GroupAccessRequests<C extends boolean = false> extends ResourceAccessRequests<C> {
-  constructor(options: BaseServiceOptions<C>) {
+export class GroupAccessRequests extends ResourceAccessRequests {
+  constructor(options: BaseServiceOptions) {
     /* istanbul ignore next */
     super('groups', options);
   }

--- a/packages/gitbeaker-core/src/services/GroupBadges.ts
+++ b/packages/gitbeaker-core/src/services/GroupBadges.ts
@@ -1,51 +1,36 @@
 import { BaseServiceOptions } from '@gitbeaker/requester-utils';
 import { ResourceBadges, BadgeSchema } from '../templates';
-import {
-  BaseRequestOptions,
-  PaginatedRequestOptions,
-  Sudo,
-  CamelizedRecord,
-} from '../infrastructure';
+import { BaseRequestOptions, PaginatedRequestOptions, Sudo } from '../infrastructure';
 
 export interface GroupBadgeSchema extends BadgeSchema {
   kind: 'group';
 }
 
-export interface GroupBadges<C extends boolean = false> extends ResourceBadges<C> {
-  add(
-    groupId: string | number,
-    options?: BaseRequestOptions,
-  ): Promise<CamelizedRecord<C, GroupBadgeSchema>>;
+export interface GroupBadges extends ResourceBadges {
+  add(groupId: string | number, options?: BaseRequestOptions): Promise<GroupBadgeSchema>;
 
-  all(
-    groupId: string | number,
-    options?: PaginatedRequestOptions,
-  ): Promise<CamelizedRecord<C, GroupBadgeSchema>[]>;
+  all(groupId: string | number, options?: PaginatedRequestOptions): Promise<GroupBadgeSchema[]>;
 
   edit(
     groupId: string | number,
     badgeId: number,
     options?: BaseRequestOptions,
-  ): Promise<CamelizedRecord<C, GroupBadgeSchema>>;
+  ): Promise<GroupBadgeSchema>;
 
   preview(
     groupId: string | number,
     linkUrl: string,
     imageUrl: string,
     options?: Sudo,
-  ): Promise<CamelizedRecord<C, Omit<GroupBadgeSchema, 'id' | 'name' | 'kind'>>>;
+  ): Promise<Omit<GroupBadgeSchema, 'id' | 'name' | 'kind'>>;
 
   remove(groupId: string | number, badgeId: number, options?: Sudo): Promise<void>;
 
-  show(
-    groupId: string | number,
-    badgeId: number,
-    options?: Sudo,
-  ): Promise<CamelizedRecord<C, GroupBadgeSchema>>;
+  show(groupId: string | number, badgeId: number, options?: Sudo): Promise<GroupBadgeSchema>;
 }
 
-export class GroupBadges<C extends boolean = false> extends ResourceBadges<C> {
-  constructor(options: BaseServiceOptions<C>) {
+export class GroupBadges extends ResourceBadges {
+  constructor(options: BaseServiceOptions) {
     /* istanbul ignore next */
     super('groups', options);
   }

--- a/packages/gitbeaker-core/src/services/GroupCustomAttributes.ts
+++ b/packages/gitbeaker-core/src/services/GroupCustomAttributes.ts
@@ -1,20 +1,19 @@
 import { BaseServiceOptions } from '@gitbeaker/requester-utils';
 import { ResourceCustomAttributes, CustomAttributeSchema } from '../templates';
-import { PaginatedRequestOptions, Sudo, CamelizedRecord } from '../infrastructure';
+import { PaginatedRequestOptions, Sudo } from '../infrastructure';
 
-export interface GroupCustomAttributes<C extends boolean = false>
-  extends ResourceCustomAttributes<C> {
+export interface GroupCustomAttributes extends ResourceCustomAttributes {
   all(
     groupId: string | number,
     options?: PaginatedRequestOptions,
-  ): Promise<CamelizedRecord<C, CustomAttributeSchema>[]>;
+  ): Promise<CustomAttributeSchema[]>;
 
   set(
     groupId: string | number,
     customAttributeId: number,
     value: string,
     options?: Sudo,
-  ): Promise<CamelizedRecord<C, CustomAttributeSchema>>;
+  ): Promise<CustomAttributeSchema>;
 
   remove(groupId: string | number, customAttributeId: number, options?: Sudo): Promise<void>;
 
@@ -22,11 +21,11 @@ export interface GroupCustomAttributes<C extends boolean = false>
     groupId: string | number,
     customAttributeId: number,
     options?: Sudo,
-  ): Promise<CamelizedRecord<C, CustomAttributeSchema>>;
+  ): Promise<CustomAttributeSchema>;
 }
 
-export class GroupCustomAttributes<C extends boolean = false> extends ResourceCustomAttributes<C> {
-  constructor(options: BaseServiceOptions<C>) {
+export class GroupCustomAttributes extends ResourceCustomAttributes {
+  constructor(options: BaseServiceOptions) {
     /* istanbul ignore next */
     super('groups', options);
   }

--- a/packages/gitbeaker-core/src/services/GroupDeployTokens.ts
+++ b/packages/gitbeaker-core/src/services/GroupDeployTokens.ts
@@ -1,32 +1,25 @@
 import { BaseServiceOptions } from '@gitbeaker/requester-utils';
 import { ResourceDeployTokens, DeployTokenScope, DeployTokenSchema } from '../templates';
-import {
-  BaseRequestOptions,
-  PaginatedRequestOptions,
-  CamelizedRecord,
-  Sudo,
-} from '../infrastructure';
+import { BaseRequestOptions, PaginatedRequestOptions, Sudo } from '../infrastructure';
 
-export interface GroupDeployTokens<C extends boolean = false> extends ResourceDeployTokens<C> {
+export interface GroupDeployTokens extends ResourceDeployTokens {
   add(
     groupId: string | number,
     tokenName: string,
     tokenScopes: DeployTokenScope[],
     options?: BaseRequestOptions,
-  ): Promise<CamelizedRecord<C, DeployTokenSchema>>;
+  ): Promise<DeployTokenSchema>;
 
   all({
     groupId,
     ...options
-  }: { groupId?: string | number } & PaginatedRequestOptions): Promise<
-    CamelizedRecord<C, DeployTokenSchema>[]
-  >;
+  }: { groupId?: string | number } & PaginatedRequestOptions): Promise<DeployTokenSchema[]>;
 
   remove(groupId: string | number, tokenId: number, options?: Sudo): Promise<void>;
 }
 
-export class GroupDeployTokens<C extends boolean = false> extends ResourceDeployTokens<C> {
-  constructor(options: BaseServiceOptions<C>) {
+export class GroupDeployTokens extends ResourceDeployTokens {
+  constructor(options: BaseServiceOptions) {
     /* istanbul ignore next */
     super('groups', options);
   }

--- a/packages/gitbeaker-core/src/services/GroupIssueBoards.ts
+++ b/packages/gitbeaker-core/src/services/GroupIssueBoards.ts
@@ -1,41 +1,29 @@
 import { BaseServiceOptions } from '@gitbeaker/requester-utils';
 import { GroupSchema } from './Groups';
 import { ResourceIssueBoards, IssueBoardSchema, IssueBoardListSchema } from '../templates';
-import {
-  BaseRequestOptions,
-  PaginatedRequestOptions,
-  Sudo,
-  CamelizedRecord,
-} from '../infrastructure';
+import { BaseRequestOptions, PaginatedRequestOptions, Sudo } from '../infrastructure';
 
 export interface GroupIssueBoardSchema extends IssueBoardSchema {
   group: Pick<GroupSchema, 'id' | 'name' | 'web_url'>;
 }
 
-export interface GroupIssueBoards<C extends boolean = false> extends ResourceIssueBoards<C> {
-  all(
-    groupId: string | number,
-    options?: PaginatedRequestOptions,
-  ): Promise<CamelizedRecord<C, IssueBoardSchema>[]>;
+export interface GroupIssueBoards extends ResourceIssueBoards {
+  all(groupId: string | number, options?: PaginatedRequestOptions): Promise<IssueBoardSchema[]>;
 
-  create(
-    groupId: string | number,
-    name: string,
-    options?: Sudo,
-  ): Promise<CamelizedRecord<C, GroupIssueBoardSchema>>;
+  create(groupId: string | number, name: string, options?: Sudo): Promise<GroupIssueBoardSchema>;
 
   createList(
     groupId: string | number,
     boardId: number,
     labelId: number | string,
     options?: Sudo,
-  ): Promise<CamelizedRecord<C, IssueBoardListSchema>>;
+  ): Promise<IssueBoardListSchema>;
 
   edit(
     groupId: string | number,
     boardId: number,
     options?: BaseRequestOptions,
-  ): Promise<CamelizedRecord<C, GroupIssueBoardSchema>>;
+  ): Promise<GroupIssueBoardSchema>;
 
   editList(
     groupId: string | number,
@@ -43,13 +31,9 @@ export interface GroupIssueBoards<C extends boolean = false> extends ResourceIss
     listId: number,
     position: number,
     options?: Sudo,
-  ): Promise<CamelizedRecord<C, IssueBoardListSchema>>;
+  ): Promise<IssueBoardListSchema>;
 
-  lists(
-    groupId: string | number,
-    boardId: number,
-    options?: Sudo,
-  ): Promise<CamelizedRecord<C, IssueBoardListSchema>[]>;
+  lists(groupId: string | number, boardId: number, options?: Sudo): Promise<IssueBoardListSchema[]>;
 
   remove(groupId: string | number, boardId: number, options?: Sudo): Promise<void>;
 
@@ -60,22 +44,18 @@ export interface GroupIssueBoards<C extends boolean = false> extends ResourceIss
     options?: Sudo,
   ): Promise<void>;
 
-  show(
-    groupId: string | number,
-    boardId: number,
-    options?: Sudo,
-  ): Promise<CamelizedRecord<C, GroupIssueBoardSchema>>;
+  show(groupId: string | number, boardId: number, options?: Sudo): Promise<GroupIssueBoardSchema>;
 
   showList(
     groupId: string | number,
     boardId: number,
     listId: number,
     options?: Sudo,
-  ): Promise<CamelizedRecord<C, IssueBoardListSchema>>;
+  ): Promise<IssueBoardListSchema>;
 }
 
-export class GroupIssueBoards<C extends boolean = false> extends ResourceIssueBoards<C> {
-  constructor(options: BaseServiceOptions<C>) {
+export class GroupIssueBoards extends ResourceIssueBoards {
+  constructor(options: BaseServiceOptions) {
     /* istanbul ignore next */
     super('groups', options);
   }

--- a/packages/gitbeaker-core/src/services/GroupLabels.ts
+++ b/packages/gitbeaker-core/src/services/GroupLabels.ts
@@ -1,30 +1,22 @@
 import { BaseServiceOptions } from '@gitbeaker/requester-utils';
-import {
-  BaseRequestOptions,
-  PaginatedRequestOptions,
-  CamelizedRecord,
-  Sudo,
-} from '../infrastructure';
+import { BaseRequestOptions, PaginatedRequestOptions, Sudo } from '../infrastructure';
 import { ResourceLabels, LabelSchema } from '../templates';
 
-export interface GroupLabels<C extends boolean = false> extends ResourceLabels<C> {
-  all(
-    groupId: string | number,
-    options?: PaginatedRequestOptions,
-  ): Promise<CamelizedRecord<C, LabelSchema>[]>;
+export interface GroupLabels extends ResourceLabels {
+  all(groupId: string | number, options?: PaginatedRequestOptions): Promise<LabelSchema[]>;
 
   create(
     groupId: string | number,
     labelName: string,
     color: string,
     options?: BaseRequestOptions,
-  ): Promise<CamelizedRecord<C, LabelSchema>>;
+  ): Promise<LabelSchema>;
 
   edit(
     groupId: string | number,
     labelId: number | string,
     options?: BaseRequestOptions,
-  ): Promise<CamelizedRecord<C, LabelSchema>>;
+  ): Promise<LabelSchema>;
 
   remove(groupId: string | number, labelId: number | string, options?: Sudo): Promise<void>;
 
@@ -32,17 +24,17 @@ export interface GroupLabels<C extends boolean = false> extends ResourceLabels<C
     groupId: string | number,
     labelId: number | string,
     options?: Sudo,
-  ): Promise<CamelizedRecord<C, LabelSchema>>;
+  ): Promise<LabelSchema>;
 
   unsubscribe(
     groupId: string | number,
     labelId: number | string,
     options?: Sudo,
-  ): Promise<CamelizedRecord<C, LabelSchema>>;
+  ): Promise<LabelSchema>;
 }
 
-export class GroupLabels<C extends boolean = false> extends ResourceLabels<C> {
-  constructor(options: BaseServiceOptions<C>) {
+export class GroupLabels extends ResourceLabels {
+  constructor(options: BaseServiceOptions) {
     /* istanbul ignore next */
     super('groups', options);
   }

--- a/packages/gitbeaker-core/src/services/GroupMembers.ts
+++ b/packages/gitbeaker-core/src/services/GroupMembers.ts
@@ -1,43 +1,38 @@
 import { BaseServiceOptions } from '@gitbeaker/requester-utils';
 import { ResourceMembers, MembersSchema, IncludeInherited, AccessLevel } from '../templates';
-import {
-  BaseRequestOptions,
-  PaginatedRequestOptions,
-  CamelizedRecord,
-  Sudo,
-} from '../infrastructure';
+import { BaseRequestOptions, PaginatedRequestOptions, Sudo } from '../infrastructure';
 
-export interface GroupMembers<C extends boolean = false> extends ResourceMembers<C> {
+export interface GroupMembers extends ResourceMembers {
   add(
     groupId: string | number,
     userId: number,
     accessLevel: AccessLevel,
     options?: BaseRequestOptions,
-  ): Promise<CamelizedRecord<C, MembersSchema>>;
+  ): Promise<MembersSchema>;
 
   all(
     groupId: string | number,
     options?: IncludeInherited & PaginatedRequestOptions,
-  ): Promise<CamelizedRecord<C, MembersSchema>[]>;
+  ): Promise<MembersSchema[]>;
 
   edit(
     groupId: string | number,
     userId: number,
     accessLevel: AccessLevel,
     options?: BaseRequestOptions,
-  ): Promise<CamelizedRecord<C, MembersSchema>>;
+  ): Promise<MembersSchema>;
 
   show(
     groupId: string | number,
     userId: number,
     options?: IncludeInherited & Sudo,
-  ): Promise<CamelizedRecord<C, MembersSchema>>;
+  ): Promise<MembersSchema>;
 
   remove(groupId: string | number, userId: number, options?: Sudo): Promise<void>;
 }
 
-export class GroupMembers<C extends boolean = false> extends ResourceMembers<C> {
-  constructor(options: BaseServiceOptions<C>) {
+export class GroupMembers extends ResourceMembers {
+  constructor(options: BaseServiceOptions) {
     /* istanbul ignore next */
     super('groups', options);
   }

--- a/packages/gitbeaker-core/src/services/GroupMilestones.ts
+++ b/packages/gitbeaker-core/src/services/GroupMilestones.ts
@@ -1,53 +1,37 @@
 import { BaseServiceOptions } from '@gitbeaker/requester-utils';
 import { ResourceMilestones, MilestoneSchema } from '../templates';
-import {
-  PaginatedRequestOptions,
-  BaseRequestOptions,
-  Sudo,
-  CamelizedRecord,
-} from '../infrastructure';
+import { PaginatedRequestOptions, BaseRequestOptions, Sudo } from '../infrastructure';
 import { IssueSchema } from './Issues';
 import { MergeRequestSchema } from './MergeRequests';
 
-export interface GroupMilestones<C extends boolean = false> extends ResourceMilestones<C> {
-  all(
-    groupId: string | number,
-    options?: PaginatedRequestOptions,
-  ): Promise<CamelizedRecord<C, MilestoneSchema>[]>;
+export interface GroupMilestones extends ResourceMilestones {
+  all(groupId: string | number, options?: PaginatedRequestOptions): Promise<MilestoneSchema[]>;
 
   create(
     groupId: string | number,
     title: string,
     options?: BaseRequestOptions,
-  ): Promise<CamelizedRecord<C, MilestoneSchema>>;
+  ): Promise<MilestoneSchema>;
 
   edit(
     groupId: string | number,
     milestoneId: number,
     options?: BaseRequestOptions,
-  ): Promise<CamelizedRecord<C, MilestoneSchema>>;
+  ): Promise<MilestoneSchema>;
 
-  issues(
-    groupId: string | number,
-    milestoneId: number,
-    options?: Sudo,
-  ): Promise<CamelizedRecord<C, IssueSchema>[]>;
+  issues(groupId: string | number, milestoneId: number, options?: Sudo): Promise<IssueSchema[]>;
 
   mergeRequests(
     groupId: string | number,
     milestoneId: number,
     options?: Sudo,
-  ): Promise<CamelizedRecord<C, MergeRequestSchema>[]>;
+  ): Promise<MergeRequestSchema[]>;
 
-  show(
-    groupId: string | number,
-    milestoneId: number,
-    options?: Sudo,
-  ): Promise<CamelizedRecord<C, MilestoneSchema>>;
+  show(groupId: string | number, milestoneId: number, options?: Sudo): Promise<MilestoneSchema>;
 }
 
-export class GroupMilestones<C extends boolean = false> extends ResourceMilestones<C> {
-  constructor(options: BaseServiceOptions<C>) {
+export class GroupMilestones extends ResourceMilestones {
+  constructor(options: BaseServiceOptions) {
     /* istanbul ignore next */
     super('groups', options);
   }

--- a/packages/gitbeaker-core/src/services/GroupRunners.ts
+++ b/packages/gitbeaker-core/src/services/GroupRunners.ts
@@ -2,7 +2,7 @@ import { BaseService } from '@gitbeaker/requester-utils';
 import { PaginatedRequestOptions, ShowExpanded, RequestHelper } from '../infrastructure';
 import { RunnerSchema } from './Runners';
 
-export class GroupRunners<C extends boolean = false> extends BaseService<C> {
+export class GroupRunners extends BaseService {
   all(groupId: string | number, options?: PaginatedRequestOptions & ShowExpanded) {
     const gId = encodeURIComponent(groupId);
 

--- a/packages/gitbeaker-core/src/services/GroupVariables.ts
+++ b/packages/gitbeaker-core/src/services/GroupVariables.ts
@@ -1,35 +1,32 @@
 import { BaseServiceOptions } from '@gitbeaker/requester-utils';
 import { ResourceVariables, ResourceVariableSchema } from '../templates';
-import { PaginatedRequestOptions, BaseRequestOptions, CamelizedRecord } from '../infrastructure';
+import { PaginatedRequestOptions, BaseRequestOptions } from '../infrastructure';
 
-export interface GroupVariables<C extends boolean = false> extends ResourceVariables<C> {
+export interface GroupVariables extends ResourceVariables {
   all(
     groupId: string | number,
     options?: PaginatedRequestOptions,
-  ): Promise<CamelizedRecord<C, ResourceVariableSchema>[]>;
+  ): Promise<ResourceVariableSchema[]>;
 
-  create(
-    groupId: string | number,
-    options?: BaseRequestOptions,
-  ): Promise<CamelizedRecord<C, ResourceVariableSchema>>;
+  create(groupId: string | number, options?: BaseRequestOptions): Promise<ResourceVariableSchema>;
 
   edit(
     groupId: string | number,
     key: string,
     options?: BaseRequestOptions,
-  ): Promise<CamelizedRecord<C, ResourceVariableSchema>>;
+  ): Promise<ResourceVariableSchema>;
 
   show(
     groupId: string | number,
     key: string,
     options?: PaginatedRequestOptions,
-  ): Promise<CamelizedRecord<C, ResourceVariableSchema>>;
+  ): Promise<ResourceVariableSchema>;
 
   remove(groupId: string | number, key: string, options?: PaginatedRequestOptions): Promise<void>;
 }
 
-export class GroupVariables<C extends boolean = false> extends ResourceVariables<C> {
-  constructor(options: BaseServiceOptions<C>) {
+export class GroupVariables extends ResourceVariables {
+  constructor(options: BaseServiceOptions) {
     /* istanbul ignore next */
     super('groups', options);
   }

--- a/packages/gitbeaker-core/src/services/Groups.ts
+++ b/packages/gitbeaker-core/src/services/Groups.ts
@@ -58,7 +58,7 @@ export type GroupDetailSchema = {
   created_at: string;
 };
 
-export class Groups<C extends boolean = false> extends BaseService<C> {
+export class Groups extends BaseService {
   all(options?: PaginatedRequestOptions) {
     return RequestHelper.get<GroupSchema[]>()(this, 'groups', options);
   }

--- a/packages/gitbeaker-core/src/services/IssueAwardEmojis.ts
+++ b/packages/gitbeaker-core/src/services/IssueAwardEmojis.ts
@@ -1,20 +1,20 @@
 import { BaseServiceOptions } from '@gitbeaker/requester-utils';
 import { ResourceAwardEmojis, AwardEmojiSchema } from '../templates';
-import { PaginatedRequestOptions, Sudo, CamelizedRecord } from '../infrastructure';
+import { PaginatedRequestOptions, Sudo } from '../infrastructure';
 
-export interface IssueAwardEmojis<C extends boolean = false> extends ResourceAwardEmojis<C> {
+export interface IssueAwardEmojis extends ResourceAwardEmojis {
   all(
     projectId: string | number,
     issueIId: number,
     options?: PaginatedRequestOptions,
-  ): Promise<CamelizedRecord<C, AwardEmojiSchema>[]>;
+  ): Promise<AwardEmojiSchema[]>;
 
   award(
     projectId: string | number,
     issueIId: number,
     name: string,
     options?: Sudo,
-  ): Promise<CamelizedRecord<C, AwardEmojiSchema>>;
+  ): Promise<AwardEmojiSchema>;
 
   remove(
     projectId: string | number,
@@ -28,11 +28,11 @@ export interface IssueAwardEmojis<C extends boolean = false> extends ResourceAwa
     issueIId: number,
     awardId: number,
     options?: Sudo,
-  ): Promise<CamelizedRecord<C, AwardEmojiSchema>>;
+  ): Promise<AwardEmojiSchema>;
 }
 
-export class IssueAwardEmojis<C extends boolean = false> extends ResourceAwardEmojis<C> {
-  constructor(options: BaseServiceOptions<C>) {
+export class IssueAwardEmojis extends ResourceAwardEmojis {
+  constructor(options: BaseServiceOptions) {
     /* istanbul ignore next */
     super('issues', options);
   }

--- a/packages/gitbeaker-core/src/services/IssueDiscussions.ts
+++ b/packages/gitbeaker-core/src/services/IssueDiscussions.ts
@@ -1,13 +1,8 @@
 import { BaseServiceOptions } from '@gitbeaker/requester-utils';
 import { ResourceDiscussions, DiscussionSchema } from '../templates';
-import {
-  BaseRequestOptions,
-  PaginatedRequestOptions,
-  Sudo,
-  CamelizedRecord,
-} from '../infrastructure';
+import { BaseRequestOptions, PaginatedRequestOptions, Sudo } from '../infrastructure';
 
-export interface IssueDiscussions<C extends boolean = false> extends ResourceDiscussions<C> {
+export interface IssueDiscussions extends ResourceDiscussions {
   addNote(
     projectId: string | number,
     issueIId: number,
@@ -15,20 +10,20 @@ export interface IssueDiscussions<C extends boolean = false> extends ResourceDis
     noteId: number,
     body: string,
     options?: BaseRequestOptions,
-  ): Promise<CamelizedRecord<C, DiscussionSchema>>;
+  ): Promise<DiscussionSchema>;
 
   all(
     projectId: string | number,
     issueIId: number,
     options?: PaginatedRequestOptions,
-  ): Promise<CamelizedRecord<C, DiscussionSchema>[]>;
+  ): Promise<DiscussionSchema[]>;
 
   create(
     projectId: string | number,
     issueIId: number,
     body: string,
     options?: BaseRequestOptions,
-  ): Promise<CamelizedRecord<C, DiscussionSchema>>;
+  ): Promise<DiscussionSchema>;
 
   editNote(
     projectId: string | number,
@@ -36,7 +31,7 @@ export interface IssueDiscussions<C extends boolean = false> extends ResourceDis
     discussionId: number,
     noteId: number,
     options: BaseRequestOptions & { body: string },
-  ): Promise<CamelizedRecord<C, DiscussionSchema>>;
+  ): Promise<DiscussionSchema>;
 
   removeNote(
     projectId: string | number,
@@ -51,11 +46,11 @@ export interface IssueDiscussions<C extends boolean = false> extends ResourceDis
     issueIId: number,
     discussionId: number,
     options?: Sudo,
-  ): Promise<CamelizedRecord<C, DiscussionSchema>>;
+  ): Promise<DiscussionSchema>;
 }
 
-export class IssueDiscussions<C extends boolean = false> extends ResourceDiscussions<C> {
-  constructor(options: BaseServiceOptions<C>) {
+export class IssueDiscussions extends ResourceDiscussions {
+  constructor(options: BaseServiceOptions) {
     /* istanbul ignore next */
     super('projects', 'issues', options);
   }

--- a/packages/gitbeaker-core/src/services/IssueNoteAwardEmojis.ts
+++ b/packages/gitbeaker-core/src/services/IssueNoteAwardEmojis.ts
@@ -1,15 +1,14 @@
 import { BaseServiceOptions } from '@gitbeaker/requester-utils';
 import { ResourceNoteAwardEmojis, AwardEmojiSchema } from '../templates';
-import { PaginatedRequestOptions, CamelizedRecord, Sudo } from '../infrastructure';
+import { PaginatedRequestOptions, Sudo } from '../infrastructure';
 
-export interface IssueNoteAwardEmojis<C extends boolean = false>
-  extends ResourceNoteAwardEmojis<C> {
+export interface IssueNoteAwardEmojis extends ResourceNoteAwardEmojis {
   all(
     projectId: string | number,
     issueIId: number,
     noteId: number,
     options?: PaginatedRequestOptions,
-  ): Promise<CamelizedRecord<C, AwardEmojiSchema>[]>;
+  ): Promise<AwardEmojiSchema[]>;
 
   award(
     projectId: string | number,
@@ -17,7 +16,7 @@ export interface IssueNoteAwardEmojis<C extends boolean = false>
     noteId: number,
     name: string,
     options?: Sudo,
-  ): Promise<CamelizedRecord<C, AwardEmojiSchema>>;
+  ): Promise<AwardEmojiSchema>;
 
   remove(
     projectId: string | number,
@@ -33,11 +32,11 @@ export interface IssueNoteAwardEmojis<C extends boolean = false>
     noteId: number,
     awardId: number,
     options?: Sudo,
-  ): Promise<CamelizedRecord<C, AwardEmojiSchema>>;
+  ): Promise<AwardEmojiSchema>;
 }
 
-export class IssueNoteAwardEmojis<C extends boolean = false> extends ResourceNoteAwardEmojis<C> {
-  constructor(options: BaseServiceOptions<C>) {
+export class IssueNoteAwardEmojis extends ResourceNoteAwardEmojis {
+  constructor(options: BaseServiceOptions) {
     /* istanbul ignore next */
     super('issues', options);
   }

--- a/packages/gitbeaker-core/src/services/IssueNotes.ts
+++ b/packages/gitbeaker-core/src/services/IssueNotes.ts
@@ -1,11 +1,6 @@
 import { BaseServiceOptions } from '@gitbeaker/requester-utils';
 import { ResourceNotes, NoteSchema } from '../templates';
-import {
-  PaginatedRequestOptions,
-  BaseRequestOptions,
-  Sudo,
-  CamelizedRecord,
-} from '../infrastructure';
+import { PaginatedRequestOptions, BaseRequestOptions, Sudo } from '../infrastructure';
 
 export interface IssueNoteSchema extends NoteSchema {
   attachment?: string;
@@ -16,19 +11,19 @@ export interface IssueNoteSchema extends NoteSchema {
   resolvable: boolean;
 }
 
-export interface IssueNotes<C extends boolean = false> extends ResourceNotes<C> {
+export interface IssueNotes extends ResourceNotes {
   all(
     projectId: string | number,
     issueIId: number,
     options?: PaginatedRequestOptions,
-  ): Promise<CamelizedRecord<C, IssueNoteSchema>[]>;
+  ): Promise<IssueNoteSchema[]>;
 
   create(
     projectId: string | number,
     issueIId: number,
     body: string,
     options?: BaseRequestOptions,
-  ): Promise<CamelizedRecord<C, IssueNoteSchema>>;
+  ): Promise<IssueNoteSchema>;
 
   edit(
     projectId: string | number,
@@ -36,7 +31,7 @@ export interface IssueNotes<C extends boolean = false> extends ResourceNotes<C> 
     noteId: number,
     body: string,
     options?: BaseRequestOptions,
-  ): Promise<CamelizedRecord<C, IssueNoteSchema>>;
+  ): Promise<IssueNoteSchema>;
 
   remove(
     projectId: string | number,
@@ -50,11 +45,11 @@ export interface IssueNotes<C extends boolean = false> extends ResourceNotes<C> 
     issueIId: number,
     noteId: number,
     options?: Sudo,
-  ): Promise<CamelizedRecord<C, IssueNoteSchema>>;
+  ): Promise<IssueNoteSchema>;
 }
 
-export class IssueNotes<C extends boolean = false> extends ResourceNotes<C> {
-  constructor(options: BaseServiceOptions<C>) {
+export class IssueNotes extends ResourceNotes {
+  constructor(options: BaseServiceOptions) {
     /* istanbul ignore next */
     super('projects', 'issues', options);
   }

--- a/packages/gitbeaker-core/src/services/Issues.ts
+++ b/packages/gitbeaker-core/src/services/Issues.ts
@@ -72,7 +72,7 @@ export interface IssueSchema extends Record<string, unknown> {
   };
 }
 
-export class Issues<C extends boolean = false> extends BaseService<C> {
+export class Issues extends BaseService {
   addSpentTime(projectId: string | number, issueIid: number, duration: string, options?: Sudo) {
     const [pId, iId] = [projectId, issueIid].map(encodeURIComponent);
 

--- a/packages/gitbeaker-core/src/services/IssuesStatistics.ts
+++ b/packages/gitbeaker-core/src/services/IssuesStatistics.ts
@@ -13,7 +13,7 @@ export interface StatisticsSchema extends Record<string, unknown> {
   };
 }
 
-export class IssuesStatistics<C extends boolean = false> extends BaseService<C> {
+export class IssuesStatistics extends BaseService {
   all({ projectId, groupId, ...options }: ProjectOrGroup & BaseRequestOptions = {}) {
     let url: string;
 

--- a/packages/gitbeaker-core/src/services/Jobs.ts
+++ b/packages/gitbeaker-core/src/services/Jobs.ts
@@ -74,7 +74,7 @@ export interface BridgeSchema extends Record<string, unknown> {
   downstream_pipeline: Exclude<PipelineSchema, 'user'>;
 }
 
-export class Jobs<C extends boolean = false> extends BaseService<C> {
+export class Jobs extends BaseService {
   all(projectId: string | number, options?: PaginatedRequestOptions) {
     const pId = encodeURIComponent(projectId);
 

--- a/packages/gitbeaker-core/src/services/Keys.ts
+++ b/packages/gitbeaker-core/src/services/Keys.ts
@@ -11,7 +11,7 @@ export interface KeySchema extends Record<string, unknown> {
   user: UserExtendedSchema;
 }
 
-export class Keys<C extends boolean = false> extends BaseService<C> {
+export class Keys extends BaseService {
   show(keyId: string, options?: Sudo) {
     const kId = encodeURIComponent(keyId);
 

--- a/packages/gitbeaker-core/src/services/Labels.ts
+++ b/packages/gitbeaker-core/src/services/Labels.ts
@@ -1,30 +1,22 @@
 import { BaseServiceOptions } from '@gitbeaker/requester-utils';
-import {
-  BaseRequestOptions,
-  PaginatedRequestOptions,
-  CamelizedRecord,
-  Sudo,
-} from '../infrastructure';
+import { BaseRequestOptions, PaginatedRequestOptions, Sudo } from '../infrastructure';
 import { ResourceLabels, LabelSchema } from '../templates';
 
-export interface Labels<C extends boolean = false> extends ResourceLabels<C> {
-  all(
-    projectId: string | number,
-    options?: PaginatedRequestOptions,
-  ): Promise<CamelizedRecord<C, LabelSchema>[]>;
+export interface Labels extends ResourceLabels {
+  all(projectId: string | number, options?: PaginatedRequestOptions): Promise<LabelSchema[]>;
 
   create(
     projectId: string | number,
     labelName: string,
     color: string,
     options?: BaseRequestOptions,
-  ): Promise<CamelizedRecord<C, LabelSchema>>;
+  ): Promise<LabelSchema>;
 
   edit(
     projectId: string | number,
     labelId: number | string,
     options?: BaseRequestOptions,
-  ): Promise<CamelizedRecord<C, LabelSchema>>;
+  ): Promise<LabelSchema>;
 
   remove(projectId: string | number, labelId: number | string, options?: Sudo): Promise<void>;
 
@@ -32,17 +24,17 @@ export interface Labels<C extends boolean = false> extends ResourceLabels<C> {
     projectId: string | number,
     labelId: number | string,
     options?: Sudo,
-  ): Promise<CamelizedRecord<C, LabelSchema>>;
+  ): Promise<LabelSchema>;
 
   unsubscribe(
     projectId: string | number,
     labelId: number | string,
     options?: Sudo,
-  ): Promise<CamelizedRecord<C, LabelSchema>>;
+  ): Promise<LabelSchema>;
 }
 
-export class Labels<C extends boolean = false> extends ResourceLabels<C> {
-  constructor(options: BaseServiceOptions<C>) {
+export class Labels extends ResourceLabels {
+  constructor(options: BaseServiceOptions) {
     /* istanbul ignore next */
     super('projects', options);
   }

--- a/packages/gitbeaker-core/src/services/License.ts
+++ b/packages/gitbeaker-core/src/services/License.ts
@@ -22,7 +22,7 @@ export interface LicenseSchema extends Record<string, unknown> {
   };
 }
 
-export class License<C extends boolean = false> extends BaseService<C> {
+export class License extends BaseService {
   add(license: string, options?: Sudo) {
     return RequestHelper.post<LicenseSchema>()(this, 'license', { license, ...options });
   }

--- a/packages/gitbeaker-core/src/services/LicenseTemplates.ts
+++ b/packages/gitbeaker-core/src/services/LicenseTemplates.ts
@@ -1,6 +1,6 @@
 import { BaseServiceOptions } from '@gitbeaker/requester-utils';
 import { ResourceTemplates } from '../templates';
-import { PaginatedRequestOptions, Sudo, CamelizedRecord } from '../infrastructure';
+import { PaginatedRequestOptions, Sudo } from '../infrastructure';
 
 export interface LicenseTemplateSchema extends Record<string, unknown> {
   key: string;
@@ -16,13 +16,13 @@ export interface LicenseTemplateSchema extends Record<string, unknown> {
   content: string;
 }
 
-export interface LicenseTemplates<C extends boolean = false> extends ResourceTemplates<C> {
-  all(options?: PaginatedRequestOptions): Promise<CamelizedRecord<C, LicenseTemplateSchema>[]>;
-  show(key: string | number, options?: Sudo): Promise<CamelizedRecord<C, LicenseTemplateSchema>>;
+export interface LicenseTemplates extends ResourceTemplates {
+  all(options?: PaginatedRequestOptions): Promise<LicenseTemplateSchema[]>;
+  show(key: string | number, options?: Sudo): Promise<LicenseTemplateSchema>;
 }
 
-export class LicenseTemplates<C extends boolean = false> extends ResourceTemplates<C> {
-  constructor(options: BaseServiceOptions<C>) {
+export class LicenseTemplates extends ResourceTemplates {
+  constructor(options: BaseServiceOptions) {
     /* istanbul ignore next */
     super('Licenses', options);
   }

--- a/packages/gitbeaker-core/src/services/Lint.ts
+++ b/packages/gitbeaker-core/src/services/Lint.ts
@@ -7,7 +7,7 @@ export interface LintSchema extends Record<string, unknown> {
   warnings?: string[];
 }
 
-export class Lint<C extends boolean = false> extends BaseService<C> {
+export class Lint extends BaseService {
   lint(content: string, options?: Sudo) {
     return RequestHelper.post<LintSchema>()(this, 'ci/lint', { content, ...options });
   }

--- a/packages/gitbeaker-core/src/services/Markdown.ts
+++ b/packages/gitbeaker-core/src/services/Markdown.ts
@@ -5,7 +5,7 @@ export interface MarkdownSchema extends Record<string, unknown> {
   html: string;
 }
 
-export class Markdown<C extends boolean = false> extends BaseService<C> {
+export class Markdown extends BaseService {
   render(text: string, options?: { gfm?: string; project?: string | number } & Sudo) {
     return RequestHelper.post<MarkdownSchema>()(this, 'markdown', { text, ...options });
   }

--- a/packages/gitbeaker-core/src/services/MergeRequestApprovals.ts
+++ b/packages/gitbeaker-core/src/services/MergeRequestApprovals.ts
@@ -19,7 +19,7 @@ export type ApprovalRulesRequestOptions = {
   protectedBranchIds?: number[];
 };
 
-export class MergeRequestApprovals<C extends boolean = false> extends BaseService<C> {
+export class MergeRequestApprovals extends BaseService {
   addApprovalRule(
     projectId: string | number,
     name: string,

--- a/packages/gitbeaker-core/src/services/MergeRequestAwardEmojis.ts
+++ b/packages/gitbeaker-core/src/services/MergeRequestAwardEmojis.ts
@@ -1,20 +1,20 @@
 import { BaseServiceOptions } from '@gitbeaker/requester-utils';
 import { ResourceAwardEmojis, AwardEmojiSchema } from '../templates';
-import { PaginatedRequestOptions, Sudo, CamelizedRecord } from '../infrastructure';
+import { PaginatedRequestOptions, Sudo } from '../infrastructure';
 
-export interface MergeRequestAwardEmojis<C extends boolean = false> extends ResourceAwardEmojis<C> {
+export interface MergeRequestAwardEmojis extends ResourceAwardEmojis {
   all(
     projectId: string | number,
     mergerequestIId: number,
     options?: PaginatedRequestOptions,
-  ): Promise<CamelizedRecord<C, AwardEmojiSchema>[]>;
+  ): Promise<AwardEmojiSchema[]>;
 
   award(
     projectId: string | number,
     mergerequestIId: number,
     name: string,
     options?: Sudo,
-  ): Promise<CamelizedRecord<C, AwardEmojiSchema>>;
+  ): Promise<AwardEmojiSchema>;
 
   remove(
     projectId: string | number,
@@ -28,11 +28,11 @@ export interface MergeRequestAwardEmojis<C extends boolean = false> extends Reso
     mergerequestIId: number,
     awardId: number,
     options?: Sudo,
-  ): Promise<CamelizedRecord<C, AwardEmojiSchema>>;
+  ): Promise<AwardEmojiSchema>;
 }
 
-export class MergeRequestAwardEmojis<C extends boolean = false> extends ResourceAwardEmojis<C> {
-  constructor(options: BaseServiceOptions<C>) {
+export class MergeRequestAwardEmojis extends ResourceAwardEmojis {
+  constructor(options: BaseServiceOptions) {
     /* istanbul ignore next */
     super('merge_requests', options);
   }

--- a/packages/gitbeaker-core/src/services/MergeRequestDiscussions.ts
+++ b/packages/gitbeaker-core/src/services/MergeRequestDiscussions.ts
@@ -1,13 +1,8 @@
 import { BaseServiceOptions } from '@gitbeaker/requester-utils';
 import { ResourceDiscussions, DiscussionSchema } from '../templates';
-import {
-  BaseRequestOptions,
-  PaginatedRequestOptions,
-  Sudo,
-  CamelizedRecord,
-} from '../infrastructure';
+import { BaseRequestOptions, PaginatedRequestOptions, Sudo } from '../infrastructure';
 
-export interface MergeRequestDiscussions<C extends boolean = false> extends ResourceDiscussions<C> {
+export interface MergeRequestDiscussions extends ResourceDiscussions {
   addNote(
     projectId: string | number,
     mergerequestId: string | number,
@@ -15,20 +10,20 @@ export interface MergeRequestDiscussions<C extends boolean = false> extends Reso
     noteId: number,
     body: string,
     options?: BaseRequestOptions,
-  ): Promise<CamelizedRecord<C, DiscussionSchema>>;
+  ): Promise<DiscussionSchema>;
 
   all(
     projectId: string | number,
     issueId: string | number,
     options?: PaginatedRequestOptions,
-  ): Promise<CamelizedRecord<C, DiscussionSchema>[]>;
+  ): Promise<DiscussionSchema[]>;
 
   create(
     projectId: string | number,
     mergerequestId: string | number,
     body: string,
     options?: BaseRequestOptions,
-  ): Promise<CamelizedRecord<C, DiscussionSchema>>;
+  ): Promise<DiscussionSchema>;
 
   editNote(
     projectId: string | number,
@@ -36,7 +31,7 @@ export interface MergeRequestDiscussions<C extends boolean = false> extends Reso
     discussionId: number,
     noteId: number,
     options: BaseRequestOptions & ({ body: string } | { resolved: boolean }),
-  ): Promise<CamelizedRecord<C, DiscussionSchema>>;
+  ): Promise<DiscussionSchema>;
 
   removeNote(
     projectId: string | number,
@@ -51,11 +46,11 @@ export interface MergeRequestDiscussions<C extends boolean = false> extends Reso
     mergerequestId: string | number,
     discussionId: number,
     options?: Sudo,
-  ): Promise<CamelizedRecord<C, DiscussionSchema>>;
+  ): Promise<DiscussionSchema>;
 }
 
-export class MergeRequestDiscussions<C extends boolean = false> extends ResourceDiscussions<C> {
-  constructor(options: BaseServiceOptions<C>) {
+export class MergeRequestDiscussions extends ResourceDiscussions {
+  constructor(options: BaseServiceOptions) {
     /* istanbul ignore next */
     super('projects', 'merge_requests', options);
   }

--- a/packages/gitbeaker-core/src/services/MergeRequestNotes.ts
+++ b/packages/gitbeaker-core/src/services/MergeRequestNotes.ts
@@ -1,11 +1,6 @@
 import { BaseServiceOptions } from '@gitbeaker/requester-utils';
 import { ResourceNotes, NoteSchema } from '../templates';
-import {
-  PaginatedRequestOptions,
-  BaseRequestOptions,
-  Sudo,
-  CamelizedRecord,
-} from '../infrastructure';
+import { PaginatedRequestOptions, BaseRequestOptions, Sudo } from '../infrastructure';
 
 export interface MergeRequestNoteSchema extends NoteSchema {
   attachment?: string;
@@ -16,19 +11,19 @@ export interface MergeRequestNoteSchema extends NoteSchema {
   resolvable: boolean;
 }
 
-export interface MergeRequestNotes<C extends boolean = false> extends ResourceNotes<C> {
+export interface MergeRequestNotes extends ResourceNotes {
   all(
     projectId: string | number,
     mergerequestId: string | number,
     options?: PaginatedRequestOptions,
-  ): Promise<CamelizedRecord<C, MergeRequestNoteSchema>[]>;
+  ): Promise<MergeRequestNoteSchema[]>;
 
   create(
     projectId: string | number,
     mergerequestId: string | number,
     body: string,
     options?: BaseRequestOptions,
-  ): Promise<CamelizedRecord<C, MergeRequestNoteSchema>>;
+  ): Promise<MergeRequestNoteSchema>;
 
   edit(
     projectId: string | number,
@@ -36,7 +31,7 @@ export interface MergeRequestNotes<C extends boolean = false> extends ResourceNo
     noteId: number,
     body: string,
     options?: BaseRequestOptions,
-  ): Promise<CamelizedRecord<C, MergeRequestNoteSchema>>;
+  ): Promise<MergeRequestNoteSchema>;
 
   remove(
     projectId: string | number,
@@ -50,11 +45,11 @@ export interface MergeRequestNotes<C extends boolean = false> extends ResourceNo
     mergerequestIdepicId: string | number,
     noteId: number,
     options?: Sudo,
-  ): Promise<CamelizedRecord<C, MergeRequestNoteSchema>>;
+  ): Promise<MergeRequestNoteSchema>;
 }
 
-export class MergeRequestNotes<C extends boolean = false> extends ResourceNotes<C> {
-  constructor(options: BaseServiceOptions<C>) {
+export class MergeRequestNotes extends ResourceNotes {
+  constructor(options: BaseServiceOptions) {
     /* istanbul ignore next */
     super('projects', 'merge_requests', options);
   }

--- a/packages/gitbeaker-core/src/services/MergeRequests.ts
+++ b/packages/gitbeaker-core/src/services/MergeRequests.ts
@@ -165,7 +165,7 @@ export interface MergeRequestSchema extends Record<string, unknown> {
   changes?: CommitDiffSchema[];
 }
 
-export class MergeRequests<C extends boolean = false> extends BaseService<C> {
+export class MergeRequests extends BaseService {
   accept(
     projectId: string | number,
     mergerequestIid: number,

--- a/packages/gitbeaker-core/src/services/Namespaces.ts
+++ b/packages/gitbeaker-core/src/services/Namespaces.ts
@@ -17,7 +17,7 @@ export interface NamespaceSchema extends Record<string, unknown> {
 }
 
 // TODO: Add missing functions
-export class Namespaces<C extends boolean = false> extends BaseService<C> {
+export class Namespaces extends BaseService {
   all(options?: PaginatedRequestOptions) {
     return RequestHelper.get<NamespaceSchema[]>()(this, 'namespaces', options);
   }

--- a/packages/gitbeaker-core/src/services/NotificationSettings.ts
+++ b/packages/gitbeaker-core/src/services/NotificationSettings.ts
@@ -30,7 +30,7 @@ function url({ projectId, groupId }) {
   return `${uri}notification_settings`;
 }
 
-export class NotificationSettings<C extends boolean = false> extends BaseService<C> {
+export class NotificationSettings extends BaseService {
   all({ projectId, groupId, ...options }: ProjectOrGroup & PaginatedRequestOptions = {}) {
     return RequestHelper.get<NotificationSettingSchema[]>()(
       this,

--- a/packages/gitbeaker-core/src/services/Packages.ts
+++ b/packages/gitbeaker-core/src/services/Packages.ts
@@ -23,7 +23,7 @@ export interface PackageFileSchema extends Record<string, unknown> {
   pipelines?: PipelineSchema[];
 }
 
-export class Packages<C extends boolean = false> extends BaseService<C> {
+export class Packages extends BaseService {
   all(projectId: string | number, options?: PaginatedRequestOptions) {
     const pId = encodeURIComponent(projectId);
 

--- a/packages/gitbeaker-core/src/services/PagesDomains.ts
+++ b/packages/gitbeaker-core/src/services/PagesDomains.ts
@@ -19,7 +19,7 @@ export interface PagesDomainSchema extends Record<string, unknown> {
 
 // TODO: Add missing functions
 
-export class PagesDomains<C extends boolean = false> extends BaseService<C> {
+export class PagesDomains extends BaseService {
   all({ projectId, ...options }: { projectId?: string | number } & PaginatedRequestOptions = {}) {
     const url = projectId ? `projects/${encodeURIComponent(projectId)}/` : '';
 

--- a/packages/gitbeaker-core/src/services/PipelineScheduleVariables.ts
+++ b/packages/gitbeaker-core/src/services/PipelineScheduleVariables.ts
@@ -2,7 +2,7 @@ import { BaseService } from '@gitbeaker/requester-utils';
 import { PipelineVariableSchema } from './Pipelines';
 import { BaseRequestOptions, PaginatedRequestOptions, RequestHelper } from '../infrastructure';
 
-export class PipelineScheduleVariables<C extends boolean = false> extends BaseService<C> {
+export class PipelineScheduleVariables extends BaseService {
   all(projectId: string | number, pipelineScheduleId: number, options?: PaginatedRequestOptions) {
     const [pId, psId] = [projectId, pipelineScheduleId].map(encodeURIComponent);
 

--- a/packages/gitbeaker-core/src/services/PipelineSchedules.ts
+++ b/packages/gitbeaker-core/src/services/PipelineSchedules.ts
@@ -25,7 +25,7 @@ export interface PipelineScheduleExtendedSchema extends PipelineScheduleSchema {
   last_pipeline: Pick<PipelineSchema, 'id' | 'sha' | 'ref' | 'status'>;
 }
 
-export class PipelineSchedules<C extends boolean = false> extends BaseService<C> {
+export class PipelineSchedules extends BaseService {
   all(projectId: string | number, options?: PaginatedRequestOptions) {
     const pId = encodeURIComponent(projectId);
 

--- a/packages/gitbeaker-core/src/services/Pipelines.ts
+++ b/packages/gitbeaker-core/src/services/Pipelines.ts
@@ -52,7 +52,7 @@ export interface PipelineVariableSchema extends Record<string, unknown> {
 
 // TODO: Add missing function
 
-export class Pipelines<C extends boolean = false> extends BaseService<C> {
+export class Pipelines extends BaseService {
   all(projectId: string | number, options?: PaginatedRequestOptions) {
     const pId = encodeURIComponent(projectId);
 

--- a/packages/gitbeaker-core/src/services/ProjectAccessRequests.ts
+++ b/packages/gitbeaker-core/src/services/ProjectAccessRequests.ts
@@ -1,23 +1,23 @@
 import { BaseServiceOptions } from '@gitbeaker/requester-utils';
 import { ResourceAccessRequests, AccessRequestSchema, AccessLevel } from '../templates';
-import { Sudo, CamelizedRecord } from '../infrastructure';
+import { Sudo } from '../infrastructure';
 
-export interface GroupAccessRequests<C extends boolean = false> extends ResourceAccessRequests<C> {
-  all(projectId: string | number): Promise<CamelizedRecord<C, AccessRequestSchema>[]>;
+export interface GroupAccessRequests extends ResourceAccessRequests {
+  all(projectId: string | number): Promise<AccessRequestSchema[]>;
 
-  request(projectId: string | number): Promise<CamelizedRecord<C, AccessRequestSchema>>;
+  request(projectId: string | number): Promise<AccessRequestSchema>;
 
   approve(
     projectId: string | number,
     userId: number,
     options?: { accessLevel?: AccessLevel } & Sudo,
-  ): Promise<CamelizedRecord<C, AccessRequestSchema>>;
+  ): Promise<AccessRequestSchema>;
 
   deny(projectId: string | number, userId: number): Promise<void>;
 }
 
-export class ProjectAccessRequests<C extends boolean = false> extends ResourceAccessRequests<C> {
-  constructor(options: BaseServiceOptions<C>) {
+export class ProjectAccessRequests extends ResourceAccessRequests {
+  constructor(options: BaseServiceOptions) {
     /* istanbul ignore next */
     super('projects', options);
   }

--- a/packages/gitbeaker-core/src/services/ProjectBadges.ts
+++ b/packages/gitbeaker-core/src/services/ProjectBadges.ts
@@ -1,51 +1,36 @@
 import { BaseServiceOptions } from '@gitbeaker/requester-utils';
 import { ResourceBadges, BadgeSchema } from '../templates';
-import {
-  BaseRequestOptions,
-  PaginatedRequestOptions,
-  Sudo,
-  CamelizedRecord,
-} from '../infrastructure';
+import { BaseRequestOptions, PaginatedRequestOptions, Sudo } from '../infrastructure';
 
 export interface ProjectBadgeSchema extends BadgeSchema {
   kind: 'project';
 }
 
-export interface ProjectBadges<C extends boolean = false> extends ResourceBadges<C> {
-  add(
-    productId: string | number,
-    options?: BaseRequestOptions,
-  ): Promise<CamelizedRecord<C, ProjectBadgeSchema>>;
+export interface ProjectBadges extends ResourceBadges {
+  add(productId: string | number, options?: BaseRequestOptions): Promise<ProjectBadgeSchema>;
 
-  all(
-    productId: string | number,
-    options?: PaginatedRequestOptions,
-  ): Promise<CamelizedRecord<C, ProjectBadgeSchema>[]>;
+  all(productId: string | number, options?: PaginatedRequestOptions): Promise<ProjectBadgeSchema[]>;
 
   edit(
     productId: string | number,
     badgeId: number,
     options?: BaseRequestOptions,
-  ): Promise<CamelizedRecord<C, ProjectBadgeSchema>>;
+  ): Promise<ProjectBadgeSchema>;
 
   preview(
     productId: string | number,
     linkUrl: string,
     imageUrl: string,
     options?: Sudo,
-  ): Promise<CamelizedRecord<C, Omit<ProjectBadgeSchema, 'id' | 'name' | 'kind'>>>;
+  ): Promise<Omit<ProjectBadgeSchema, 'id' | 'name' | 'kind'>>;
 
   remove(productId: string | number, badgeId: number, options?: Sudo): Promise<void>;
 
-  show(
-    productId: string | number,
-    badgeId: number,
-    options?: Sudo,
-  ): Promise<CamelizedRecord<C, ProjectBadgeSchema>>;
+  show(productId: string | number, badgeId: number, options?: Sudo): Promise<ProjectBadgeSchema>;
 }
 
-export class ProjectBadges<C extends boolean = false> extends ResourceBadges<C> {
-  constructor(options: BaseServiceOptions<C>) {
+export class ProjectBadges extends ResourceBadges {
+  constructor(options: BaseServiceOptions) {
     /* istanbul ignore next */
     super('groups', options);
   }

--- a/packages/gitbeaker-core/src/services/ProjectCustomAttributes.ts
+++ b/packages/gitbeaker-core/src/services/ProjectCustomAttributes.ts
@@ -1,20 +1,19 @@
 import { BaseServiceOptions } from '@gitbeaker/requester-utils';
 import { ResourceCustomAttributes, CustomAttributeSchema } from '../templates';
-import { PaginatedRequestOptions, CamelizedRecord, Sudo } from '../infrastructure';
+import { PaginatedRequestOptions, Sudo } from '../infrastructure';
 
-export interface ProjectCustomAttributes<C extends boolean = false>
-  extends ResourceCustomAttributes<C> {
+export interface ProjectCustomAttributes extends ResourceCustomAttributes {
   all(
     projectId: string | number,
     options?: PaginatedRequestOptions,
-  ): Promise<CamelizedRecord<C, CustomAttributeSchema>[]>;
+  ): Promise<CustomAttributeSchema[]>;
 
   set(
     projectId: string | number,
     customAttributeId: number,
     value: string,
     options?: Sudo,
-  ): Promise<CamelizedRecord<C, CustomAttributeSchema>>;
+  ): Promise<CustomAttributeSchema>;
 
   remove(projectId: string | number, customAttributeId: number, options?: Sudo): Promise<void>;
 
@@ -22,11 +21,11 @@ export interface ProjectCustomAttributes<C extends boolean = false>
     projectId: string | number,
     customAttributeId: number,
     options?: Sudo,
-  ): Promise<CamelizedRecord<C, CustomAttributeSchema>>;
+  ): Promise<CustomAttributeSchema>;
 }
 
-export class ProjectCustomAttributes<C extends boolean> extends ResourceCustomAttributes<C> {
-  constructor(options: BaseServiceOptions<C>) {
+export class ProjectCustomAttributes extends ResourceCustomAttributes {
+  constructor(options: BaseServiceOptions) {
     /* istanbul ignore next */
     super('projects', options);
   }

--- a/packages/gitbeaker-core/src/services/ProjectDeployTokens.ts
+++ b/packages/gitbeaker-core/src/services/ProjectDeployTokens.ts
@@ -1,32 +1,25 @@
 import { BaseServiceOptions } from '@gitbeaker/requester-utils';
 import { ResourceDeployTokens, DeployTokenScope, DeployTokenSchema } from '../templates';
-import {
-  BaseRequestOptions,
-  PaginatedRequestOptions,
-  CamelizedRecord,
-  Sudo,
-} from '../infrastructure';
+import { BaseRequestOptions, PaginatedRequestOptions, Sudo } from '../infrastructure';
 
-export interface ProjectDeployTokens<C extends boolean = false> extends ResourceDeployTokens<C> {
+export interface ProjectDeployTokens extends ResourceDeployTokens {
   add(
     projectId: string | number,
     tokenName: string,
     tokenScopes: DeployTokenScope[],
     options?: BaseRequestOptions,
-  ): Promise<CamelizedRecord<C, DeployTokenSchema>>;
+  ): Promise<DeployTokenSchema>;
 
   all({
     projectId,
     ...options
-  }: { projectId?: string | number } & PaginatedRequestOptions): Promise<
-    CamelizedRecord<C, DeployTokenSchema>[]
-  >;
+  }: { projectId?: string | number } & PaginatedRequestOptions): Promise<DeployTokenSchema[]>;
 
   remove(projectId: string | number, tokenId: number, options?: Sudo): Promise<void>;
 }
 
-export class ProjectDeployTokens<C extends boolean = false> extends ResourceDeployTokens<C> {
-  constructor(options: BaseServiceOptions<C>) {
+export class ProjectDeployTokens extends ResourceDeployTokens {
+  constructor(options: BaseServiceOptions) {
     /* istanbul ignore next */
     super('projects', options);
   }

--- a/packages/gitbeaker-core/src/services/ProjectHooks.ts
+++ b/packages/gitbeaker-core/src/services/ProjectHooks.ts
@@ -27,7 +27,7 @@ export interface ProjectHookSchema extends Record<string, unknown> {
   created_at: string;
 }
 
-export class ProjectHooks<C extends boolean = false> extends BaseService<C> {
+export class ProjectHooks extends BaseService {
   all(projectId: string | number, options?: PaginatedRequestOptions) {
     const pId = encodeURIComponent(projectId);
 

--- a/packages/gitbeaker-core/src/services/ProjectImportExport.ts
+++ b/packages/gitbeaker-core/src/services/ProjectImportExport.ts
@@ -48,7 +48,7 @@ export const defaultMetadata = {
   contentType: 'application/octet-stream',
 };
 
-export class ProjectImportExport<C extends boolean = false> extends BaseService<C> {
+export class ProjectImportExport extends BaseService {
   download(projectId: string | number, options?: Sudo) {
     const pId = encodeURIComponent(projectId);
 

--- a/packages/gitbeaker-core/src/services/ProjectIssueBoards.ts
+++ b/packages/gitbeaker-core/src/services/ProjectIssueBoards.ts
@@ -1,12 +1,7 @@
 import { BaseServiceOptions } from '@gitbeaker/requester-utils';
 import { ProjectSchema } from './Projects';
 import { ResourceIssueBoards, IssueBoardSchema, IssueBoardListSchema } from '../templates';
-import {
-  BaseRequestOptions,
-  PaginatedRequestOptions,
-  Sudo,
-  CamelizedRecord,
-} from '../infrastructure';
+import { BaseRequestOptions, PaginatedRequestOptions, Sudo } from '../infrastructure';
 
 export interface ProjectIssueBoardSchema extends IssueBoardSchema {
   project: Pick<
@@ -21,30 +16,26 @@ export interface ProjectIssueBoardSchema extends IssueBoardSchema {
   >;
 }
 
-export interface ProjectIssueBoards<C extends boolean = false> extends ResourceIssueBoards<C> {
+export interface ProjectIssueBoards extends ResourceIssueBoards {
   all(
     groupId: string | number,
     options?: PaginatedRequestOptions,
-  ): Promise<CamelizedRecord<C, ProjectIssueBoardSchema>[]>;
+  ): Promise<ProjectIssueBoardSchema[]>;
 
-  create(
-    groupId: string | number,
-    name: string,
-    options?: Sudo,
-  ): Promise<CamelizedRecord<C, ProjectIssueBoardSchema>>;
+  create(groupId: string | number, name: string, options?: Sudo): Promise<ProjectIssueBoardSchema>;
 
   createList(
     groupId: string | number,
     boardId: number,
     labelId: number | string,
     options?: Sudo,
-  ): Promise<CamelizedRecord<C, IssueBoardListSchema>>;
+  ): Promise<IssueBoardListSchema>;
 
   edit(
     groupId: string | number,
     boardId: number,
     options?: BaseRequestOptions,
-  ): Promise<CamelizedRecord<C, ProjectIssueBoardSchema>>;
+  ): Promise<ProjectIssueBoardSchema>;
 
   editList(
     groupId: string | number,
@@ -52,13 +43,9 @@ export interface ProjectIssueBoards<C extends boolean = false> extends ResourceI
     listId: number,
     position: number,
     options?: Sudo,
-  ): Promise<CamelizedRecord<C, IssueBoardListSchema>>;
+  ): Promise<IssueBoardListSchema>;
 
-  lists(
-    groupId: string | number,
-    boardId: number,
-    options?: Sudo,
-  ): Promise<CamelizedRecord<C, IssueBoardListSchema>[]>;
+  lists(groupId: string | number, boardId: number, options?: Sudo): Promise<IssueBoardListSchema[]>;
 
   remove(groupId: string | number, boardId: number, options?: Sudo): Promise<void>;
 
@@ -69,22 +56,18 @@ export interface ProjectIssueBoards<C extends boolean = false> extends ResourceI
     options?: Sudo,
   ): Promise<void>;
 
-  show(
-    groupId: string | number,
-    boardId: number,
-    options?: Sudo,
-  ): Promise<CamelizedRecord<C, ProjectIssueBoardSchema>>;
+  show(groupId: string | number, boardId: number, options?: Sudo): Promise<ProjectIssueBoardSchema>;
 
   showList(
     groupId: string | number,
     boardId: number,
     listId: number,
     options?: Sudo,
-  ): Promise<CamelizedRecord<C, IssueBoardListSchema>>;
+  ): Promise<IssueBoardListSchema>;
 }
 
-export class ProjectIssueBoards<C extends boolean = false> extends ResourceIssueBoards<C> {
-  constructor(options: BaseServiceOptions<C>) {
+export class ProjectIssueBoards extends ResourceIssueBoards {
+  constructor(options: BaseServiceOptions) {
     /* istanbul ignore next */
     super('projects', options);
   }

--- a/packages/gitbeaker-core/src/services/ProjectMembers.ts
+++ b/packages/gitbeaker-core/src/services/ProjectMembers.ts
@@ -1,43 +1,38 @@
 import { BaseServiceOptions } from '@gitbeaker/requester-utils';
 import { ResourceMembers, MembersSchema, IncludeInherited, AccessLevel } from '../templates';
-import {
-  BaseRequestOptions,
-  PaginatedRequestOptions,
-  CamelizedRecord,
-  Sudo,
-} from '../infrastructure';
+import { BaseRequestOptions, PaginatedRequestOptions, Sudo } from '../infrastructure';
 
-export interface GroupMembers<C extends boolean = false> extends ResourceMembers<C> {
+export interface GroupMembers extends ResourceMembers {
   add(
     projectId: string | number,
     userId: number,
     accessLevel: AccessLevel,
     options?: BaseRequestOptions,
-  ): Promise<CamelizedRecord<C, MembersSchema>>;
+  ): Promise<MembersSchema>;
 
   all(
     projectId: string | number,
     options?: IncludeInherited & PaginatedRequestOptions,
-  ): Promise<CamelizedRecord<C, MembersSchema>[]>;
+  ): Promise<MembersSchema[]>;
 
   edit(
     projectId: string | number,
     userId: number,
     accessLevel: AccessLevel,
     options?: BaseRequestOptions,
-  ): Promise<CamelizedRecord<C, MembersSchema>>;
+  ): Promise<MembersSchema>;
 
   show(
     projectId: string | number,
     userId: number,
     options?: IncludeInherited & Sudo,
-  ): Promise<CamelizedRecord<C, MembersSchema>>;
+  ): Promise<MembersSchema>;
 
   remove(projectId: string | number, userId: number, options?: Sudo): Promise<void>;
 }
 
-export class ProjectMembers<C extends boolean = false> extends ResourceMembers<C> {
-  constructor(options: BaseServiceOptions<C>) {
+export class ProjectMembers extends ResourceMembers {
+  constructor(options: BaseServiceOptions) {
     /* istanbul ignore next */
     super('projects', options);
   }

--- a/packages/gitbeaker-core/src/services/ProjectMilestones.ts
+++ b/packages/gitbeaker-core/src/services/ProjectMilestones.ts
@@ -2,52 +2,36 @@ import { BaseServiceOptions } from '@gitbeaker/requester-utils';
 import { IssueSchema } from './Issues';
 import { MergeRequestSchema } from './MergeRequests';
 import { ResourceMilestones, MilestoneSchema } from '../templates';
-import {
-  PaginatedRequestOptions,
-  BaseRequestOptions,
-  Sudo,
-  CamelizedRecord,
-} from '../infrastructure';
+import { PaginatedRequestOptions, BaseRequestOptions, Sudo } from '../infrastructure';
 
-export interface ProjectMilestones<C extends boolean = false> extends ResourceMilestones<C> {
-  all(
-    projectId: string | number,
-    options?: PaginatedRequestOptions,
-  ): Promise<CamelizedRecord<C, MilestoneSchema>[]>;
+export interface ProjectMilestones extends ResourceMilestones {
+  all(projectId: string | number, options?: PaginatedRequestOptions): Promise<MilestoneSchema[]>;
 
   create(
     projectId: string | number,
     title: string,
     options?: BaseRequestOptions,
-  ): Promise<CamelizedRecord<C, MilestoneSchema>>;
+  ): Promise<MilestoneSchema>;
 
   edit(
     projectId: string | number,
     milestoneId: number,
     options?: BaseRequestOptions,
-  ): Promise<CamelizedRecord<C, MilestoneSchema>>;
+  ): Promise<MilestoneSchema>;
 
-  issues(
-    projectId: string | number,
-    milestoneId: number,
-    options?: Sudo,
-  ): Promise<CamelizedRecord<C, IssueSchema>[]>;
+  issues(projectId: string | number, milestoneId: number, options?: Sudo): Promise<IssueSchema[]>;
 
   mergeRequests(
     projectId: string | number,
     milestoneId: number,
     options?: Sudo,
-  ): Promise<CamelizedRecord<C, MergeRequestSchema>[]>;
+  ): Promise<MergeRequestSchema[]>;
 
-  show(
-    projectId: string | number,
-    milestoneId: number,
-    options?: Sudo,
-  ): Promise<CamelizedRecord<C, MilestoneSchema>>;
+  show(projectId: string | number, milestoneId: number, options?: Sudo): Promise<MilestoneSchema>;
 }
 
-export class ProjectMilestones<C extends boolean = false> extends ResourceMilestones<C> {
-  constructor(options: BaseServiceOptions<C>) {
+export class ProjectMilestones extends ResourceMilestones {
+  constructor(options: BaseServiceOptions) {
     /* istanbul ignore next */
     super('projects', options);
   }

--- a/packages/gitbeaker-core/src/services/ProjectSnippetAwardEmojis.ts
+++ b/packages/gitbeaker-core/src/services/ProjectSnippetAwardEmojis.ts
@@ -1,21 +1,20 @@
 import { BaseServiceOptions } from '@gitbeaker/requester-utils';
 import { ResourceAwardEmojis, AwardEmojiSchema } from '../templates';
-import { PaginatedRequestOptions, Sudo, CamelizedRecord } from '../infrastructure';
+import { PaginatedRequestOptions, Sudo } from '../infrastructure';
 
-export interface ProjectSnippetAwardEmojis<C extends boolean = false>
-  extends ResourceAwardEmojis<C> {
+export interface ProjectSnippetAwardEmojis extends ResourceAwardEmojis {
   all(
     projectId: string | number,
     snippetIId: number,
     options?: PaginatedRequestOptions,
-  ): Promise<CamelizedRecord<C, AwardEmojiSchema>[]>;
+  ): Promise<AwardEmojiSchema[]>;
 
   award(
     projectId: string | number,
     snippetIId: number,
     name: string,
     options?: Sudo,
-  ): Promise<CamelizedRecord<C, AwardEmojiSchema>>;
+  ): Promise<AwardEmojiSchema>;
 
   remove(
     projectId: string | number,
@@ -29,11 +28,11 @@ export interface ProjectSnippetAwardEmojis<C extends boolean = false>
     snippetIId: number,
     awardId: number,
     options?: Sudo,
-  ): Promise<CamelizedRecord<C, AwardEmojiSchema>>;
+  ): Promise<AwardEmojiSchema>;
 }
 
-export class ProjectSnippetAwardEmojis<C extends boolean = false> extends ResourceAwardEmojis<C> {
-  constructor(options: BaseServiceOptions<C>) {
+export class ProjectSnippetAwardEmojis extends ResourceAwardEmojis {
+  constructor(options: BaseServiceOptions) {
     /* istanbul ignore next */
     super('snippets', options);
   }

--- a/packages/gitbeaker-core/src/services/ProjectSnippetDiscussions.ts
+++ b/packages/gitbeaker-core/src/services/ProjectSnippetDiscussions.ts
@@ -1,14 +1,8 @@
 import { BaseServiceOptions } from '@gitbeaker/requester-utils';
 import { ResourceDiscussions, DiscussionSchema } from '../templates';
-import {
-  BaseRequestOptions,
-  PaginatedRequestOptions,
-  Sudo,
-  CamelizedRecord,
-} from '../infrastructure';
+import { BaseRequestOptions, PaginatedRequestOptions, Sudo } from '../infrastructure';
 
-export interface ProjectSnippetDiscussions<C extends boolean = false>
-  extends ResourceDiscussions<C> {
+export interface ProjectSnippetDiscussions extends ResourceDiscussions {
   addNote(
     projectId: string | number,
     snippetId: string | number,
@@ -16,20 +10,20 @@ export interface ProjectSnippetDiscussions<C extends boolean = false>
     noteId: number,
     body: string,
     options?: BaseRequestOptions,
-  ): Promise<CamelizedRecord<C, DiscussionSchema>>;
+  ): Promise<DiscussionSchema>;
 
   all(
     projectId: string | number,
     issueId: string | number,
     options?: PaginatedRequestOptions,
-  ): Promise<CamelizedRecord<C, DiscussionSchema>[]>;
+  ): Promise<DiscussionSchema[]>;
 
   create(
     projectId: string | number,
     snippetId: string | number,
     body: string,
     options?: BaseRequestOptions,
-  ): Promise<CamelizedRecord<C, DiscussionSchema>>;
+  ): Promise<DiscussionSchema>;
 
   editNote(
     projectId: string | number,
@@ -37,7 +31,7 @@ export interface ProjectSnippetDiscussions<C extends boolean = false>
     discussionId: number,
     noteId: number,
     options: BaseRequestOptions & { body: string },
-  ): Promise<CamelizedRecord<C, DiscussionSchema>>;
+  ): Promise<DiscussionSchema>;
 
   removeNote(
     projectId: string | number,
@@ -52,11 +46,11 @@ export interface ProjectSnippetDiscussions<C extends boolean = false>
     snippetId: string | number,
     discussionId: number,
     options?: Sudo,
-  ): Promise<CamelizedRecord<C, DiscussionSchema>>;
+  ): Promise<DiscussionSchema>;
 }
 
-export class ProjectSnippetDiscussions<C extends boolean = false> extends ResourceDiscussions<C> {
-  constructor(options: BaseServiceOptions<C>) {
+export class ProjectSnippetDiscussions extends ResourceDiscussions {
+  constructor(options: BaseServiceOptions) {
     /* istanbul ignore next */
     super('projects', 'snippets', options);
   }

--- a/packages/gitbeaker-core/src/services/ProjectSnippetNotes.ts
+++ b/packages/gitbeaker-core/src/services/ProjectSnippetNotes.ts
@@ -1,30 +1,25 @@
 import { BaseServiceOptions } from '@gitbeaker/requester-utils';
 import { ResourceNotes, NoteSchema } from '../templates';
-import {
-  PaginatedRequestOptions,
-  BaseRequestOptions,
-  Sudo,
-  CamelizedRecord,
-} from '../infrastructure';
+import { PaginatedRequestOptions, BaseRequestOptions, Sudo } from '../infrastructure';
 
 export interface SnippetNoteSchema extends NoteSchema {
   file_name: string;
   expires_at: string;
 }
 
-export interface ProjectSnippetNotes<C extends boolean = false> extends ResourceNotes<C> {
+export interface ProjectSnippetNotes extends ResourceNotes {
   all(
     projectId: string | number,
     snippetId: string | number,
     options?: PaginatedRequestOptions,
-  ): Promise<CamelizedRecord<C, SnippetNoteSchema>[]>;
+  ): Promise<SnippetNoteSchema[]>;
 
   create(
     projectId: string | number,
     snippetId: string | number,
     body: string,
     options?: BaseRequestOptions,
-  ): Promise<CamelizedRecord<C, SnippetNoteSchema>>;
+  ): Promise<SnippetNoteSchema>;
 
   edit(
     projectId: string | number,
@@ -32,7 +27,7 @@ export interface ProjectSnippetNotes<C extends boolean = false> extends Resource
     noteId: number,
     body: string,
     options?: BaseRequestOptions,
-  ): Promise<CamelizedRecord<C, SnippetNoteSchema>>;
+  ): Promise<SnippetNoteSchema>;
 
   remove(projectId: string | number, snippetId: string | number, noteId: number, options?: Sudo);
 
@@ -41,11 +36,11 @@ export interface ProjectSnippetNotes<C extends boolean = false> extends Resource
     snippetId: string | number,
     noteId: number,
     options?: Sudo,
-  ): Promise<CamelizedRecord<C, SnippetNoteSchema>>;
+  ): Promise<SnippetNoteSchema>;
 }
 
-export class ProjectSnippetNotes<C extends boolean = false> extends ResourceNotes<C> {
-  constructor(options: BaseServiceOptions<C>) {
+export class ProjectSnippetNotes extends ResourceNotes {
+  constructor(options: BaseServiceOptions) {
     /* istanbul ignore next */
     super('projects', 'snippets', options);
   }

--- a/packages/gitbeaker-core/src/services/ProjectSnippets.ts
+++ b/packages/gitbeaker-core/src/services/ProjectSnippets.ts
@@ -21,7 +21,7 @@ export interface ProjectSnippetSchema extends Record<string, unknown> {
   raw_url: string;
 }
 
-export class ProjectSnippets<C extends boolean = false> extends BaseService<C> {
+export class ProjectSnippets extends BaseService {
   all(projectId: string | number, options?: PaginatedRequestOptions) {
     const pId = encodeURIComponent(projectId);
 

--- a/packages/gitbeaker-core/src/services/ProjectVariables.ts
+++ b/packages/gitbeaker-core/src/services/ProjectVariables.ts
@@ -1,29 +1,26 @@
 import { BaseServiceOptions } from '@gitbeaker/requester-utils';
 import { ResourceVariables, ResourceVariableSchema } from '../templates';
-import { BaseRequestOptions, PaginatedRequestOptions, CamelizedRecord } from '../infrastructure';
+import { BaseRequestOptions, PaginatedRequestOptions } from '../infrastructure';
 
-export interface ProjectVariables<C extends boolean = false> extends ResourceVariables<C> {
+export interface ProjectVariables extends ResourceVariables {
   all(
     projectId: string | number,
     options?: PaginatedRequestOptions,
-  ): Promise<CamelizedRecord<C, ResourceVariableSchema>[]>;
+  ): Promise<ResourceVariableSchema[]>;
 
-  create(
-    projectId: string | number,
-    options?: BaseRequestOptions,
-  ): Promise<CamelizedRecord<C, ResourceVariableSchema>>;
+  create(projectId: string | number, options?: BaseRequestOptions): Promise<ResourceVariableSchema>;
 
   edit(
     projectId: string | number,
     keyId: string,
     options?: BaseRequestOptions,
-  ): Promise<CamelizedRecord<C, ResourceVariableSchema>>;
+  ): Promise<ResourceVariableSchema>;
 
   show(
     projectId: string | number,
     keyId: string,
     options?: PaginatedRequestOptions,
-  ): Promise<CamelizedRecord<C, ResourceVariableSchema>>;
+  ): Promise<ResourceVariableSchema>;
 
   remove(
     projectId: string | number,
@@ -32,8 +29,8 @@ export interface ProjectVariables<C extends boolean = false> extends ResourceVar
   ): Promise<void>;
 }
 
-export class ProjectVariables<C extends boolean = false> extends ResourceVariables<C> {
-  constructor(options: BaseServiceOptions<C>) {
+export class ProjectVariables extends ResourceVariables {
+  constructor(options: BaseServiceOptions) {
     /* istanbul ignore next */
     super('projects', options);
   }

--- a/packages/gitbeaker-core/src/services/Projects.ts
+++ b/packages/gitbeaker-core/src/services/Projects.ts
@@ -146,7 +146,7 @@ export interface ProjectFileUploadSchema extends Record<string, unknown> {
   markdown: string;
 }
 
-export class Projects<C extends boolean = false> extends BaseService<C> {
+export class Projects extends BaseService {
   all(options?: PaginatedRequestOptions) {
     return RequestHelper.get<ProjectSchema[]>()(this, 'projects', options);
   }

--- a/packages/gitbeaker-core/src/services/ProtectedBranches.ts
+++ b/packages/gitbeaker-core/src/services/ProtectedBranches.ts
@@ -22,7 +22,7 @@ export interface ProtectedBranchSchema extends Record<string, unknown> {
   code_owner_approval_required: boolean;
 }
 
-export class ProtectedBranches<C extends boolean = false> extends BaseService<C> {
+export class ProtectedBranches extends BaseService {
   all(projectId: string | number, options: { search?: string } & PaginatedRequestOptions = {}) {
     const pId = encodeURIComponent(projectId);
 

--- a/packages/gitbeaker-core/src/services/ProtectedTags.ts
+++ b/packages/gitbeaker-core/src/services/ProtectedTags.ts
@@ -16,7 +16,7 @@ export interface ProtectedTagSchema extends Record<string, unknown> {
   create_access_levels?: ProtectedTagAccessLevelSchema[];
 }
 
-export class ProtectedTags<C extends boolean = false> extends BaseService<C> {
+export class ProtectedTags extends BaseService {
   all(projectId: string | number, options?: PaginatedRequestOptions) {
     const pId = encodeURIComponent(projectId);
 

--- a/packages/gitbeaker-core/src/services/PushRules.ts
+++ b/packages/gitbeaker-core/src/services/PushRules.ts
@@ -18,7 +18,7 @@ export interface PushRulesSchema extends Record<string, unknown> {
   reject_unsigned_commits?: boolean;
 }
 
-export class PushRules<C extends boolean = false> extends BaseService<C> {
+export class PushRules extends BaseService {
   create(projectId: string | number, options?: BaseRequestOptions) {
     const pId = encodeURIComponent(projectId);
 

--- a/packages/gitbeaker-core/src/services/ReleaseLinks.ts
+++ b/packages/gitbeaker-core/src/services/ReleaseLinks.ts
@@ -9,7 +9,7 @@ export interface ReleaseLinkSchema extends Record<string, unknown> {
   link_type: string;
 }
 
-export class ReleaseLinks<C extends boolean = false> extends BaseService<C> {
+export class ReleaseLinks extends BaseService {
   all(projectId: string | number, tagName: string, options?: PaginatedRequestOptions) {
     const [pId, tId] = [projectId, tagName].map(encodeURIComponent);
 

--- a/packages/gitbeaker-core/src/services/Releases.ts
+++ b/packages/gitbeaker-core/src/services/Releases.ts
@@ -50,7 +50,7 @@ export interface ReleaseSchema extends Record<string, unknown> {
 }
 
 // TODO: Add missing functions
-export class Releases<C extends boolean = false> extends BaseService<C> {
+export class Releases extends BaseService {
   all(projectId: string | number, options?: PaginatedRequestOptions) {
     const pId = encodeURIComponent(projectId);
 

--- a/packages/gitbeaker-core/src/services/Repositories.ts
+++ b/packages/gitbeaker-core/src/services/Repositories.ts
@@ -34,7 +34,7 @@ export interface RepositoryTreeSchema extends Record<string, unknown> {
   mode: string;
 }
 
-export class Repositories<C extends boolean = false> extends BaseService<C> {
+export class Repositories extends BaseService {
   compare(projectId: string | number, from: string, to: string, options?: Sudo) {
     const pId = encodeURIComponent(projectId);
 

--- a/packages/gitbeaker-core/src/services/RepositoryFiles.ts
+++ b/packages/gitbeaker-core/src/services/RepositoryFiles.ts
@@ -25,7 +25,7 @@ export interface RepositoryFileSchema extends Record<string, unknown> {
   branch: string;
 }
 
-export class RepositoryFiles<C extends boolean = false> extends BaseService<C> {
+export class RepositoryFiles extends BaseService {
   create(
     projectId: string | number,
     filePath: string,

--- a/packages/gitbeaker-core/src/services/Runners.ts
+++ b/packages/gitbeaker-core/src/services/Runners.ts
@@ -35,7 +35,7 @@ export interface RunnerExtendedSchema extends RunnerSchema {
   maximum_timeout?: number;
 }
 
-export class Runners<C extends boolean = false> extends BaseService<C> {
+export class Runners extends BaseService {
   all({ projectId, ...options }: { projectId?: string | number } & PaginatedRequestOptions = {}) {
     const url = projectId ? `projects/${encodeURIComponent(projectId)}/runners` : 'runners/all';
 

--- a/packages/gitbeaker-core/src/services/Search.ts
+++ b/packages/gitbeaker-core/src/services/Search.ts
@@ -20,7 +20,7 @@ export interface SearchResultSchema extends Record<string, unknown> {
   last_activity_at: string;
 }
 
-export class Search<C extends boolean = false> extends BaseService<C> {
+export class Search extends BaseService {
   all(
     scope: string,
     search: string,

--- a/packages/gitbeaker-core/src/services/Services.ts
+++ b/packages/gitbeaker-core/src/services/Services.ts
@@ -61,7 +61,7 @@ export interface ServiceSchema extends Record<string, unknown> {
   comment_on_event_enabled: boolean;
 }
 
-export class Services<C extends boolean = false> extends BaseService<C> {
+export class Services extends BaseService {
   all(projectId: string | number, options?: PaginatedRequestOptions) {
     const pId = encodeURIComponent(projectId);
 

--- a/packages/gitbeaker-core/src/services/SidekiqMetrics.ts
+++ b/packages/gitbeaker-core/src/services/SidekiqMetrics.ts
@@ -39,7 +39,7 @@ export interface SidekickCompoundMetricsSchema
     SidekickQueueMetricsSchema,
     SidekickProcessMetricsSchema {}
 
-export class SidekiqMetrics<C extends boolean = false> extends BaseService<C> {
+export class SidekiqMetrics extends BaseService {
   queueMetrics() {
     return RequestHelper.get<SidekickQueueMetricsSchema>()(this, 'sidekiq/queue_metrics');
   }

--- a/packages/gitbeaker-core/src/services/Snippets.ts
+++ b/packages/gitbeaker-core/src/services/Snippets.ts
@@ -41,7 +41,7 @@ export interface UserAgentDetailSchema extends Record<string, unknown> {
   akismet_submitted: boolean;
 }
 
-export class Snippets<C extends boolean = false> extends BaseService<C> {
+export class Snippets extends BaseService {
   all({ public: p, ...options }: { public?: boolean } & PaginatedRequestOptions = {}) {
     const url = p ? 'snippets/public' : 'snippets';
 

--- a/packages/gitbeaker-core/src/services/SystemHooks.ts
+++ b/packages/gitbeaker-core/src/services/SystemHooks.ts
@@ -17,7 +17,7 @@ export interface SystemHookSchema extends Record<string, unknown> {
   enable_ssl_verification: boolean;
 }
 
-export class SystemHooks<C extends boolean = false> extends BaseService<C> {
+export class SystemHooks extends BaseService {
   add(url: string, options?: BaseRequestOptions) {
     return RequestHelper.post<SystemHookSchema>()(this, 'hooks', { url, ...options });
   }

--- a/packages/gitbeaker-core/src/services/Tags.ts
+++ b/packages/gitbeaker-core/src/services/Tags.ts
@@ -17,7 +17,7 @@ export interface TagSchema extends Record<string, unknown> {
   protected: boolean;
 }
 
-export class Tags<C extends boolean = false> extends BaseService<C> {
+export class Tags extends BaseService {
   all(projectId: string | number, options?: PaginatedRequestOptions) {
     const pId = encodeURIComponent(projectId);
 

--- a/packages/gitbeaker-core/src/services/Todos.ts
+++ b/packages/gitbeaker-core/src/services/Todos.ts
@@ -44,7 +44,7 @@ export interface TodoSchema extends Record<string, unknown> {
   updated_at: string;
 }
 
-export class Todos<C extends boolean = false> extends BaseService<C> {
+export class Todos extends BaseService {
   all(options?: PaginatedRequestOptions) {
     return RequestHelper.get<TodoSchema[]>()(this, 'todos', options);
   }

--- a/packages/gitbeaker-core/src/services/Triggers.ts
+++ b/packages/gitbeaker-core/src/services/Triggers.ts
@@ -18,7 +18,7 @@ export interface PipelineTriggerSchema extends Record<string, unknown> {
 }
 
 // TODO: Rename PipelineTriggers
-export class Triggers<C extends boolean = false> extends BaseService<C> {
+export class Triggers extends BaseService {
   add(projectId: string | number, options?: BaseRequestOptions) {
     const pId = encodeURIComponent(projectId);
 

--- a/packages/gitbeaker-core/src/services/UserCustomAttributes.ts
+++ b/packages/gitbeaker-core/src/services/UserCustomAttributes.ts
@@ -1,20 +1,16 @@
 import { BaseServiceOptions } from '@gitbeaker/requester-utils';
 import { ResourceCustomAttributes, CustomAttributeSchema } from '../templates';
-import { PaginatedRequestOptions, CamelizedRecord, Sudo } from '../infrastructure';
+import { PaginatedRequestOptions, Sudo } from '../infrastructure';
 
-export interface UserCustomAttributes<C extends boolean = false>
-  extends ResourceCustomAttributes<C> {
-  all(
-    userId: string | number,
-    options?: PaginatedRequestOptions,
-  ): Promise<CamelizedRecord<C, CustomAttributeSchema>[]>;
+export interface UserCustomAttributes extends ResourceCustomAttributes {
+  all(userId: string | number, options?: PaginatedRequestOptions): Promise<CustomAttributeSchema[]>;
 
   set(
     userId: string | number,
     customAttributeId: number,
     value: string,
     options?: Sudo,
-  ): Promise<CamelizedRecord<C, CustomAttributeSchema>>;
+  ): Promise<CustomAttributeSchema>;
 
   remove(userId: string | number, customAttributeId: number, options?: Sudo): Promise<void>;
 
@@ -22,11 +18,11 @@ export interface UserCustomAttributes<C extends boolean = false>
     userId: string | number,
     customAttributeId: number,
     options?: Sudo,
-  ): Promise<CamelizedRecord<C, CustomAttributeSchema>>;
+  ): Promise<CustomAttributeSchema>;
 }
 
-export class UserCustomAttributes<C extends boolean = false> extends ResourceCustomAttributes<C> {
-  constructor(options: BaseServiceOptions<C>) {
+export class UserCustomAttributes extends ResourceCustomAttributes {
+  constructor(options: BaseServiceOptions) {
     /* istanbul ignore next */
     super('users', options);
   }

--- a/packages/gitbeaker-core/src/services/UserEmails.ts
+++ b/packages/gitbeaker-core/src/services/UserEmails.ts
@@ -10,7 +10,7 @@ export interface UserEmailSchema extends Record<string, unknown> {
 const url = (userId?: number) =>
   userId ? `users/${encodeURIComponent(userId)}/emails` : 'user/emails';
 
-export class UserEmails<C extends boolean = false> extends BaseService<C> {
+export class UserEmails extends BaseService {
   all({ userId, ...options }: { userId?: number } & PaginatedRequestOptions = {}) {
     return RequestHelper.get<UserEmailSchema[]>()(this, url(userId), options);
   }

--- a/packages/gitbeaker-core/src/services/UserGPGKeys.ts
+++ b/packages/gitbeaker-core/src/services/UserGPGKeys.ts
@@ -10,7 +10,7 @@ export interface UserGPGKeySchema extends Record<string, unknown> {
 const url = (userId?: number) =>
   userId ? `users/${encodeURIComponent(userId)}/gpg_keys` : 'user/gpg_keys';
 
-export class UserGPGKeys<C extends boolean = false> extends BaseService<C> {
+export class UserGPGKeys extends BaseService {
   all({ userId, ...options }: { userId?: number } & PaginatedRequestOptions = {}) {
     return RequestHelper.get<UserGPGKeySchema[]>()(this, url(userId), options);
   }

--- a/packages/gitbeaker-core/src/services/UserImpersonationTokens.ts
+++ b/packages/gitbeaker-core/src/services/UserImpersonationTokens.ts
@@ -16,7 +16,7 @@ export interface UserImpersonationTokenSchema extends Record<string, unknown> {
   expires_at: string;
 }
 
-export class UserImpersonationTokens<C extends boolean = false> extends BaseService<C> {
+export class UserImpersonationTokens extends BaseService {
   all(userId: number, options?: { state?: ImpersonationTokenState } & PaginatedRequestOptions) {
     const uId = encodeURIComponent(userId);
 

--- a/packages/gitbeaker-core/src/services/UserSSHKeys.ts
+++ b/packages/gitbeaker-core/src/services/UserSSHKeys.ts
@@ -11,7 +11,7 @@ export interface UserSSHKeySchema extends Record<string, unknown> {
 const url = (userId?: number) =>
   userId ? `users/${encodeURIComponent(userId)}/keys` : 'user/keys';
 
-export class UserSSHKeys<C extends boolean = false> extends BaseService<C> {
+export class UserSSHKeys extends BaseService {
   all({ userId, ...options }: { userId?: number } & PaginatedRequestOptions = {}) {
     return RequestHelper.get<UserSSHKeySchema[]>()(this, url(userId), options);
   }

--- a/packages/gitbeaker-core/src/services/Users.ts
+++ b/packages/gitbeaker-core/src/services/Users.ts
@@ -49,7 +49,7 @@ export interface UserActivitySchema extends Record<string, unknown> {
   last_activity_at: string;
 }
 
-export class Users<C extends boolean = false> extends BaseService<C> {
+export class Users extends BaseService {
   all(options?: PaginatedRequestOptions) {
     return RequestHelper.get<UserSchema[]>()(this, 'users', options);
   }

--- a/packages/gitbeaker-core/src/services/Version.ts
+++ b/packages/gitbeaker-core/src/services/Version.ts
@@ -6,7 +6,7 @@ interface VersionSchema extends Record<string, unknown> {
   revision: string;
 }
 
-export class Version<C extends boolean = false> extends BaseService<C> {
+export class Version extends BaseService {
   show(options?: Sudo) {
     return RequestHelper.get<VersionSchema>()(this, 'version', options);
   }

--- a/packages/gitbeaker-core/src/services/VulnerabilityFindings.ts
+++ b/packages/gitbeaker-core/src/services/VulnerabilityFindings.ts
@@ -64,7 +64,7 @@ export interface VulnerabilityFindingSchema extends Record<string, unknown> {
   blob_path: string;
 }
 
-export class VulnerabilityFindings<C extends boolean = false> extends BaseService<C> {
+export class VulnerabilityFindings extends BaseService {
   all(
     projectId: string | number,
     options?: {

--- a/packages/gitbeaker-core/src/services/Wikis.ts
+++ b/packages/gitbeaker-core/src/services/Wikis.ts
@@ -13,7 +13,7 @@ export interface WikiSchema extends Record<string, unknown> {
   title: string;
 }
 
-export class Wikis<C extends boolean = false> extends BaseService<C> {
+export class Wikis extends BaseService {
   all(projectId: string | number, options?: PaginatedRequestOptions) {
     const pId = encodeURIComponent(projectId);
 

--- a/packages/gitbeaker-core/src/templates/ResourceAccessRequests.ts
+++ b/packages/gitbeaker-core/src/templates/ResourceAccessRequests.ts
@@ -12,8 +12,8 @@ export interface AccessRequestSchema extends Record<string, unknown> {
   requested_at: string;
 }
 
-export class ResourceAccessRequests<C extends boolean = false> extends BaseService<C> {
-  constructor(resourceType: string, options: BaseServiceOptions<C>) {
+export class ResourceAccessRequests extends BaseService {
+  constructor(resourceType: string, options: BaseServiceOptions) {
     super({ prefixUrl: resourceType, ...options });
   }
 

--- a/packages/gitbeaker-core/src/templates/ResourceAwardEmojis.ts
+++ b/packages/gitbeaker-core/src/templates/ResourceAwardEmojis.ts
@@ -31,10 +31,10 @@ export function url(
   return output.join('/');
 }
 
-export class ResourceAwardEmojis<C extends boolean = false> extends BaseService<C> {
+export class ResourceAwardEmojis extends BaseService {
   protected resourceType: string;
 
-  constructor(resourceType: string, options: BaseServiceOptions<C>) {
+  constructor(resourceType: string, options: BaseServiceOptions) {
     super({ prefixUrl: 'projects', ...options });
 
     this.resourceType = resourceType;

--- a/packages/gitbeaker-core/src/templates/ResourceBadges.ts
+++ b/packages/gitbeaker-core/src/templates/ResourceBadges.ts
@@ -16,8 +16,8 @@ export interface BadgeSchema extends Record<string, unknown> {
   kind: 'project' | 'group';
 }
 
-export class ResourceBadges<C extends boolean = false> extends BaseService<C> {
-  constructor(resourceType: string, options: BaseServiceOptions<C>) {
+export class ResourceBadges extends BaseService {
+  constructor(resourceType: string, options: BaseServiceOptions) {
     super({ prefixUrl: resourceType, ...options });
   }
 

--- a/packages/gitbeaker-core/src/templates/ResourceCustomAttributes.ts
+++ b/packages/gitbeaker-core/src/templates/ResourceCustomAttributes.ts
@@ -6,8 +6,8 @@ export interface CustomAttributeSchema extends Record<string, unknown> {
   value: string;
 }
 
-export class ResourceCustomAttributes<C extends boolean = false> extends BaseService<C> {
-  constructor(resourceType: string, options: BaseServiceOptions<C>) {
+export class ResourceCustomAttributes extends BaseService {
+  constructor(resourceType: string, options: BaseServiceOptions) {
     super({ prefixUrl: resourceType, ...options });
   }
 

--- a/packages/gitbeaker-core/src/templates/ResourceDeployTokens.ts
+++ b/packages/gitbeaker-core/src/templates/ResourceDeployTokens.ts
@@ -22,8 +22,8 @@ export interface DeployTokenSchema extends Record<string, unknown> {
 }
 
 // https://docs.gitlab.com/ee/api/deploy_tokens.html
-export class ResourceDeployTokens<C extends boolean = false> extends BaseService<C> {
-  constructor(resourceType: string, options: BaseServiceOptions<C>) {
+export class ResourceDeployTokens extends BaseService {
+  constructor(resourceType: string, options: BaseServiceOptions) {
     super({ prefixUrl: resourceType, ...options });
   }
 

--- a/packages/gitbeaker-core/src/templates/ResourceDiscussions.ts
+++ b/packages/gitbeaker-core/src/templates/ResourceDiscussions.ts
@@ -40,10 +40,10 @@ export interface DiscussionSchema extends Record<string, unknown> {
   notes?: NotesEntitySchema[];
 }
 
-export class ResourceDiscussions<C extends boolean = false> extends BaseService<C> {
+export class ResourceDiscussions extends BaseService {
   protected resource2Type: string;
 
-  constructor(resourceType: string, resource2Type: string, options: BaseServiceOptions<C>) {
+  constructor(resourceType: string, resource2Type: string, options: BaseServiceOptions) {
     super({ prefixUrl: resourceType, ...options });
 
     this.resource2Type = resource2Type;

--- a/packages/gitbeaker-core/src/templates/ResourceIssueBoards.ts
+++ b/packages/gitbeaker-core/src/templates/ResourceIssueBoards.ts
@@ -24,8 +24,8 @@ export interface IssueBoardSchema extends Record<string, unknown> {
   lists?: IssueBoardListSchema[];
 }
 
-export class ResourceIssueBoards<C extends boolean = false> extends BaseService<C> {
-  constructor(resourceType: string, options: BaseServiceOptions<C>) {
+export class ResourceIssueBoards extends BaseService {
+  constructor(resourceType: string, options: BaseServiceOptions) {
     super({ prefixUrl: resourceType, ...options });
   }
 

--- a/packages/gitbeaker-core/src/templates/ResourceLabels.ts
+++ b/packages/gitbeaker-core/src/templates/ResourceLabels.ts
@@ -22,8 +22,8 @@ export interface LabelSchema extends Record<string, unknown> {
   is_project_label: boolean;
 }
 
-export class ResourceLabels<C extends boolean = false> extends BaseService<C> {
-  constructor(resourceType: string, options: BaseServiceOptions<C>) {
+export class ResourceLabels extends BaseService {
+  constructor(resourceType: string, options: BaseServiceOptions) {
     super({ prefixUrl: resourceType, ...options });
   }
 

--- a/packages/gitbeaker-core/src/templates/ResourceMembers.ts
+++ b/packages/gitbeaker-core/src/templates/ResourceMembers.ts
@@ -28,8 +28,8 @@ export interface MembersSchema extends Record<string, unknown> {
   };
 }
 
-export class ResourceMembers<C extends boolean = false> extends BaseService<C> {
-  constructor(resourceType: string, options: BaseServiceOptions<C>) {
+export class ResourceMembers extends BaseService {
+  constructor(resourceType: string, options: BaseServiceOptions) {
     super({ prefixUrl: resourceType, ...options });
   }
 

--- a/packages/gitbeaker-core/src/templates/ResourceMilestones.ts
+++ b/packages/gitbeaker-core/src/templates/ResourceMilestones.ts
@@ -23,8 +23,8 @@ export interface MilestoneSchema extends Record<string, unknown> {
   web_url?: string;
 }
 
-export class ResourceMilestones<C extends boolean = false> extends BaseService<C> {
-  constructor(resourceType: string, options: BaseServiceOptions<C>) {
+export class ResourceMilestones extends BaseService {
+  constructor(resourceType: string, options: BaseServiceOptions) {
     super({ prefixUrl: resourceType, ...options });
   }
 

--- a/packages/gitbeaker-core/src/templates/ResourceNoteAwardEmojis.ts
+++ b/packages/gitbeaker-core/src/templates/ResourceNoteAwardEmojis.ts
@@ -2,10 +2,10 @@ import { BaseService, BaseServiceOptions } from '@gitbeaker/requester-utils';
 import { PaginatedRequestOptions, RequestHelper, Sudo } from '../infrastructure';
 import { AwardEmojiSchema, url } from './ResourceAwardEmojis';
 
-export class ResourceNoteAwardEmojis<C extends boolean = false> extends BaseService<C> {
+export class ResourceNoteAwardEmojis extends BaseService {
   protected resourceType: string;
 
-  constructor(resourceType: string, options: BaseServiceOptions<C>) {
+  constructor(resourceType: string, options: BaseServiceOptions) {
     super({ prefixUrl: 'projects', ...options });
 
     this.resourceType = resourceType;

--- a/packages/gitbeaker-core/src/templates/ResourceNotes.ts
+++ b/packages/gitbeaker-core/src/templates/ResourceNotes.ts
@@ -16,10 +16,10 @@ export interface NoteSchema extends Record<string, unknown> {
   confidential: boolean;
 }
 
-export class ResourceNotes<C extends boolean = false> extends BaseService<C> {
+export class ResourceNotes extends BaseService {
   protected resource2Type: string;
 
-  constructor(resourceType: string, resource2Type: string, options: BaseServiceOptions<C>) {
+  constructor(resourceType: string, resource2Type: string, options: BaseServiceOptions) {
     super({ prefixUrl: resourceType, ...options });
 
     this.resource2Type = resource2Type;

--- a/packages/gitbeaker-core/src/templates/ResourceTemplates.ts
+++ b/packages/gitbeaker-core/src/templates/ResourceTemplates.ts
@@ -6,8 +6,8 @@ export interface ResourceTemplateSchema extends Record<string, unknown> {
   content: string;
 }
 
-export class ResourceTemplates<C extends boolean = false> extends BaseService<C> {
-  constructor(resourceType: string, options: BaseServiceOptions<C>) {
+export class ResourceTemplates extends BaseService {
+  constructor(resourceType: string, options: BaseServiceOptions) {
     super({ prefixUrl: ['templates', resourceType].join('/'), ...options });
   }
 

--- a/packages/gitbeaker-core/src/templates/ResourceVariables.ts
+++ b/packages/gitbeaker-core/src/templates/ResourceVariables.ts
@@ -10,8 +10,8 @@ export interface ResourceVariableSchema extends Record<string, unknown> {
   key: string;
 }
 
-export class ResourceVariables<C extends boolean> extends BaseService<C> {
-  constructor(resourceType: string, options: BaseServiceOptions<C>) {
+export class ResourceVariables extends BaseService {
+  constructor(resourceType: string, options: BaseServiceOptions) {
     super({ prefixUrl: resourceType, ...options });
   }
 

--- a/packages/gitbeaker-core/test/unit/templates/ResourceVariables.ts
+++ b/packages/gitbeaker-core/test/unit/templates/ResourceVariables.ts
@@ -6,7 +6,7 @@ jest.mock(
   () => require('../../__mocks__/RequestHelper').default,
 );
 
-let service: ResourceVariables<false>;
+let service: ResourceVariables;
 
 beforeEach(() => {
   service = new ResourceVariables('resource', {

--- a/packages/gitbeaker-requester-utils/src/BaseService.ts
+++ b/packages/gitbeaker-requester-utils/src/BaseService.ts
@@ -1,6 +1,6 @@
 import { RequesterType, DefaultServiceOptions } from './RequesterUtils';
 
-export interface BaseServiceOptions<C> {
+export interface BaseServiceOptions {
   oauthToken?: string;
   token?: string;
   jobToken?: string;
@@ -8,7 +8,7 @@ export interface BaseServiceOptions<C> {
   prefixUrl?: string;
   version?: 3 | 4;
   rejectUnauthorized?: boolean;
-  camelize?: C;
+  camelize?: boolean;
   requesterFn?: (serviceOptions: DefaultServiceOptions) => RequesterType;
   requestTimeout?: number;
   profileToken?: string;
@@ -16,7 +16,7 @@ export interface BaseServiceOptions<C> {
   profileMode?: 'execution' | 'memory';
 }
 
-export class BaseService<C extends boolean = false> {
+export class BaseService {
   public readonly url: string;
 
   public readonly requester: RequesterType;
@@ -25,7 +25,7 @@ export class BaseService<C extends boolean = false> {
 
   public readonly headers: { [header: string]: string };
 
-  public readonly camelize: C | undefined;
+  public readonly camelize: boolean;
 
   public readonly rejectUnauthorized: boolean;
 
@@ -43,7 +43,7 @@ export class BaseService<C extends boolean = false> {
     version = 4,
     rejectUnauthorized = true,
     requestTimeout = 300000,
-  }: BaseServiceOptions<C> = {}) {
+  }: BaseServiceOptions = {}) {
     if (!requesterFn) throw new ReferenceError('requesterFn must be passed');
 
     this.url = [host, 'api', `v${version}`, prefixUrl].join('/');
@@ -52,7 +52,7 @@ export class BaseService<C extends boolean = false> {
       'user-agent': 'gitbeaker',
     };
     this.rejectUnauthorized = rejectUnauthorized;
-    this.camelize = camelize;
+    this.camelize = !!camelize;
     this.requestTimeout = requestTimeout;
 
     // Handle auth tokens


### PR DESCRIPTION
Removes camelization from being represented in the type system
Updates BaseService to remove generic parameter
Updates types leveraging BaseService to remove generic camelize paramter

In general, it seems like the API can return different casings in different responses.
If that's the case, handling it when processing requests and responses seems to me to
be a better approach that letting it propagate throughout the type system.

This may be a breaking change, as if I am understanding it correctly, objects before
this pr had two properties: `fooBar` and `foo_bar`.

Hopefully, after this change, this will not be the case.