### PR TITLE
fix(core): change Commits.diff response type to CommitDiffSchema[]

### DIFF
--- a/packages/core/src/resources/Commits.ts
+++ b/packages/core/src/resources/Commits.ts
@@ -204,7 +204,7 @@ export class Commits<C extends boolean = false> extends BaseResource<C> {
   diff(projectId: string | number, sha: string, options?: Sudo) {
     const pId = encodeURIComponent(projectId);
 
-    return RequestHelper.get<CommitDiffSchema>()(
+    return RequestHelper.get<CommitDiffSchema[]>()(
       this,
       `projects/${pId}/repository/commits/${sha}/diff`,
       options,


### PR DESCRIPTION
see https://docs.gitlab.com/ee/api/commits.html#get-the-diff-of-a-commit