### PR TITLE
Users.search should return an array

### DIFF
--- a/packages/core/src/resources/Users.ts
+++ b/packages/core/src/resources/Users.ts
@@ -91,7 +91,7 @@ export class Users<C extends boolean = false> extends BaseResource<C> {
   }
 
   search(emailOrUsername: string, options?: Sudo) {
-    return RequestHelper.get<UserSchema>()(this, 'users', {
+    return RequestHelper.get<UserSchema[]>()(this, 'users', {
       search: emailOrUsername,
       ...options,
     });


### PR DESCRIPTION
The GitLab users/search endpoint returns an array, not a single user.