### PR TITLE
Add a CJS build to the browser package

### DIFF
--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -50,6 +50,7 @@
   ],
   "license": "MIT",
   "browser": "dist/index.js",
+  "main": "dist/index.cjs.js",
   "types": "dist/types",
   "repository": {
     "type": "git",

--- a/packages/browser/rollup.config.js
+++ b/packages/browser/rollup.config.js
@@ -11,14 +11,21 @@ export default [
   {
     input: 'src/index.ts',
     external: ['form-data'],
-    output: {
-      file: pkg.browser,
-      name: 'gitbeaker',
-      format: 'umd',
-      exports: 'named',
-      globals: { 'form-data': 'FormData' },
-      sourcemap: true,
-    },
+    output: [
+      {
+        file: pkg.browser,
+        name: 'gitbeaker',
+        format: 'umd',
+        exports: 'named',
+        globals: { 'form-data': 'FormData' },
+        sourcemap: true,
+      },
+      {
+        file: pkg.main, // CommonJS (for Node) build.
+        format: 'cjs',
+        sourcemap: true,
+      },
+    ],
     plugins: [
       globals(),
       builtins(),


### PR DESCRIPTION
I am running Jest-based unit tests in a system that combines both frontend and backend plugins. I'm running into the problem that `@gitbeaker/browser` can't even be imported during a Jest test run.

I've added a CJS build to the `@gitbeaker/browser` package. This shouldn't affect usage of the package in the browser, but it allows Jest to resolve the package. After that we can mock it or do whatever we want.

(First pull request to this project, apologies if I missed something)
