### PR TITLE
Update Jobs showPipelineJobs to have correct array return type

### DIFF
--- a/packages/core/src/resources/Jobs.ts
+++ b/packages/core/src/resources/Jobs.ts
@@ -208,7 +208,7 @@ export class Jobs<C extends boolean = false> extends BaseResource<C> {
   ) {
     const [pId, ppId] = [projectId, pipelineId].map(encodeURIComponent);
 
-    return RequestHelper.get<JobSchema>()(this, `projects/${pId}/pipelines/${ppId}/jobs`, options);
+    return RequestHelper.get<JobSchema[]>()(this, `projects/${pId}/pipelines/${ppId}/jobs`, options);
   }
 
   showPipelineBridges(


### PR DESCRIPTION
Getting the Pipeline Jobs is an array of jobs, not a single job. This is a breaking change. Better than having to do something like: 

``` typescript
var manualJobsResponse = await gitlabApi.Jobs.showPipelineJobs(projectId, pipeline.id, {
    scope: 'manual'
})

var manualJobs = manualJobsResponse as unknown as JobSchema[];
```