### PR TITLE
Improved mime handling

### DIFF
--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -16,6 +16,7 @@
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^19.0.0",
+    "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-node-resolve": "^13.0.0",
     "@rollup/plugin-replace": "^2.4.2",
     "@types/node": "^16.0.0",

--- a/packages/browser/rollup.config.js
+++ b/packages/browser/rollup.config.js
@@ -3,6 +3,7 @@ import commonjs from '@rollup/plugin-commonjs';
 import builtins from 'rollup-plugin-node-polyfills';
 import globals from 'rollup-plugin-node-globals';
 import ts from 'rollup-plugin-typescript2';
+import json from '@rollup/plugin-json';
 import { terser } from 'rollup-plugin-terser';
 import pkg from './package.json';
 
@@ -30,6 +31,7 @@ export default [
           },
         },
       }),
+      json(),
       commonjs(),
       terser({ mangle: false }),
     ],

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,6 +17,7 @@
     "xcase": "^2.0.1"
   },
   "devDependencies": {
+    "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-replace": "^2.4.2",
     "@types/node": "^16.0.0",
     "esm": "^3.2.25",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -12,6 +12,7 @@
     "@gitbeaker/requester-utils": "^32.0.0",
     "form-data": "^4.0.0",
     "li": "^1.3.0",
+    "mime-types": "^2.1.32",
     "query-string": "^7.0.0",
     "xcase": "^2.0.1"
   },

--- a/packages/core/rollup.config.js
+++ b/packages/core/rollup.config.js
@@ -1,5 +1,6 @@
 import replace from '@rollup/plugin-replace';
 import ts from 'rollup-plugin-typescript2';
+import json from '@rollup/plugin-json';
 import pkg from './package.json';
 
 export default {
@@ -31,5 +32,6 @@ export default {
       },
       useTsconfigDeclarationDir: true,
     }),
+    json(),
   ],
 };

--- a/packages/core/src/resources/PackageRegistry.ts
+++ b/packages/core/src/resources/PackageRegistry.ts
@@ -1,4 +1,5 @@
 import { BaseResource } from '@gitbeaker/requester-utils';
+import { lookup as mimeLookup } from 'mime-types';
 import { RequestHelper, Sudo } from '../infrastructure';
 
 export class PackageRegistry<C extends boolean = false> extends BaseResource<C> {
@@ -8,16 +9,19 @@ export class PackageRegistry<C extends boolean = false> extends BaseResource<C> 
     packageVersion: string,
     filename: string,
     content: string,
-    options?: { status?: 'default' | 'hidden' },
+    { contentType, ...options }: { contentType?: string } & { status?: 'default' | 'hidden' } = {},
   ) {
     const pId = encodeURIComponent(projectId);
+    const meta = { filename, contentType }
+
+    if (!meta.contentType) meta.contentType = mimeLookup(meta.filename)
 
     return RequestHelper.put<{ message: string }>()(
       this,
       `projects/${pId}/packages/generic/${packageName}/${packageVersion}/${filename}`,
       {
         isForm: true,
-        file: [content, { filename }],
+        file: [content, meta],
         ...options,
       },
     );

--- a/packages/core/src/resources/PackageRegistry.ts
+++ b/packages/core/src/resources/PackageRegistry.ts
@@ -12,9 +12,9 @@ export class PackageRegistry<C extends boolean = false> extends BaseResource<C> 
     { contentType, ...options }: { contentType?: string } & { status?: 'default' | 'hidden' } = {},
   ) {
     const pId = encodeURIComponent(projectId);
-    const meta = { filename, contentType }
+    const meta = { filename, contentType };
 
-    if (!meta.contentType) meta.contentType = mimeLookup(meta.filename)
+    if (!meta.contentType) meta.contentType = mimeLookup(meta.filename);
 
     return RequestHelper.put<{ message: string }>()(
       this,

--- a/packages/core/src/resources/ProjectImportExport.ts
+++ b/packages/core/src/resources/ProjectImportExport.ts
@@ -1,4 +1,5 @@
 import { BaseResource } from '@gitbeaker/requester-utils';
+import { mimeLookup } from 'mime-types';
 import { RequestHelper, Sudo, BaseRequestOptions } from '../infrastructure';
 
 export interface ExportStatusSchema extends Record<string, unknown> {
@@ -45,7 +46,6 @@ export interface UploadMetadata {
 
 export const defaultMetadata = {
   filename: `${Date.now().toString()}.tar.gz`,
-  contentType: 'application/octet-stream',
 };
 
 export class ProjectImportExport<C extends boolean = false> extends BaseResource<C> {
@@ -66,6 +66,10 @@ export class ProjectImportExport<C extends boolean = false> extends BaseResource
     path: string,
     { metadata, ...options }: { metadata?: UploadMetadata } & BaseRequestOptions = {},
   ) {
+    const meta = { ...defaultMetadata, ...metadata };
+
+    if (!meta.contentType) meta.contentType = mimeLookup(meta.filename)
+
     return RequestHelper.post<ImportStatusSchema>()(this, 'projects/import', {
       isForm: true,
       ...options,

--- a/packages/core/src/resources/ProjectImportExport.ts
+++ b/packages/core/src/resources/ProjectImportExport.ts
@@ -1,5 +1,5 @@
 import { BaseResource } from '@gitbeaker/requester-utils';
-import { mimeLookup } from 'mime-types';
+import { lookup as mimeLookup } from 'mime-types';
 import { RequestHelper, Sudo, BaseRequestOptions } from '../infrastructure';
 
 export interface ExportStatusSchema extends Record<string, unknown> {
@@ -68,12 +68,12 @@ export class ProjectImportExport<C extends boolean = false> extends BaseResource
   ) {
     const meta = { ...defaultMetadata, ...metadata };
 
-    if (!meta.contentType) meta.contentType = mimeLookup(meta.filename)
+    if (!meta.contentType) meta.contentType = mimeLookup(meta.filename);
 
     return RequestHelper.post<ImportStatusSchema>()(this, 'projects/import', {
       isForm: true,
       ...options,
-      file: [content, { ...defaultMetadata, ...metadata }],
+      file: [content, meta],
       path,
     });
   }

--- a/packages/core/src/resources/Projects.ts
+++ b/packages/core/src/resources/Projects.ts
@@ -281,7 +281,7 @@ export class Projects<C extends boolean = false> extends BaseResource<C> {
     const pId = encodeURIComponent(projectId);
     const meta = { ...defaultMetadata, ...metadata };
 
-    if (!meta.contentType) meta.contentType = mimeLookup(meta.filename)
+    if (!meta.contentType) meta.contentType = mimeLookup(meta.filename);
 
     return RequestHelper.post<ProjectFileUploadSchema>()(this, `projects/${pId}/uploads`, {
       isForm: true,

--- a/packages/core/src/resources/Projects.ts
+++ b/packages/core/src/resources/Projects.ts
@@ -1,4 +1,5 @@
 import { BaseResource } from '@gitbeaker/requester-utils';
+import { lookup as mimeLookup } from 'mime-types';
 import { UserSchema } from './Users';
 import { NamespaceSchema } from './Namespaces';
 import { LicenseTemplateSchema } from './LicenseTemplates';
@@ -278,10 +279,13 @@ export class Projects<C extends boolean = false> extends BaseResource<C> {
     { metadata, ...options }: { metadata?: UploadMetadata } & BaseRequestOptions = {},
   ) {
     const pId = encodeURIComponent(projectId);
+    const meta = { ...defaultMetadata, ...metadata };
+
+    if (!meta.contentType) meta.contentType = mimeLookup(meta.filename)
 
     return RequestHelper.post<ProjectFileUploadSchema>()(this, `projects/${pId}/uploads`, {
       isForm: true,
-      file: [content, { ...defaultMetadata, ...metadata }],
+      file: [content, meta],
       ...options,
     });
   }

--- a/packages/core/test/unit/resources/PackageRegistry.ts
+++ b/packages/core/test/unit/resources/PackageRegistry.ts
@@ -35,7 +35,10 @@ describe('PackageRegistry.publish', () => {
       `projects/1/packages/generic/name/v1.0/filename.txt`,
       {
         isForm: true,
-        file: ['content', { filename: 'filename.txt' }],
+        file: ['content', {
+          contentType: 'text/plain',
+          filename: 'filename.txt'
+        }],
       },
     );
   });

--- a/packages/core/test/unit/resources/PackageRegistry.ts
+++ b/packages/core/test/unit/resources/PackageRegistry.ts
@@ -35,10 +35,13 @@ describe('PackageRegistry.publish', () => {
       `projects/1/packages/generic/name/v1.0/filename.txt`,
       {
         isForm: true,
-        file: ['content', {
-          contentType: 'text/plain',
-          filename: 'filename.txt'
-        }],
+        file: [
+          'content',
+          {
+            contentType: 'text/plain',
+            filename: 'filename.txt',
+          },
+        ],
       },
     );
   });

--- a/packages/core/test/unit/resources/ProjectImportExport.ts
+++ b/packages/core/test/unit/resources/ProjectImportExport.ts
@@ -47,7 +47,7 @@ describe('ProjectImportExport.exportStatus', () => {
 });
 
 describe('ProjectImportExport.import', () => {
-  it.only('should request POST /projects/import', async () => {
+  it('should request POST /projects/import', async () => {
     await service.import('content', 'path');
 
     expect(RequestHelper.post()).toHaveBeenCalledWith(service, 'projects/import', {
@@ -61,11 +61,11 @@ describe('ProjectImportExport.import', () => {
   });
 
   it('should request POST /projects/import with metadata', async () => {
-    await service.import('content', 'path', { metadata: { filename: 'filename' } });
+    await service.import('content', 'path', { metadata: { filename: 'filename.txt' } });
 
     expect(RequestHelper.post()).toHaveBeenCalledWith(service, 'projects/import', {
       isForm: true,
-      file: ['content', { filename: 'filename', contentType: 'application/octet-stream' }],
+      file: ['content', { filename: 'filename.txt', contentType: 'text/plain' }],
       path: 'path',
     });
   });

--- a/packages/core/test/unit/resources/ProjectImportExport.ts
+++ b/packages/core/test/unit/resources/ProjectImportExport.ts
@@ -47,14 +47,14 @@ describe('ProjectImportExport.exportStatus', () => {
 });
 
 describe('ProjectImportExport.import', () => {
-  it('should request POST /projects/import', async () => {
+  it.only('should request POST /projects/import', async () => {
     await service.import('content', 'path');
 
     expect(RequestHelper.post()).toHaveBeenCalledWith(service, 'projects/import', {
       isForm: true,
       file: [
         'content',
-        { filename: expect.stringContaining('.tar.gz'), contentType: 'application/octet-stream' },
+        { filename: expect.stringContaining('.tar.gz'), contentType: 'application/gzip' },
       ],
       path: 'path',
     });

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -16,6 +16,7 @@
     "xcase": "^2.0.1"
   },
   "devDependencies": {
+    "@rollup/plugin-json": "^4.1.0",
     "@types/node": "^16.0.0",
     "form-data": "^4.0.0",
     "jest-extended": "^0.11.5",

--- a/packages/node/rollup.config.js
+++ b/packages/node/rollup.config.js
@@ -1,4 +1,5 @@
 import ts from 'rollup-plugin-typescript2';
+import json from '@rollup/plugin-json';
 import pkg from './package.json';
 
 export default {
@@ -25,5 +26,6 @@ export default {
       },
       useTsconfigDeclarationDir: true,
     }),
+    json(),
   ],
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -6590,12 +6590,24 @@ mime-db@1.48.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.48.0.tgz#e35b31045dd7eada3aaad537ed88a33afbef2d1d"
   integrity sha512-FM3QwxV+TnZYQ2aRqhlKBMHxk10lTbMt3bBkMAp54ddrNeVSfcQYOOKuGuy3Ddrm38I04If834fOUSq1yzslJQ==
 
+mime-db@1.49.0:
+  version "1.49.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.49.0.tgz#f3dfde60c99e9cf3bc9701d687778f537001cbed"
+  integrity sha512-CIc8j9URtOVApSFCQIF+VBkX1RwXp/oMMOrqdyXSBXq5RWNEsRfyj1kiRnQgmNXmHxPoFIxOroKA3zcU9P+nAA==
+
 mime-types@^2.1.12, mime-types@~2.1.19:
   version "2.1.31"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.31.tgz#a00d76b74317c61f9c2db2218b8e9f8e9c5c9e6b"
   integrity sha512-XGZnNzm3QvgKxa8dpzyhFTHmpP3l5YNusmne07VUOXxou9CqUqYa/HBy124RqtVh/O2pECas/MOcsDgpilPOPg==
   dependencies:
     mime-db "1.48.0"
+
+mime-types@^2.1.32:
+  version "2.1.32"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.32.tgz#1d00e89e7de7fe02008db61001d9e02852670fd5"
+  integrity sha512-hJGaVS4G4c9TSMYh2n6SQAGrC4RnfU+daP8G7cSCmaqNjiOoUY0VHCMS42pxnQmVF1GWwFhbHWn3RIxCqTmZ9A==
+  dependencies:
+    mime-db "1.49.0"
 
 mime@^2.4.6:
   version "2.5.2"


### PR DESCRIPTION
Extension of #1822 

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>32.2.0--canary.1979.349447020.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @gitbeaker/browser@32.2.0--canary.1979.349447020.0
  npm install @gitbeaker/cli@32.2.0--canary.1979.349447020.0
  npm install @gitbeaker/core@32.2.0--canary.1979.349447020.0
  npm install @gitbeaker/node@32.2.0--canary.1979.349447020.0
  npm install @gitbeaker/requester-utils@32.2.0--canary.1979.349447020.0
  # or 
  yarn add @gitbeaker/browser@32.2.0--canary.1979.349447020.0
  yarn add @gitbeaker/cli@32.2.0--canary.1979.349447020.0
  yarn add @gitbeaker/core@32.2.0--canary.1979.349447020.0
  yarn add @gitbeaker/node@32.2.0--canary.1979.349447020.0
  yarn add @gitbeaker/requester-utils@32.2.0--canary.1979.349447020.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
