### PR TITLE
Package Registry Support

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,31 +7,31 @@ updates:
       time: '04:00'
     open-pull-requests-limit: 10
   - package-ecosystem: npm
-    directory: '/packages/gitbeaker-browser'
+    directory: '/packages/browser'
     schedule:
       interval: daily
       time: '04:00'
     open-pull-requests-limit: 10
   - package-ecosystem: npm
-    directory: '/packages/gitbeaker-node'
+    directory: '/packages/node'
     schedule:
       interval: daily
       time: '04:00'
     open-pull-requests-limit: 10
   - package-ecosystem: npm
-    directory: '/packages/gitbeaker-cli'
+    directory: '/packages/cli'
     schedule:
       interval: daily
       time: '04:00'
     open-pull-requests-limit: 10
   - package-ecosystem: npm
-    directory: '/packages/gitbeaker-core'
+    directory: '/packages/core'
     schedule:
       interval: daily
       time: '04:00'
     open-pull-requests-limit: 10
   - package-ecosystem: npm
-    directory: '/packages/gitbeaker-requester-utils'
+    directory: '/packages/requester-utils'
     schedule:
       interval: daily
       time: '04:00'

--- a/README.md
+++ b/README.md
@@ -141,10 +141,12 @@ Available instantiating options:
 | `sudo`               | Yes      | `false`                                                                                                                                                             | [Sudo](https://docs.gitlab.com/ee/api/#sudo) query parameter                                                       |
 | `version`            | Yes      | `4`                                                                                                                                                                 | API Version ID                                                                                                     |
 | `camelize`           | Yes      | `false`                                                                                                                                                             | Camelizes all response body keys                                                                                   |
-| `requesterFn`        | Yes\*    | @gitbeaker/node & @gitbeaker/cli : Got-based, @gitbeaker/browser: Ky-based. The @gitbeaker/core package **does not** have a default and thus must be set explicitly | Request Library Wrapper                                                                                            |
+| `requesterFn`        | Yes    | @gitbeaker/node & @gitbeaker/cli : Got-based, @gitbeaker/browser: Ky-based. The @gitbeaker/core package **does not** have a default and thus must be set explicitly | Request Library Wrapper                                                                                            |
 | `requestTimeout`     | Yes      | `300000`                                                                                                                                                            | Request Library Timeout in ms                                                                                      |
 | `profileToken`       | Yes      | N/A                                                                                                                                                                 | [Requests Profiles Token](https://docs.gitlab.com/ee/administration/monitoring/performance/request_profiling.html) |
 | `profileMode`        | Yes      | `execution`                                                                                                                                                         | [Requests Profiles Token](https://docs.gitlab.com/ee/administration/monitoring/performance/request_profiling.html) |
+
+>*One of these options must be supplied.
 
 ### CLI Support
 
@@ -253,6 +255,7 @@ MergeRequestAwardEmojis
 MergeRequestDiscussions
 MergeRequestNotes
 Packages
+PackageRegistry
 Pipelines
 PipelineSchedules
 PipelineScheduleVariables

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -53,6 +53,7 @@ export const {
   MergeRequestDiscussions,
   MergeRequestNotes,
   Packages,
+  PackageRegistry,
   Pipelines,
   PipelineSchedules,
   PipelineScheduleVariables,

--- a/packages/core/src/services/PackageRegistry.ts
+++ b/packages/core/src/services/PackageRegistry.ts
@@ -1,0 +1,41 @@
+import { BaseService } from '@gitbeaker/requester-utils';
+import { RequestHelper, Sudo } from '../infrastructure';
+
+export class PackageRegistry<C extends boolean = false> extends BaseService<C> {
+  publish(
+    projectId: string | number,
+    packageName: string,
+    packageVersion: string,
+    filename: string,
+    content: string,
+    options?: { status?: 'default' | 'hidden' },
+  ) {
+    const pId = encodeURIComponent(projectId);
+
+    return RequestHelper.put<{ message: string }>()(
+      this,
+      `projects/${pId}/packages/generic/${packageName}/${packageVersion}/${filename}`,
+      {
+        isForm: true,
+        file: [content, { filename }],
+        ...options,
+      },
+    );
+  }
+
+  download(
+    projectId: string | number,
+    packageName: string,
+    packageVersion: string,
+    filename: string,
+    options?: Sudo,
+  ) {
+    const pId = encodeURIComponent(projectId);
+
+    return RequestHelper.get<{ message: string }>()(
+      this,
+      `projects/${pId}/packages/generic/${packageName}/${packageVersion}/${filename}`,
+      options,
+    );
+  }
+}

--- a/packages/core/src/services/index.ts
+++ b/packages/core/src/services/index.ts
@@ -46,6 +46,7 @@ export { MergeRequestAwardEmojis } from './MergeRequestAwardEmojis';
 export { MergeRequestDiscussions } from './MergeRequestDiscussions';
 export { MergeRequestNotes } from './MergeRequestNotes';
 export { Packages } from './Packages';
+export { PackageRegistry } from './PackageRegistry';
 export { Pipelines } from './Pipelines';
 export { PipelineSchedules } from './PipelineSchedules';
 export { PipelineScheduleVariables } from './PipelineScheduleVariables';

--- a/packages/core/test/unit/services/PackageRegistry.ts
+++ b/packages/core/test/unit/services/PackageRegistry.ts
@@ -17,7 +17,7 @@ beforeEach(() => {
 });
 
 describe('Instantiating PackageRegistry service', () => {
-  it('should create a valid service object', async () => {
+  it('should create a valid service object', () => {
     expect(service).toBeInstanceOf(PackageRegistry);
     expect(service.url).toBeDefined();
     expect(service.rejectUnauthorized).toBeTruthy();

--- a/packages/core/test/unit/services/PackageRegistry.ts
+++ b/packages/core/test/unit/services/PackageRegistry.ts
@@ -1,0 +1,54 @@
+import { RequestHelper } from '../../../src/infrastructure';
+import { PackageRegistry } from '../../../src';
+
+jest.mock(
+  '../../../src/infrastructure/RequestHelper',
+  () => require('../../__mocks__/RequestHelper').default,
+);
+
+let service: PackageRegistry;
+
+beforeEach(() => {
+  service = new PackageRegistry({
+    requesterFn: jest.fn(),
+    token: 'abcdefg',
+    requestTimeout: 3000,
+  });
+});
+
+describe('Instantiating PackageRegistry service', () => {
+  it('should create a valid service object', async () => {
+    expect(service).toBeInstanceOf(PackageRegistry);
+    expect(service.url).toBeDefined();
+    expect(service.rejectUnauthorized).toBeTruthy();
+    expect(service.headers).toMatchObject({ 'private-token': 'abcdefg' });
+    expect(service.requestTimeout).toBe(3000);
+  });
+});
+
+describe('PackageRegistry.publish', () => {
+  it('should request PUT projects/:projectId/packages/generic/:packageName/:packageVersion/:filename', async () => {
+    await service.publish(1, 'name', 'v1.0', 'filename.txt', 'content');
+
+    expect(RequestHelper.put()).toHaveBeenCalledWith(
+      service,
+      `projects/1/packages/generic/name/v1.0/filename.txt`,
+      {
+        isForm: true,
+        file: ['content', { filename: 'filename.txt' }],
+      },
+    );
+  });
+});
+
+describe('PackageRegistry.download', () => {
+  it('should request GET projects/:projectId/packages/generic/:packageName/:packageVersion/:filename', async () => {
+    await service.download(1, 'name', 'v1.0', 'filename.txt');
+
+    expect(RequestHelper.get()).toHaveBeenCalledWith(
+      service,
+      `projects/1/packages/generic/name/v1.0/filename.txt`,
+      undefined,
+    );
+  });
+});

--- a/packages/core/test/unit/services/Packages.ts
+++ b/packages/core/test/unit/services/Packages.ts
@@ -28,9 +28,19 @@ describe('Instantiating Packages service', () => {
 
 describe('Packages.all', () => {
   it('should request GET /projects/:id/packages', async () => {
-    await service.all(1);
+    await service.all({ projectId: 1 });
 
-    expect(RequestHelper.get()).toHaveBeenCalledWith(service, 'projects/1/packages', undefined);
+    expect(RequestHelper.get()).toHaveBeenCalledWith(service, 'projects/1/packages', {});
+  });
+
+  it('should request GET /groups/:id/packages', async () => {
+    await service.all({ groupId: 1 });
+
+    expect(RequestHelper.get()).toHaveBeenCalledWith(service, 'groups/1/packages', {});
+  });
+
+  it('should throw an error is neither groupId or projectId is passed', async () => {
+    expect(() => service.all()).toThrow('projectId or groupId must be passed');
   });
 });
 
@@ -39,6 +49,18 @@ describe('Packages.remove', () => {
     await service.remove(1, 2);
 
     expect(RequestHelper.del()).toHaveBeenCalledWith(service, 'projects/1/packages/2', undefined);
+  });
+});
+
+describe('Packages.removeFile', () => {
+  it('should request DEL /projects/:id/packages/:id/package_files', async () => {
+    await service.removeFile(1, 2, 3);
+
+    expect(RequestHelper.del()).toHaveBeenCalledWith(
+      service,
+      'projects/1/packages/2/package_files/3',
+      undefined,
+    );
   });
 });
 

--- a/packages/core/test/unit/services/Packages.ts
+++ b/packages/core/test/unit/services/Packages.ts
@@ -39,7 +39,7 @@ describe('Packages.all', () => {
     expect(RequestHelper.get()).toHaveBeenCalledWith(service, 'groups/1/packages', {});
   });
 
-  it('should throw an error is neither groupId or projectId is passed', async () => {
+  it('should throw an error is neither groupId or projectId is passed', () => {
     expect(() => service.all()).toThrow('projectId or groupId must be passed');
   });
 });

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -53,6 +53,7 @@ export const {
   MergeRequestDiscussions,
   MergeRequestNotes,
   Packages,
+  PackageRegistry,
   Pipelines,
   PipelineSchedules,
   PipelineScheduleVariables,

--- a/scripts/auto-before-commit-changelog-plugin.js
+++ b/scripts/auto-before-commit-changelog-plugin.js
@@ -13,7 +13,7 @@ module.exports = class LintDocsPlugin {
    */
   apply(auto) {
     auto.hooks.beforeCommitChangelog.tapPromise(this.name, async () => {
-      await execPromise('yarn', ['lint:doc:fix']);
+      await execPromise('yarn', ['lint:docs:fix']);
       await execPromise('git', ['add', '.']);
     });
   }


### PR DESCRIPTION
- Adds support for the Package Registry API

BREAKING
- Updates the Package API all method to accept groupIds.

fixes: #1623 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>30.0.0-canary.1822.311782152.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @gitbeaker/browser@30.0.0-canary.1822.311782152.0
  npm install @gitbeaker/cli@30.0.0-canary.1822.311782152.0
  npm install @gitbeaker/core@30.0.0-canary.1822.311782152.0
  npm install @gitbeaker/node@30.0.0-canary.1822.311782152.0
  npm install @gitbeaker/requester-utils@30.0.0-canary.1822.311782152.0
  # or 
  yarn add @gitbeaker/browser@30.0.0-canary.1822.311782152.0
  yarn add @gitbeaker/cli@30.0.0-canary.1822.311782152.0
  yarn add @gitbeaker/core@30.0.0-canary.1822.311782152.0
  yarn add @gitbeaker/node@30.0.0-canary.1822.311782152.0
  yarn add @gitbeaker/requester-utils@30.0.0-canary.1822.311782152.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
