### PR TITLE
Fix CLI release compilation 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,31 +7,31 @@ updates:
       time: '04:00'
     open-pull-requests-limit: 10
   - package-ecosystem: npm
-    directory: '/packages/gitbeaker-browser'
+    directory: '/packages/browser'
     schedule:
       interval: daily
       time: '04:00'
     open-pull-requests-limit: 10
   - package-ecosystem: npm
-    directory: '/packages/gitbeaker-node'
+    directory: '/packages/node'
     schedule:
       interval: daily
       time: '04:00'
     open-pull-requests-limit: 10
   - package-ecosystem: npm
-    directory: '/packages/gitbeaker-cli'
+    directory: '/packages/cli'
     schedule:
       interval: daily
       time: '04:00'
     open-pull-requests-limit: 10
   - package-ecosystem: npm
-    directory: '/packages/gitbeaker-core'
+    directory: '/packages/core'
     schedule:
       interval: daily
       time: '04:00'
     open-pull-requests-limit: 10
   - package-ecosystem: npm
-    directory: '/packages/gitbeaker-requester-utils'
+    directory: '/packages/requester-utils'
     schedule:
       interval: daily
       time: '04:00'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -52,7 +52,7 @@ lint:src:
 lint:docs:
   needs: ['install']
   stage: lint
-  script: yarn lint:doc
+  script: yarn lint:docs
 
 # Unit Tests
 test:unit:cli:
@@ -126,11 +126,12 @@ test:unit:utils:
 #   script:
 #     - yarn workspace @gitbeaker/browser test:integration
 
-# test:integration:node:
+# test:integration:
 #   <<: *integration-test
 #   script:
-#     - yarn workspace @gitbeaker/node test:integration
-#     - yarn workspace @gitbeaker/node test:integration --moduleNameMapper='{"src":"<rootDir>/dist/index.js"}'
+#     - yarn workspace @gitbeaker/cli test:integration
+# - yarn workspace @gitbeaker/node test:integration
+# - yarn workspace @gitbeaker/node test:integration --moduleNameMapper='{"src":"<rootDir>/dist/index.js"}'
 
 # Canary
 canary:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -45,10 +45,12 @@ build:
 
 # Lint all code, tests and supporting documentation (README, CHANGELOG etc)
 lint:src:
+  needs: ['install']
   stage: lint
   script: yarn lint
 
 lint:docs:
+  needs: ['install']
   stage: lint
   script: yarn lint:doc
 

--- a/package.json
+++ b/package.json
@@ -39,8 +39,8 @@
   "scripts": {
     "build": "lerna run build",
     "lint": "prettier --check 'packages/**/{src,test}/**/*.ts' && eslint 'packages/**/{src,test}/**/*/*.ts'",
-    "lint:doc": "prettier --check './**/*.json' './**/*.yml' './**/*.js' '!./**/(dist|coverage)/**'",
-    "lint:doc:fix": "prettier --write './**/*.json' './**/*.yml' './**/*.js' '!./**/(dist|coverage)/**'",
+    "lint:docs": "prettier --check './**/*.json' './**/*.yml' './**/*.js' '!./**/(dist|coverage)/**'",
+    "lint:docs:fix": "prettier --write './**/*.json' './**/*.yml' './**/*.js' '!./**/(dist|coverage)/**'",
     "lint:fix": "prettier --write 'packages/**/{src,test}/**/*.ts' && eslint 'packages/**/{src,test}/**/*/*.ts' --fix",
     "test:unit": "jest test/unit",
     "release": "auto shipit --verbose --verbose",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -25,7 +25,7 @@
     "rollup-plugin-preserve-shebangs": "^0.2.0",
     "rollup-plugin-typescript2": "^0.30.0",
     "strip-ansi": "^7.0.0",
-    "uuid": "^8.3.2"
+    "uuid": "^8.3.2",
     "typescript": "^4.2.4"
   },
   "engines": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -25,6 +25,7 @@
     "rollup-plugin-preserve-shebangs": "^0.2.0",
     "rollup-plugin-typescript2": "^0.30.0",
     "strip-ansi": "^7.0.0",
+    "uuid": "^8.3.2"
     "typescript": "^4.2.4"
   },
   "engines": {
@@ -48,7 +49,7 @@
   },
   "scripts": {
     "build": "rollup -c",
-    "test:integration": "jest test/integration",
+    "test:integration": "TEST_ID=$(uuid) jest test/integration",
     "test:unit": "jest test/unit"
   }
 }

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -92,17 +92,28 @@ function param(string: string): string {
   let cleaned = string;
 
   // Handle exceptions
-  if (string.includes('GitLabCI')) cleaned = cleaned.replace('GitLabCI', 'Gitlabci');
-  if (string.includes('YML')) cleaned = cleaned.replace('YML', 'Yml');
-  if (string.includes('GPG')) cleaned = cleaned.replace('GPG', 'Gpg');
+  const exceptions = [
+    'GitLabCI',
+    'YML',
+    'GPG',
+    'SSH'
+  ]
 
-  const attempt = decamelize(cleaned, '-');
+  const ex = exceptions.find(e => string.includes(e))
 
-  return attempt !== cleaned ? attempt : depascalize(cleaned, '-');
+  if (ex) cleaned = cleaned.replace(ex, ex.charAt(0).toUpperCase() + ex.slice(1))
+
+
+  // Decamelize
+  const decamelized = decamelize(cleaned, '-');
+
+  return decamelized !== cleaned ? decamelized : depascalize(cleaned, '-');
 }
 
-function setupAPIMethods(setupArgs, methodArgs: string[]) {
-  methodArgs.forEach((name: string) => {
+function setupAPIMethods(setupArgs, methodArgs: unknown[]) {
+  methodArgs.forEach((name) => {
+    if (typeof name !== 'string') return;
+
     setupArgs.positional(`[--${param(name)}] <${param(name)}>`, {
       group: 'Required Options',
       type: 'string',

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -92,17 +92,11 @@ function param(string: string): string {
   let cleaned = string;
 
   // Handle exceptions
-  const exceptions = [
-    'GitLabCI',
-    'YML',
-    'GPG',
-    'SSH'
-  ]
+  const exceptions = ['GitLabCI', 'YML', 'GPG', 'SSH'];
 
-  const ex = exceptions.find(e => string.includes(e))
+  const ex = exceptions.find((e) => string.includes(e));
 
-  if (ex) cleaned = cleaned.replace(ex, ex.charAt(0).toUpperCase() + ex.slice(1))
-
+  if (ex) cleaned = cleaned.replace(ex, ex.charAt(0).toUpperCase() + ex.slice(1));
 
   // Decamelize
   const decamelized = decamelize(cleaned, '-');

--- a/packages/cli/test/integration/services/Projects.ts
+++ b/packages/cli/test/integration/services/Projects.ts
@@ -1,21 +1,16 @@
-import { spawnSync } from 'child_process';
+import { promisify } from 'util'
+import { exec } from 'child_process';
+
+const execP = promisify(exec)
 
 const { TEST_ID = '', GITLAB_PERSONAL_ACCESS_TOKEN = '', GITLAB_URL = '' } = process.env;
 
 describe('gitbeaker projects create', () => {
-  it('should create a valid project', () => {
-    const output = spawnSync('node', [
-      '../../../dist/index',
-      `gitbeaker projects create --name="CLI Project ${TEST_ID}" --gb-token="${GITLAB_PERSONAL_ACCESS_TOKEN}" --gb-host="${GITLAB_URL}"`,
-    ]);
+  it('should create a valid project', async () => {
+    const command = `projects create --name="CLI Project ${TEST_ID}" --gb-token="${GITLAB_PERSONAL_ACCESS_TOKEN}" --gb-host="${GITLAB_URL}"`;
+    const { stdout } = await execP(`node dist/index.js ${command}`)
+    const { name } = JSON.parse(stdout)
 
-    console.log('error', output.error);
-    console.log('stdout ', output.stdout);
-    console.log('stderr ', output.stderr);
-    console.log('stderr ', output.output);
-
-    console.log(JSON.stringify(output));
-    expect(true).toBeTruthy();
-    // expect(data.name).toBe(`CLI Project ${TEST_ID}`);
+    expect(name).toBe(`CLI Project ${TEST_ID}`);
   });
 });

--- a/packages/cli/test/integration/services/Projects.ts
+++ b/packages/cli/test/integration/services/Projects.ts
@@ -1,14 +1,21 @@
+import { spawnSync } from 'child_process';
+
 const { TEST_ID = '', GITLAB_PERSONAL_ACCESS_TOKEN = '', GITLAB_URL = '' } = process.env;
 
 describe('gitbeaker projects create', () => {
-  it('should create a valid project', async () => {
-    // eslint-disable-next-line
-    const { cli } = require('../../../dist/index');
-    const { output } = await cli.parse(
+  it('should create a valid project', () => {
+    const output = spawnSync('node', [
+      '../../../dist/index',
       `gitbeaker projects create --name="CLI Project ${TEST_ID}" --gb-token="${GITLAB_PERSONAL_ACCESS_TOKEN}" --gb-host="${GITLAB_URL}"`,
-    );
-    const data = JSON.parse(output);
+    ]);
 
-    expect(data.name).toBe(`CLI Project ${TEST_ID}`);
+    console.log('error', output.error);
+    console.log('stdout ', output.stdout);
+    console.log('stderr ', output.stderr);
+    console.log('stderr ', output.output);
+
+    console.log(JSON.stringify(output));
+    expect(true).toBeTruthy();
+    // expect(data.name).toBe(`CLI Project ${TEST_ID}`);
   });
 });

--- a/packages/cli/test/integration/services/Projects.ts
+++ b/packages/cli/test/integration/services/Projects.ts
@@ -1,15 +1,15 @@
-import { promisify } from 'util'
+import { promisify } from 'util';
 import { exec } from 'child_process';
 
-const execP = promisify(exec)
+const execP = promisify(exec);
 
 const { TEST_ID = '', GITLAB_PERSONAL_ACCESS_TOKEN = '', GITLAB_URL = '' } = process.env;
 
 describe('gitbeaker projects create', () => {
   it('should create a valid project', async () => {
     const command = `projects create --name="CLI Project ${TEST_ID}" --gb-token="${GITLAB_PERSONAL_ACCESS_TOKEN}" --gb-host="${GITLAB_URL}"`;
-    const { stdout } = await execP(`node dist/index.js ${command}`)
-    const { name } = JSON.parse(stdout)
+    const { stdout } = await execP(`node dist/index.js ${command}`);
+    const { name } = JSON.parse(stdout);
 
     expect(name).toBe(`CLI Project ${TEST_ID}`);
   });


### PR DESCRIPTION
Fixes the compilation error. Still some odd behaviour with ts-jest though, not really sure how to work around that without looking for another lib.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>29.3.0-canary.1838.313135381.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @gitbeaker/browser@29.3.0-canary.1838.313135381.0
  npm install @gitbeaker/cli@29.3.0-canary.1838.313135381.0
  npm install @gitbeaker/core@29.3.0-canary.1838.313135381.0
  npm install @gitbeaker/node@29.3.0-canary.1838.313135381.0
  npm install @gitbeaker/requester-utils@29.3.0-canary.1838.313135381.0
  # or 
  yarn add @gitbeaker/browser@29.3.0-canary.1838.313135381.0
  yarn add @gitbeaker/cli@29.3.0-canary.1838.313135381.0
  yarn add @gitbeaker/core@29.3.0-canary.1838.313135381.0
  yarn add @gitbeaker/node@29.3.0-canary.1838.313135381.0
  yarn add @gitbeaker/requester-utils@29.3.0-canary.1838.313135381.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
