### PR TITLE
Refactor endpoint generation, using tagged template to encode parameters

### DIFF
--- a/packages/core/src/infrastructure/Utils.ts
+++ b/packages/core/src/infrastructure/Utils.ts
@@ -31,3 +31,19 @@ export function getAPIMap(): Record<string, unknown> {
     throw new Error('This function is only available in the distributed code');
   }
 }
+
+/**
+ * Normalize GitLab API endpoint by encoding route parameters.
+ * @param strings
+ * @param values
+ */
+export function endpoint<T extends (string | number)[]>(
+  strings: TemplateStringsArray,
+  ...values: T
+): T extends number[] ? void : string;
+export function endpoint(strings: TemplateStringsArray, ...values: (string | number)[]): string {
+  return values.reduce<string>(
+    (string, value, index) => string + encodeURIComponent(value) + strings[index + 1],
+    strings[0],
+  );
+}

--- a/packages/core/src/resources/Branches.ts
+++ b/packages/core/src/resources/Branches.ts
@@ -1,6 +1,6 @@
 import { BaseResource } from '@gitbeaker/requester-utils';
 import { CommitSchema } from './Commits';
-import { PaginatedRequestOptions, RequestHelper, Sudo } from '../infrastructure';
+import { endpoint, PaginatedRequestOptions, RequestHelper, Sudo } from '../infrastructure';
 
 export interface BranchSchema extends Record<string, unknown> {
   name: string;
@@ -16,38 +16,39 @@ export interface BranchSchema extends Record<string, unknown> {
 
 export class Branches<C extends boolean = false> extends BaseResource<C> {
   all(projectId: string | number, options?: PaginatedRequestOptions) {
-    const pId = encodeURIComponent(projectId);
-
     return RequestHelper.get<BranchSchema[]>()(
       this,
-      `projects/${pId}/repository/branches`,
+      endpoint`projects/${projectId}/repository/branches`,
       options,
     );
   }
 
   create(projectId: string | number, branchName: string, ref: string, options?: Sudo) {
-    const pId = encodeURIComponent(projectId);
     const branchKey = this.url.includes('v3') ? 'branchName' : 'branch';
 
-    return RequestHelper.post<BranchSchema>()(this, `projects/${pId}/repository/branches`, {
-      [branchKey]: branchName,
-      ref,
-      ...options,
-    });
+    return RequestHelper.post<BranchSchema>()(
+      this,
+      endpoint`projects/${projectId}/repository/branches`,
+      {
+        [branchKey]: branchName,
+        ref,
+        ...options,
+      },
+    );
   }
 
   remove(projectId: string | number, branchName: string, options?: Sudo) {
-    const [pId, bName] = [projectId, branchName].map(encodeURIComponent);
-
-    return RequestHelper.del()(this, `projects/${pId}/repository/branches/${bName}`, options);
+    return RequestHelper.del()(
+      this,
+      endpoint`projects/${projectId}/repository/branches/${branchName}`,
+      options,
+    );
   }
 
   show(projectId: string | number, branchName: string, options?: Sudo) {
-    const [pId, bName] = [projectId, branchName].map(encodeURIComponent);
-
     return RequestHelper.get<BranchSchema>()(
       this,
-      `projects/${pId}/repository/branches/${bName}`,
+      endpoint`projects/${projectId}/repository/branches/${branchName}`,
       options,
     );
   }

--- a/packages/core/src/resources/BroadcastMessages.ts
+++ b/packages/core/src/resources/BroadcastMessages.ts
@@ -30,20 +30,22 @@ export class BroadcastMessages<C extends boolean = false> extends BaseResource<C
   }
 
   edit(broadcastMessageId: number, options?: Camelize<Omit<BroadcastMessageSchema, 'id'>> & Sudo) {
-    const bId = encodeURIComponent(broadcastMessageId);
-
-    return RequestHelper.put<BroadcastMessageSchema>()(this, `broadcast_messages/${bId}`, options);
+    return RequestHelper.put<BroadcastMessageSchema>()(
+      this,
+      `broadcast_messages/${broadcastMessageId}`,
+      options,
+    );
   }
 
   remove(broadcastMessageId: number, options?: Sudo) {
-    const bId = encodeURIComponent(broadcastMessageId);
-
-    return RequestHelper.del()(this, `broadcast_messages/${bId}`, options);
+    return RequestHelper.del()(this, `broadcast_messages/${broadcastMessageId}`, options);
   }
 
   show(broadcastMessageId: number, options?: BaseRequestOptions) {
-    const bId = encodeURIComponent(broadcastMessageId);
-
-    return RequestHelper.get<BroadcastMessageSchema>()(this, `broadcast_messages/${bId}`, options);
+    return RequestHelper.get<BroadcastMessageSchema>()(
+      this,
+      `broadcast_messages/${broadcastMessageId}`,
+      options,
+    );
   }
 }

--- a/packages/core/src/resources/Commits.ts
+++ b/packages/core/src/resources/Commits.ts
@@ -3,6 +3,7 @@ import { UserSchema } from './Users';
 import { MergeRequestSchema } from './MergeRequests';
 import {
   BaseRequestOptions,
+  endpoint,
   PaginatedRequestOptions,
   RequestHelper,
   Sudo,
@@ -138,17 +139,17 @@ export interface CommitReferenceSchema extends Record<string, unknown> {
 
 export class Commits<C extends boolean = false> extends BaseResource<C> {
   all(projectId: string | number, options?: PaginatedRequestOptions) {
-    const pId = encodeURIComponent(projectId);
-
-    return RequestHelper.get<CommitSchema[]>()(this, `projects/${pId}/repository/commits`, options);
+    return RequestHelper.get<CommitSchema[]>()(
+      this,
+      endpoint`projects/${projectId}/repository/commits`,
+      options,
+    );
   }
 
   cherryPick(projectId: string | number, sha: string, branch: string, options?: Sudo) {
-    const pId = encodeURIComponent(projectId);
-
     return RequestHelper.post<CommitSchema>()(
       this,
-      `projects/${pId}/repository/commits/${sha}/cherry_pick`,
+      endpoint`projects/${projectId}/repository/commits/${sha}/cherry_pick`,
       {
         branch,
         ...options,
@@ -157,11 +158,9 @@ export class Commits<C extends boolean = false> extends BaseResource<C> {
   }
 
   comments(projectId: string | number, sha: string, options?: Sudo) {
-    const pId = encodeURIComponent(projectId);
-
     return RequestHelper.get<CommentSchema[]>()(
       this,
-      `projects/${pId}/repository/commits/${sha}/comments`,
+      endpoint`projects/${projectId}/repository/commits/${sha}/comments`,
       options,
     );
   }
@@ -173,14 +172,16 @@ export class Commits<C extends boolean = false> extends BaseResource<C> {
     actions: CommitAction[] = [],
     options?: BaseRequestOptions,
   ) {
-    const pId = encodeURIComponent(projectId);
-
-    return RequestHelper.post<CommitExtendedSchema>()(this, `projects/${pId}/repository/commits`, {
-      branch,
-      commitMessage: message,
-      actions,
-      ...options,
-    });
+    return RequestHelper.post<CommitExtendedSchema>()(
+      this,
+      endpoint`projects/${projectId}/repository/commits`,
+      {
+        branch,
+        commitMessage: message,
+        actions,
+        ...options,
+      },
+    );
   }
 
   createComment(
@@ -189,11 +190,9 @@ export class Commits<C extends boolean = false> extends BaseResource<C> {
     note: string,
     options?: BaseRequestOptions,
   ) {
-    const pId = encodeURIComponent(projectId);
-
     return RequestHelper.post<CommentSchema>()(
       this,
-      `projects/${pId}/repository/commits/${sha}/comments`,
+      endpoint`projects/${projectId}/repository/commits/${sha}/comments`,
       {
         note,
         ...options,
@@ -202,81 +201,65 @@ export class Commits<C extends boolean = false> extends BaseResource<C> {
   }
 
   diff(projectId: string | number, sha: string, options?: Sudo) {
-    const pId = encodeURIComponent(projectId);
-
     return RequestHelper.get<CommitDiffSchema[]>()(
       this,
-      `projects/${pId}/repository/commits/${sha}/diff`,
+      endpoint`projects/${projectId}/repository/commits/${sha}/diff`,
       options,
     );
   }
 
   editStatus(projectId: string | number, sha: string, options?: BaseRequestOptions) {
-    const pId = encodeURIComponent(projectId);
-
     return RequestHelper.post<CommitStatusSchema>()(
       this,
-      `projects/${pId}/statuses/${sha}`,
+      endpoint`projects/${projectId}/statuses/${sha}`,
       options,
     );
   }
 
   references(projectId: string | number, sha: string, options?: Sudo) {
-    const pId = encodeURIComponent(projectId);
-
     return RequestHelper.get<CommitReferenceSchema[]>()(
       this,
-      `projects/${pId}/repository/commits/${sha}/refs`,
+      endpoint`projects/${projectId}/repository/commits/${sha}/refs`,
       options,
     );
   }
 
   revert(projectId: string | number, sha: string, options?: Sudo) {
-    const pId = encodeURIComponent(projectId);
-
     return RequestHelper.post<CommitSchema>()(
       this,
-      `projects/${pId}/repository/commits/${sha}/revert`,
+      endpoint`projects/${projectId}/repository/commits/${sha}/revert`,
       options,
     );
   }
 
   show(projectId: string | number, sha: string, options?: BaseRequestOptions) {
-    const pId = encodeURIComponent(projectId);
-
     return RequestHelper.get<CommitExtendedSchema>()(
       this,
-      `projects/${pId}/repository/commits/${sha}`,
+      endpoint`projects/${projectId}/repository/commits/${sha}`,
       options,
     );
   }
 
   statuses(projectId: string | number, sha: string, options?: BaseRequestOptions) {
-    const pId = encodeURIComponent(projectId);
-
     return RequestHelper.get<CommitStatusSchema[]>()(
       this,
-      `projects/${pId}/repository/commits/${sha}/statuses`,
+      endpoint`projects/${projectId}/repository/commits/${sha}/statuses`,
       options,
     );
   }
 
   mergeRequests(projectId: string | number, sha: string, options?: BaseRequestOptions) {
-    const pId = encodeURIComponent(projectId);
-
     return RequestHelper.get<MergeRequestSchema>()(
       this,
-      `projects/${pId}/repository/commits/${sha}/merge_requests`,
+      endpoint`projects/${projectId}/repository/commits/${sha}/merge_requests`,
       options,
     );
   }
 
   signature(projectId: string | number, sha: string, options?: BaseRequestOptions) {
-    const pId = encodeURIComponent(projectId);
-
     return RequestHelper.get<CommitSignatureSchema>()(
       this,
-      `projects/${pId}/repository/commits/${sha}/signature`,
+      endpoint`projects/${projectId}/repository/commits/${sha}/signature`,
       options,
     );
   }

--- a/packages/core/src/resources/ContainerRegistry.ts
+++ b/packages/core/src/resources/ContainerRegistry.ts
@@ -1,5 +1,5 @@
 import { BaseResource } from '@gitbeaker/requester-utils';
-import { RequestHelper, PaginatedRequestOptions, Sudo } from '../infrastructure';
+import { RequestHelper, PaginatedRequestOptions, Sudo, endpoint } from '../infrastructure';
 
 export interface RegistryRepositoryTagSchema extends Record<string, unknown> {
   name: string;
@@ -26,57 +26,49 @@ export interface RegistryRepositorySchema extends Record<string, unknown> {
 
 export class ContainerRegistry<C extends boolean = false> extends BaseResource<C> {
   projectRepositories(projectId: string | number, options?: PaginatedRequestOptions) {
-    const pId = encodeURIComponent(projectId);
-
     return RequestHelper.get<Omit<RegistryRepositorySchema, 'tags' | 'tags_count'>[]>()(
       this,
-      `projects/${pId}/registry/repositories`,
+      endpoint`projects/${projectId}/registry/repositories`,
       options,
     );
   }
 
   groupRepositories(projectId: string | number, options?: PaginatedRequestOptions) {
-    const pId = encodeURIComponent(projectId);
-
     return RequestHelper.get<Omit<RegistryRepositorySchema, 'tags' | 'tags_count'>[]>()(
       this,
-      `groups/${pId}/registry/repositories`,
+      endpoint`groups/${projectId}/registry/repositories`,
       options,
     );
   }
 
   showRepository(projectId: string | number, repositoryId: number, options?: Sudo) {
-    const [pId, rId] = [projectId, repositoryId].map(encodeURIComponent);
-
     return RequestHelper.get<RegistryRepositorySchema>()(
       this,
-      `projects/${pId}/registry/repositories/${rId}`,
+      endpoint`projects/${projectId}/registry/repositories/${repositoryId}`,
       options,
     );
   }
 
   tags(projectId: string | number, repositoryId: number, options?: PaginatedRequestOptions) {
-    const [pId, rId] = [projectId, repositoryId].map(encodeURIComponent);
-
     return RequestHelper.get<Pick<RegistryRepositoryTagSchema, 'name' | 'path' | 'location'>[]>()(
       this,
-      `projects/${pId}/registry/repositories/${rId}/tags`,
+      endpoint`projects/${projectId}/registry/repositories/${repositoryId}/tags`,
       options,
     );
   }
 
   removeRepository(projectId: string | number, repositoryId: number, options?: Sudo) {
-    const [pId, rId] = [projectId, repositoryId].map(encodeURIComponent);
-
-    return RequestHelper.del()(this, `projects/${pId}/registry/repositories/${rId}`, options);
+    return RequestHelper.del()(
+      this,
+      endpoint`projects/${projectId}/registry/repositories/${repositoryId}`,
+      options,
+    );
   }
 
   removeTag(projectId: string | number, repositoryId: number, tagName: string, options?: Sudo) {
-    const [pId, rId, tId] = [projectId, repositoryId, tagName].map(encodeURIComponent);
-
     return RequestHelper.del()(
       this,
-      `projects/${pId}/registry/repositories/${rId}/tags/${tId}`,
+      endpoint`projects/${projectId}/registry/repositories/${repositoryId}/tags/${tagName}`,
       options,
     );
   }
@@ -87,20 +79,20 @@ export class ContainerRegistry<C extends boolean = false> extends BaseResource<C
     nameRegexDelete: string,
     options?: Sudo & { nameRegexKeep: string; keepN: string; olderThan: string },
   ) {
-    const [pId, rId] = [projectId, repositoryId].map(encodeURIComponent);
-
-    return RequestHelper.del()(this, `projects/${pId}/registry/repositories/${rId}/tags`, {
-      nameRegexDelete,
-      ...options,
-    });
+    return RequestHelper.del()(
+      this,
+      endpoint`projects/${projectId}/registry/repositories/${repositoryId}/tags`,
+      {
+        nameRegexDelete,
+        ...options,
+      },
+    );
   }
 
   showTag(projectId: string | number, repositoryId: number, tagName: string, options?: Sudo) {
-    const [pId, rId, tId] = [projectId, repositoryId, tagName].map(encodeURIComponent);
-
     return RequestHelper.get<RegistryRepositoryTagSchema>()(
       this,
-      `projects/${pId}/registry/repositories/${rId}/tags/${tId}`,
+      endpoint`projects/${projectId}/registry/repositories/${repositoryId}/tags/${tagName}`,
       options,
     );
   }

--- a/packages/core/src/resources/DeployKeys.ts
+++ b/packages/core/src/resources/DeployKeys.ts
@@ -4,6 +4,7 @@ import {
   Sudo,
   BaseRequestOptions,
   PaginatedRequestOptions,
+  endpoint,
 } from '../infrastructure';
 
 export interface DeployKeySchema extends Record<string, unknown> {
@@ -16,16 +17,18 @@ export interface DeployKeySchema extends Record<string, unknown> {
 
 export class DeployKeys<C extends boolean = false> extends BaseResource<C> {
   add(projectId: string | number, options?: Sudo) {
-    const pId = encodeURIComponent(projectId);
-
-    return RequestHelper.post<DeployKeySchema>()(this, `projects/${pId}/deploy_keys`, options);
+    return RequestHelper.post<DeployKeySchema>()(
+      this,
+      endpoint`projects/${projectId}/deploy_keys`,
+      options,
+    );
   }
 
   all({ projectId, ...options }: { projectId?: string | number } & PaginatedRequestOptions = {}) {
     let url: string;
 
     if (projectId) {
-      url = `projects/${encodeURIComponent(projectId)}/deploy_keys`;
+      url = endpoint`projects/${projectId}/deploy_keys`;
     } else {
       url = 'deploy_keys';
     }
@@ -34,37 +37,29 @@ export class DeployKeys<C extends boolean = false> extends BaseResource<C> {
   }
 
   edit(projectId: string | number, keyId: number, options?: BaseRequestOptions) {
-    const [pId, kId] = [projectId, keyId].map(encodeURIComponent);
-
     return RequestHelper.put<DeployKeySchema>()(
       this,
-      `projects/${pId}/deploy_keys/${kId}`,
+      endpoint`projects/${projectId}/deploy_keys/${keyId}`,
       options,
     );
   }
 
   enable(projectId: string | number, keyId: number, options?: Sudo) {
-    const [pId, kId] = [projectId, keyId].map(encodeURIComponent);
-
     return RequestHelper.post<Omit<DeployKeySchema, 'can_push'>>()(
       this,
-      `projects/${pId}/deploy_keys/${kId}/enable`,
+      endpoint`projects/${projectId}/deploy_keys/${keyId}/enable`,
       options,
     );
   }
 
   remove(projectId: string | number, keyId: number, options?: Sudo) {
-    const [pId, kId] = [projectId, keyId].map(encodeURIComponent);
-
-    return RequestHelper.del()(this, `projects/${pId}/deploy_keys/${kId}`, options);
+    return RequestHelper.del()(this, endpoint`projects/${projectId}/deploy_keys/${keyId}`, options);
   }
 
   show(projectId: string | number, keyId: number, options?: Sudo) {
-    const [pId, kId] = [projectId, keyId].map(encodeURIComponent);
-
     return RequestHelper.get<DeployKeySchema>()(
       this,
-      `projects/${pId}/deploy_keys/${kId}`,
+      endpoint`projects/${projectId}/deploy_keys/${keyId}`,
       options,
     );
   }

--- a/packages/core/src/resources/Deployments.ts
+++ b/packages/core/src/resources/Deployments.ts
@@ -1,5 +1,5 @@
 import { BaseResource } from '@gitbeaker/requester-utils';
-import { RequestHelper, PaginatedRequestOptions, Sudo } from '../infrastructure';
+import { RequestHelper, PaginatedRequestOptions, Sudo, endpoint } from '../infrastructure';
 import { CommitSchema } from './Commits';
 import { PipelineSchema } from './Pipelines';
 import { UserSchema } from './Users';
@@ -41,9 +41,11 @@ export type DeploymentSchema = {
 
 export class Deployments<C extends boolean = false> extends BaseResource<C> {
   all(projectId: string | number, options?: PaginatedRequestOptions) {
-    const pId = encodeURIComponent(projectId);
-
-    return RequestHelper.get<DeploymentSchema[]>()(this, `projects/${pId}/deployments`, options);
+    return RequestHelper.get<DeploymentSchema[]>()(
+      this,
+      endpoint`projects/${projectId}/deployments`,
+      options,
+    );
   }
 
   create(
@@ -55,43 +57,43 @@ export class Deployments<C extends boolean = false> extends BaseResource<C> {
     status: DeploymentStatus,
     options?: Sudo,
   ) {
-    const [pId] = [projectId].map(encodeURIComponent);
-
-    return RequestHelper.post<DeploymentSchema>()(this, `projects/${pId}/deployments`, {
-      environment,
-      sha,
-      ref,
-      tag,
-      status,
-      ...options,
-    });
+    return RequestHelper.post<DeploymentSchema>()(
+      this,
+      endpoint`projects/${projectId}/deployments`,
+      {
+        environment,
+        sha,
+        ref,
+        tag,
+        status,
+        ...options,
+      },
+    );
   }
 
   edit(projectId: string | number, deploymentId: number, status: DeploymentStatus, options?: Sudo) {
-    const [pId, dId] = [projectId, deploymentId].map(encodeURIComponent);
-
-    return RequestHelper.put<DeploymentSchema>()(this, `projects/${pId}/deployments/${dId}`, {
-      status,
-      ...options,
-    });
+    return RequestHelper.put<DeploymentSchema>()(
+      this,
+      endpoint`projects/${projectId}/deployments/${deploymentId}`,
+      {
+        status,
+        ...options,
+      },
+    );
   }
 
   show(projectId: string | number, deploymentId: number, options?: Sudo) {
-    const [pId, dId] = [projectId, deploymentId].map(encodeURIComponent);
-
     return RequestHelper.get<DeploymentSchema>()(
       this,
-      `projects/${pId}/deployments/${dId}`,
+      endpoint`projects/${projectId}/deployments/${deploymentId}`,
       options,
     );
   }
 
   mergeRequests(projectId: string | number, deploymentId: number, options?: Sudo) {
-    const [pId, dId] = [projectId, deploymentId].map(encodeURIComponent);
-
     return RequestHelper.get<MergeRequestSchema[]>()(
       this,
-      `projects/${pId}/deployments/${dId}/merge_requests`,
+      endpoint`projects/${projectId}/deployments/${deploymentId}/merge_requests`,
       options,
     );
   }

--- a/packages/core/src/resources/Environments.ts
+++ b/packages/core/src/resources/Environments.ts
@@ -1,6 +1,7 @@
 import { BaseResource } from '@gitbeaker/requester-utils';
 import {
   BaseRequestOptions,
+  endpoint,
   PaginatedRequestOptions,
   RequestHelper,
   Sudo,
@@ -21,56 +22,49 @@ export interface EnvironmentSchema extends Record<string, unknown> {
 
 export class Environments<C extends boolean = false> extends BaseResource<C> {
   all(projectId: string | number, options?: PaginatedRequestOptions) {
-    const pId = encodeURIComponent(projectId);
-
     return RequestHelper.get<Omit<EnvironmentSchema, 'last_deployment' | 'deployable'>[]>()(
       this,
-      `projects/${pId}/environments`,
+      endpoint`projects/${projectId}/environments`,
       options,
     );
   }
 
   show(projectId: string | number, environmentId: number, options?: Sudo) {
-    const [pId, eId] = [projectId, environmentId].map(encodeURIComponent);
     return RequestHelper.get<EnvironmentSchema>()(
       this,
-      `projects/${pId}/environments/${eId}`,
+      endpoint`projects/${projectId}/environments/${environmentId}`,
       options,
     );
   }
 
   create(projectId: string | number, options?: BaseRequestOptions) {
-    const pId = encodeURIComponent(projectId);
-
     return RequestHelper.post<Omit<EnvironmentSchema, 'last_deployment' | 'deployable'>>()(
       this,
-      `projects/${pId}/environments`,
+      endpoint`projects/${projectId}/environments`,
       options,
     );
   }
 
   edit(projectId: string | number, environmentId: number, options?: BaseRequestOptions) {
-    const [pId, eId] = [projectId, environmentId].map(encodeURIComponent);
-
     return RequestHelper.put<Omit<EnvironmentSchema, 'last_deployment' | 'deployable'>>()(
       this,
-      `projects/${pId}/environments/${eId}`,
+      endpoint`projects/${projectId}/environments/${environmentId}`,
       options,
     );
   }
 
   remove(projectId: string | number, environmentId: number, options?: Sudo) {
-    const [pId, eId] = [projectId, environmentId].map(encodeURIComponent);
-
-    return RequestHelper.del()(this, `projects/${pId}/environments/${eId}`, options);
+    return RequestHelper.del()(
+      this,
+      endpoint`projects/${projectId}/environments/${environmentId}`,
+      options,
+    );
   }
 
   stop(projectId: string | number, environmentId: number, options?: Sudo) {
-    const [pId, eId] = [projectId, environmentId].map(encodeURIComponent);
-
     return RequestHelper.post<Omit<EnvironmentSchema, 'last_deployment' | 'deployable'>>()(
       this,
-      `projects/${pId}/environments/${eId}/stop`,
+      endpoint`projects/${projectId}/environments/${environmentId}/stop`,
       options,
     );
   }

--- a/packages/core/src/resources/EpicIssues.ts
+++ b/packages/core/src/resources/EpicIssues.ts
@@ -2,6 +2,7 @@ import { BaseResource } from '@gitbeaker/requester-utils';
 import { IssueSchema } from './Issues';
 import {
   BaseRequestOptions,
+  endpoint,
   PaginatedRequestOptions,
   RequestHelper,
   Sudo,
@@ -14,21 +15,17 @@ export interface EpicIssueSchema
 
 export class EpicIssues<C extends boolean = false> extends BaseResource<C> {
   all(groupId: string | number, epicIId: number, options?: PaginatedRequestOptions) {
-    const [gId, eId] = [groupId, epicIId].map(encodeURIComponent);
-
     return RequestHelper.get<EpicIssueSchema[]>()(
       this,
-      `groups/${gId}/epics/${eId}/issues`,
+      endpoint`groups/${groupId}/epics/${epicIId}/issues`,
       options,
     );
   }
 
   assign(groupId: string | number, epicIId: number, epicIssueId: number, options?: Sudo) {
-    const [gId, eId, iId] = [groupId, epicIId, epicIssueId].map(encodeURIComponent);
-
     return RequestHelper.post<EpicIssueSchema>()(
       this,
-      `groups/${gId}/epics/${eId}/issues/${iId}`,
+      endpoint`groups/${groupId}/epics/${epicIId}/issues/${epicIssueId}`,
       options,
     );
   }
@@ -39,18 +36,18 @@ export class EpicIssues<C extends boolean = false> extends BaseResource<C> {
     epicIssueId: number,
     options?: BaseRequestOptions,
   ) {
-    const [gId, eId, iId] = [groupId, epicIId, epicIssueId].map(encodeURIComponent);
-
     return RequestHelper.put<EpicIssueSchema>()(
       this,
-      `groups/${gId}/epics/${eId}/issues/${iId}`,
+      endpoint`groups/${groupId}/epics/${epicIId}/issues/${epicIssueId}`,
       options,
     );
   }
 
   remove(groupId: string | number, epicIId: number, epicIssueId: number, options?: Sudo) {
-    const [gId, eId, iId] = [groupId, epicIId, epicIssueId].map(encodeURIComponent);
-
-    return RequestHelper.del()(this, `groups/${gId}/epics/${eId}/issues/${iId}`, options);
+    return RequestHelper.del()(
+      this,
+      endpoint`groups/${groupId}/epics/${epicIId}/issues/${epicIssueId}`,
+      options,
+    );
   }
 }

--- a/packages/core/src/resources/Epics.ts
+++ b/packages/core/src/resources/Epics.ts
@@ -2,6 +2,7 @@ import { BaseResource } from '@gitbeaker/requester-utils';
 import { UserSchema } from './Users';
 import {
   BaseRequestOptions,
+  endpoint,
   PaginatedRequestOptions,
   RequestHelper,
   Sudo,
@@ -47,32 +48,33 @@ export interface EpicSchema extends Record<string, unknown> {
 
 export class Epics<C extends boolean = false> extends BaseResource<C> {
   all(groupId: string | number, options?: PaginatedRequestOptions) {
-    const gId = encodeURIComponent(groupId);
-
-    return RequestHelper.get<EpicSchema[]>()(this, `groups/${gId}/epics`, options);
+    return RequestHelper.get<EpicSchema[]>()(this, endpoint`groups/${groupId}/epics`, options);
   }
 
   create(groupId: string | number, title: string, options?: BaseRequestOptions) {
-    const gId = encodeURIComponent(groupId);
-
-    return RequestHelper.post<EpicSchema>()(this, `groups/${gId}/epics`, { title, ...options });
+    return RequestHelper.post<EpicSchema>()(this, endpoint`groups/${groupId}/epics`, {
+      title,
+      ...options,
+    });
   }
 
   edit(groupId: string | number, epicId: number, options?: BaseRequestOptions) {
-    const [gId, eId] = [groupId, epicId].map(encodeURIComponent);
-
-    return RequestHelper.put<EpicSchema>()(this, `groups/${gId}/epics/${eId}`, options);
+    return RequestHelper.put<EpicSchema>()(
+      this,
+      endpoint`groups/${groupId}/epics/${epicId}`,
+      options,
+    );
   }
 
   remove(groupId: string | number, epicId: number, options?: Sudo) {
-    const [gId, eId] = [groupId, epicId].map(encodeURIComponent);
-
-    return RequestHelper.del()(this, `groups/${gId}/epics/${eId}`, options);
+    return RequestHelper.del()(this, endpoint`groups/${groupId}/epics/${epicId}`, options);
   }
 
   show(groupId: string | number, epicId: number, options?: Sudo) {
-    const [gId, eId] = [groupId, epicId].map(encodeURIComponent);
-
-    return RequestHelper.get<EpicSchema>()(this, `groups/${gId}/epics/${eId}`, options);
+    return RequestHelper.get<EpicSchema>()(
+      this,
+      endpoint`groups/${groupId}/epics/${epicId}`,
+      options,
+    );
   }
 }

--- a/packages/core/src/resources/Events.ts
+++ b/packages/core/src/resources/Events.ts
@@ -1,6 +1,6 @@
 import { BaseResource } from '@gitbeaker/requester-utils';
 import { UserSchema } from './Users';
-import { RequestHelper, PaginatedRequestOptions } from '../infrastructure';
+import { RequestHelper, PaginatedRequestOptions, endpoint } from '../infrastructure';
 
 export interface EventOptions {
   action?:
@@ -44,9 +44,7 @@ export class Events<C extends boolean = false> extends BaseResource<C> {
     let url: string;
 
     if (projectId) {
-      const pId = encodeURIComponent(projectId);
-
-      url = `projects/${pId}/events`;
+      url = endpoint`projects/${projectId}/events`;
     } else {
       url = 'events';
     }

--- a/packages/core/src/resources/FeatureFlags.ts
+++ b/packages/core/src/resources/FeatureFlags.ts
@@ -1,6 +1,7 @@
 import { BaseResource } from '@gitbeaker/requester-utils';
 import {
   BaseRequestOptions,
+  endpoint,
   PaginatedRequestOptions,
   RequestHelper,
   Sudo,
@@ -35,9 +36,11 @@ export class FeatureFlags<C extends boolean = false> extends BaseResource<C> {
     projectId: string | number,
     options: { scopes?: 'enabled' | 'disabled' } & PaginatedRequestOptions = {},
   ) {
-    const pId = encodeURIComponent(projectId);
-
-    return RequestHelper.get<FeatureFlagSchema[]>()(this, `projects/${pId}/feature_flags`, options);
+    return RequestHelper.get<FeatureFlagSchema[]>()(
+      this,
+      endpoint`projects/${projectId}/feature_flags`,
+      options,
+    );
   }
 
   create(
@@ -46,37 +49,37 @@ export class FeatureFlags<C extends boolean = false> extends BaseResource<C> {
     version: string,
     options?: BaseRequestOptions,
   ) {
-    const [pId, fName, ver] = [projectId, flagName, version].map(encodeURIComponent);
-
-    return RequestHelper.post<FeatureFlagSchema>()(this, `projects/${pId}/feature_flags`, {
-      version: ver,
-      name: fName,
-      ...options,
-    });
+    return RequestHelper.post<FeatureFlagSchema>()(
+      this,
+      endpoint`projects/${projectId}/feature_flags`,
+      {
+        name: flagName,
+        version,
+        ...options,
+      },
+    );
   }
 
   edit(projectId: string | number, flagName: string, options?: BaseRequestOptions) {
-    const [pId, fName] = [projectId, flagName].map(encodeURIComponent);
-
     return RequestHelper.put<FeatureFlagSchema>()(
       this,
-      `projects/${pId}/feature_flags/${fName}`,
+      endpoint`projects/${projectId}/feature_flags/${flagName}`,
       options,
     );
   }
 
   remove(projectId: string | number, flagName: string, options?: Sudo) {
-    const [pId, fName] = [projectId, flagName].map(encodeURIComponent);
-
-    return RequestHelper.del()(this, `projects/${pId}/feature_flags/${fName}`, options);
+    return RequestHelper.del()(
+      this,
+      endpoint`projects/${projectId}/feature_flags/${flagName}`,
+      options,
+    );
   }
 
   show(projectId: string | number, flagName: string, options?: Sudo) {
-    const [pId, fName] = [projectId, flagName].map(encodeURIComponent);
-
     return RequestHelper.get<FeatureFlagSchema>()(
       this,
-      `projects/${pId}/feature_flags/${fName}`,
+      endpoint`projects/${projectId}/feature_flags/${flagName}`,
       options,
     );
   }

--- a/packages/core/src/resources/FeatureFlags.ts
+++ b/packages/core/src/resources/FeatureFlags.ts
@@ -37,11 +37,7 @@ export class FeatureFlags<C extends boolean = false> extends BaseResource<C> {
   ) {
     const pId = encodeURIComponent(projectId);
 
-    return RequestHelper.get<FeatureFlagSchema[]>()(
-      this,
-      `projects/${pId}/features_flags`,
-      options,
-    );
+    return RequestHelper.get<FeatureFlagSchema[]>()(this, `projects/${pId}/feature_flags`, options);
   }
 
   create(
@@ -52,7 +48,7 @@ export class FeatureFlags<C extends boolean = false> extends BaseResource<C> {
   ) {
     const [pId, fName, ver] = [projectId, flagName, version].map(encodeURIComponent);
 
-    return RequestHelper.post<FeatureFlagSchema>()(this, `projects/${pId}/features_flags`, {
+    return RequestHelper.post<FeatureFlagSchema>()(this, `projects/${pId}/feature_flags`, {
       version: ver,
       name: fName,
       ...options,
@@ -64,7 +60,7 @@ export class FeatureFlags<C extends boolean = false> extends BaseResource<C> {
 
     return RequestHelper.put<FeatureFlagSchema>()(
       this,
-      `projects/${pId}/features_flags/${fName}`,
+      `projects/${pId}/feature_flags/${fName}`,
       options,
     );
   }
@@ -72,7 +68,7 @@ export class FeatureFlags<C extends boolean = false> extends BaseResource<C> {
   remove(projectId: string | number, flagName: string, options?: Sudo) {
     const [pId, fName] = [projectId, flagName].map(encodeURIComponent);
 
-    return RequestHelper.del()(this, `projects/${pId}/features_flags/${fName}`, options);
+    return RequestHelper.del()(this, `projects/${pId}/feature_flags/${fName}`, options);
   }
 
   show(projectId: string | number, flagName: string, options?: Sudo) {
@@ -80,7 +76,7 @@ export class FeatureFlags<C extends boolean = false> extends BaseResource<C> {
 
     return RequestHelper.get<FeatureFlagSchema>()(
       this,
-      `projects/${pId}/features_flags/${fName}`,
+      `projects/${pId}/feature_flags/${fName}`,
       options,
     );
   }

--- a/packages/core/src/resources/FreezePeriods.ts
+++ b/packages/core/src/resources/FreezePeriods.ts
@@ -1,5 +1,5 @@
 import { BaseResource } from '@gitbeaker/requester-utils';
-import { BaseRequestOptions, RequestHelper, Camelize } from '../infrastructure';
+import { BaseRequestOptions, RequestHelper, Camelize, endpoint } from '../infrastructure';
 
 export interface FreezePeriodSchema extends Record<string, unknown> {
   id: number;
@@ -12,21 +12,17 @@ export interface FreezePeriodSchema extends Record<string, unknown> {
 
 export class FreezePeriods<C extends boolean = false> extends BaseResource<C> {
   all(projectId: string | number, options?: BaseRequestOptions) {
-    const pId = encodeURIComponent(projectId);
-
     return RequestHelper.get<FreezePeriodSchema[]>()(
       this,
-      `projects/${pId}/freeze_periods`,
+      endpoint`projects/${projectId}/freeze_periods`,
       options,
     );
   }
 
   show(projectId: string | number, freezePeriodId: number, options?: BaseRequestOptions) {
-    const [pId, fId] = [projectId, freezePeriodId].map(encodeURIComponent);
-
     return RequestHelper.get<FreezePeriodSchema>()(
       this,
-      `projects/${pId}/freeze_periods/${fId}`,
+      endpoint`projects/${projectId}/freeze_periods/${freezePeriodId}`,
       options,
     );
   }
@@ -37,13 +33,15 @@ export class FreezePeriods<C extends boolean = false> extends BaseResource<C> {
     freezeEnd: string,
     options?: Camelize<Pick<FreezePeriodSchema, 'cron_timezone'>> & BaseRequestOptions,
   ) {
-    const pId = encodeURIComponent(projectId);
-
-    return RequestHelper.post<FreezePeriodSchema>()(this, `projects/${pId}/freeze_periods`, {
-      freezeStart,
-      freezeEnd,
-      ...options,
-    });
+    return RequestHelper.post<FreezePeriodSchema>()(
+      this,
+      endpoint`projects/${projectId}/freeze_periods`,
+      {
+        freezeStart,
+        freezeEnd,
+        ...options,
+      },
+    );
   }
 
   edit(
@@ -52,18 +50,18 @@ export class FreezePeriods<C extends boolean = false> extends BaseResource<C> {
     options?: Camelize<Omit<FreezePeriodSchema, 'id' | 'created_at' | 'updated_at'>> &
       BaseRequestOptions,
   ) {
-    const [pId, fId] = [projectId, freezePeriodId].map(encodeURIComponent);
-
     return RequestHelper.put<FreezePeriodSchema>()(
       this,
-      `projects/${pId}/freeze_periods/${fId}`,
+      endpoint`projects/${projectId}/freeze_periods/${freezePeriodId}`,
       options,
     );
   }
 
   delete(projectId: number | string, freezePeriodId: number, options?: BaseRequestOptions) {
-    const [pId, fId] = [projectId, freezePeriodId].map(encodeURIComponent);
-
-    return RequestHelper.del()(this, `projects/${pId}/freeze_periods/${fId}`, options);
+    return RequestHelper.del()(
+      this,
+      endpoint`projects/${projectId}/freeze_periods/${freezePeriodId}`,
+      options,
+    );
   }
 }

--- a/packages/core/src/resources/GeoNodes.ts
+++ b/packages/core/src/resources/GeoNodes.ts
@@ -145,15 +145,11 @@ export class GeoNodes<C extends boolean = false> extends BaseResource<C> {
   }
 
   create(geonodeId: number, options?: BaseRequestOptions) {
-    const gId = encodeURIComponent(geonodeId);
-
-    return RequestHelper.post<GeoNodeSchema>()(this, `geo_nodes/${gId}`, options);
+    return RequestHelper.post<GeoNodeSchema>()(this, `geo_nodes/${geonodeId}`, options);
   }
 
   edit(geonodeId: number, options?: BaseRequestOptions) {
-    const gId = encodeURIComponent(geonodeId);
-
-    return RequestHelper.put<GeoNodeSchema>()(this, `geo_nodes/${gId}`, options);
+    return RequestHelper.put<GeoNodeSchema>()(this, `geo_nodes/${geonodeId}`, options);
   }
 
   failures(options?: BaseRequestOptions) {
@@ -161,27 +157,19 @@ export class GeoNodes<C extends boolean = false> extends BaseResource<C> {
   }
 
   repair(geonodeId: number, options?: Sudo) {
-    const gId = encodeURIComponent(geonodeId);
-
-    return RequestHelper.post<GeoNodeSchema>()(this, `geo_nodes/${gId}/repair`, options);
+    return RequestHelper.post<GeoNodeSchema>()(this, `geo_nodes/${geonodeId}/repair`, options);
   }
 
   remove(geonodeId: number, options?: Sudo) {
-    const gId = encodeURIComponent(geonodeId);
-
-    return RequestHelper.del<GeoNodeSchema>()(this, `geo_nodes/${gId}`, options);
+    return RequestHelper.del<GeoNodeSchema>()(this, `geo_nodes/${geonodeId}`, options);
   }
 
   show(geonodeId: number, options?: Sudo) {
-    const gId = encodeURIComponent(geonodeId);
-
-    return RequestHelper.get<GeoNodeSchema>()(this, `geo_nodes/${gId}`, options);
+    return RequestHelper.get<GeoNodeSchema>()(this, `geo_nodes/${geonodeId}`, options);
   }
 
   status(geonodeId: number, options?: Sudo) {
-    const gId = encodeURIComponent(geonodeId);
-
-    return RequestHelper.get<GeoNodeStatusSchema>()(this, `geo_nodes/${gId}/status`, options);
+    return RequestHelper.get<GeoNodeStatusSchema>()(this, `geo_nodes/${geonodeId}/status`, options);
   }
 
   statuses(options?: PaginatedRequestOptions) {

--- a/packages/core/src/resources/GroupRunners.ts
+++ b/packages/core/src/resources/GroupRunners.ts
@@ -1,11 +1,9 @@
 import { BaseResource } from '@gitbeaker/requester-utils';
-import { PaginatedRequestOptions, ShowExpanded, RequestHelper } from '../infrastructure';
+import { PaginatedRequestOptions, ShowExpanded, RequestHelper, endpoint } from '../infrastructure';
 import { RunnerSchema } from './Runners';
 
 export class GroupRunners<C extends boolean = false> extends BaseResource<C> {
   all(groupId: string | number, options?: PaginatedRequestOptions & ShowExpanded) {
-    const gId = encodeURIComponent(groupId);
-
-    return RequestHelper.get<RunnerSchema[]>()(this, `groups/${gId}/runners`, options);
+    return RequestHelper.get<RunnerSchema[]>()(this, endpoint`groups/${groupId}/runners`, options);
   }
 }

--- a/packages/core/src/resources/Groups.ts
+++ b/packages/core/src/resources/Groups.ts
@@ -5,6 +5,7 @@ import {
   ShowExpanded,
   RequestHelper,
   Sudo,
+  endpoint,
 } from '../infrastructure';
 import { ProjectSchema } from './Projects';
 
@@ -74,9 +75,7 @@ export class Groups<C extends boolean = false> extends BaseResource<C> {
     provider: string,
     options?: Sudo & ShowExpanded,
   ) {
-    const gId = encodeURIComponent(groupId);
-
-    return RequestHelper.post()(this, `groups/${gId}/ldap_group_links`, {
+    return RequestHelper.post()(this, endpoint`groups/${groupId}/ldap_group_links`, {
       cn,
       groupAccess,
       provider,
@@ -85,21 +84,19 @@ export class Groups<C extends boolean = false> extends BaseResource<C> {
   }
 
   edit(groupId: string | number, options?: BaseRequestOptions) {
-    const gId = encodeURIComponent(groupId);
-
-    return RequestHelper.put<GroupSchema>()(this, `groups/${gId}`, options);
+    return RequestHelper.put<GroupSchema>()(this, endpoint`groups/${groupId}`, options);
   }
 
   projects(groupId: string | number, options?: BaseRequestOptions) {
-    const gId = encodeURIComponent(groupId);
-
-    return RequestHelper.get<ProjectSchema[]>()(this, `groups/${gId}/projects`, options);
+    return RequestHelper.get<ProjectSchema[]>()(
+      this,
+      endpoint`groups/${groupId}/projects`,
+      options,
+    );
   }
 
   remove(groupId: string | number, options?: Sudo & ShowExpanded) {
-    const gId = encodeURIComponent(groupId);
-
-    return RequestHelper.del()(this, `groups/${gId}`, options);
+    return RequestHelper.del()(this, endpoint`groups/${groupId}`, options);
   }
 
   removeLDAPLink(
@@ -125,21 +122,15 @@ export class Groups<C extends boolean = false> extends BaseResource<C> {
   }
 
   show(groupId: string | number, options?: BaseRequestOptions) {
-    const gId = encodeURIComponent(groupId);
-
-    return RequestHelper.get<GroupDetailSchema>()(this, `groups/${gId}`, options);
+    return RequestHelper.get<GroupDetailSchema>()(this, endpoint`groups/${groupId}`, options);
   }
 
   subgroups(groupId: string | number, options?: PaginatedRequestOptions) {
-    const gId = encodeURIComponent(groupId);
-
-    return RequestHelper.get()(this, `groups/${gId}/subgroups`, options);
+    return RequestHelper.get()(this, endpoint`groups/${groupId}/subgroups`, options);
   }
 
   syncLDAP(groupId: string | number, options?: Sudo & ShowExpanded) {
-    const gId = encodeURIComponent(groupId);
-
-    return RequestHelper.post()(this, `groups/${gId}/ldap_sync`, options);
+    return RequestHelper.post()(this, endpoint`groups/${groupId}/ldap_sync`, options);
   }
 
   transferProject(
@@ -147,8 +138,6 @@ export class Groups<C extends boolean = false> extends BaseResource<C> {
     projectId: string | number,
     options?: BaseRequestOptions & ShowExpanded,
   ) {
-    const [gId, pId] = [groupId, projectId].map(encodeURIComponent);
-
-    return RequestHelper.post()(this, `groups/${gId}/projects/${pId}`, options);
+    return RequestHelper.post()(this, endpoint`groups/${groupId}/projects/${projectId}`, options);
   }
 }

--- a/packages/core/src/resources/Issues.ts
+++ b/packages/core/src/resources/Issues.ts
@@ -4,6 +4,7 @@ import { MergeRequestSchema } from './MergeRequests';
 import { MilestoneSchema } from '../templates/types';
 import {
   BaseRequestOptions,
+  endpoint,
   PaginatedRequestOptions,
   RequestHelper,
   Sudo,
@@ -95,11 +96,9 @@ export interface IssueSchema extends Record<string, unknown> {
 
 export class Issues<C extends boolean = false> extends BaseResource<C> {
   addSpentTime(projectId: string | number, issueIid: number, duration: string, options?: Sudo) {
-    const [pId, iId] = [projectId, issueIid].map(encodeURIComponent);
-
     return RequestHelper.post<TimeStatsSchema>()(
       this,
-      `projects/${pId}/issues/${iId}/add_spent_time`,
+      endpoint`projects/${projectId}/issues/${issueIid}/add_spent_time`,
       {
         duration,
         ...options,
@@ -108,11 +107,9 @@ export class Issues<C extends boolean = false> extends BaseResource<C> {
   }
 
   addTimeEstimate(projectId: string | number, issueIid: number, duration: string, options?: Sudo) {
-    const [pId, iId] = [projectId, issueIid].map(encodeURIComponent);
-
     return RequestHelper.post<TimeStatsSchema>()(
       this,
-      `projects/${pId}/issues/${iId}/time_estimate`,
+      endpoint`projects/${projectId}/issues/${issueIid}/time_estimate`,
       {
         duration,
         ...options,
@@ -128,9 +125,9 @@ export class Issues<C extends boolean = false> extends BaseResource<C> {
     let url: string;
 
     if (projectId) {
-      url = `projects/${encodeURIComponent(projectId)}/issues`;
+      url = endpoint`projects/${projectId}/issues`;
     } else if (groupId) {
-      url = `groups/${encodeURIComponent(groupId)}/issues`;
+      url = endpoint`groups/${groupId}/issues`;
     } else {
       url = 'issues';
     }
@@ -139,25 +136,23 @@ export class Issues<C extends boolean = false> extends BaseResource<C> {
   }
 
   create(projectId: string | number, options?: BaseRequestOptions) {
-    const pId = encodeURIComponent(projectId);
-
-    return RequestHelper.post<IssueSchema>()(this, `projects/${pId}/issues`, options);
+    return RequestHelper.post<IssueSchema>()(this, endpoint`projects/${projectId}/issues`, options);
   }
 
   closedBy(projectId: string | number, issueIid: number, options?: BaseRequestOptions) {
-    const [pId, iId] = [projectId, issueIid].map(encodeURIComponent);
-
     return RequestHelper.get<MergeRequestSchema[]>()(
       this,
-      `projects/${pId}/issues/${iId}/closed_by`,
+      endpoint`projects/${projectId}/issues/${issueIid}/closed_by`,
       options,
     );
   }
 
   edit(projectId: string | number, issueIid: number, options?: BaseRequestOptions) {
-    const [pId, iId] = [projectId, issueIid].map(encodeURIComponent);
-
-    return RequestHelper.put<IssueSchema>()(this, `projects/${pId}/issues/${iId}`, options);
+    return RequestHelper.put<IssueSchema>()(
+      this,
+      endpoint`projects/${projectId}/issues/${issueIid}`,
+      options,
+    );
   }
 
   // TODO move
@@ -168,39 +163,39 @@ export class Issues<C extends boolean = false> extends BaseResource<C> {
     targetIssueIId: number,
     options?: BaseRequestOptions,
   ) {
-    const [pId, iIId] = [projectId, issueIId].map(encodeURIComponent);
     const [targetPId, targetIId] = [targetProjectId, targetIssueIId].map(encodeURIComponent);
 
-    return RequestHelper.post<IssueLinkSchema>()(this, `projects/${pId}/issues/${iIId}/links`, {
-      targetProjectId: targetPId,
-      targetIssueIid: targetIId,
-      ...options,
-    });
+    return RequestHelper.post<IssueLinkSchema>()(
+      this,
+      endpoint`projects/${projectId}/issues/${issueIId}/links`,
+      {
+        targetProjectId: targetPId,
+        targetIssueIid: targetIId,
+        ...options,
+      },
+    );
   }
 
   // TODO move
   links(projectId: string | number, issueIid: number) {
-    const [pId, iId] = [projectId, issueIid].map(encodeURIComponent);
-
-    return RequestHelper.get<IssueLinkSchema[]>()(this, `projects/${pId}/issues/${iId}/links`);
+    return RequestHelper.get<IssueLinkSchema[]>()(
+      this,
+      endpoint`projects/${projectId}/issues/${issueIid}/links`,
+    );
   }
 
   participants(projectId: string | number, issueIid: number, options?: Sudo) {
-    const [pId, iId] = [projectId, issueIid].map(encodeURIComponent);
-
     return RequestHelper.get<Omit<UserSchema, 'created_at'>>()(
       this,
-      `projects/${pId}/issues/${iId}/participants`,
+      endpoint`projects/${projectId}/issues/${issueIid}/participants`,
       options,
     );
   }
 
   relatedMergeRequests(projectId: string | number, issueIid: number, options?: BaseRequestOptions) {
-    const [pId, iId] = [projectId, issueIid].map(encodeURIComponent);
-
     return RequestHelper.get<MergeRequestSchema>()(
       this,
-      `projects/${pId}/issues/${iId}/related_merge_requests`,
+      endpoint`projects/${projectId}/issues/${issueIid}/related_merge_requests`,
       options,
     );
   }
@@ -212,71 +207,63 @@ export class Issues<C extends boolean = false> extends BaseResource<C> {
     issueLinkId: string | number,
     options?: BaseRequestOptions,
   ) {
-    const [pId, iId, iLinkId] = [projectId, issueIid, issueLinkId].map(encodeURIComponent);
-
-    return RequestHelper.del()(this, `projects/${pId}/issues/${iId}/links/${iLinkId}`, {
-      ...options,
-    });
+    return RequestHelper.del()(
+      this,
+      endpoint`projects/${projectId}/issues/${issueIid}/links/${issueLinkId}`,
+      {
+        ...options,
+      },
+    );
   }
 
   remove(projectId: string | number, issueIid: number, options?: Sudo) {
-    const [pId, iId] = [projectId, issueIid].map(encodeURIComponent);
-
-    return RequestHelper.del()(this, `projects/${pId}/issues/${iId}`, options);
+    return RequestHelper.del()(this, endpoint`projects/${projectId}/issues/${issueIid}`, options);
   }
 
   resetSpentTime(projectId: string | number, issueIid: number, options?: BaseRequestOptions) {
-    const [pId, iId] = [projectId, issueIid].map(encodeURIComponent);
-
     return RequestHelper.post<TimeStatsSchema>()(
       this,
-      `projects/${pId}/issues/${iId}/reset_spent_time`,
+      endpoint`projects/${projectId}/issues/${issueIid}/reset_spent_time`,
       options,
     );
   }
 
   resetTimeEstimate(projectId: string | number, issueIid: number, options?: Sudo) {
-    const [pId, iId] = [projectId, issueIid].map(encodeURIComponent);
-
     return RequestHelper.post<TimeStatsSchema>()(
       this,
-      `projects/${pId}/issues/${iId}/reset_time_estimate`,
+      endpoint`projects/${projectId}/issues/${issueIid}/reset_time_estimate`,
       options,
     );
   }
 
   show(projectId: string | number, issueIid: number, options?: Sudo) {
-    const [pId, iId] = [projectId, issueIid].map(encodeURIComponent);
-
-    return RequestHelper.get<IssueSchema>()(this, `projects/${pId}/issues/${iId}`, options);
+    return RequestHelper.get<IssueSchema>()(
+      this,
+      endpoint`projects/${projectId}/issues/${issueIid}`,
+      options,
+    );
   }
 
   subscribe(projectId: string | number, issueIid: number, options?: Sudo) {
-    const [pId, iId] = [projectId, issueIid].map(encodeURIComponent);
-
     return RequestHelper.post<IssueSchema>()(
       this,
-      `projects/${pId}/issues/${iId}/subscribe`,
+      endpoint`projects/${projectId}/issues/${issueIid}/subscribe`,
       options,
     );
   }
 
   timeStats(projectId: string | number, issueIid: number, options?: Sudo) {
-    const [pId, iId] = [projectId, issueIid].map(encodeURIComponent);
-
     return RequestHelper.get<TimeStatsSchema>()(
       this,
-      `projects/${pId}/issues/${iId}/time_stats`,
+      endpoint`projects/${projectId}/issues/${issueIid}/time_stats`,
       options,
     );
   }
 
   unsubscribe(projectId: string | number, issueIid: number, options?: Sudo) {
-    const [pId, iId] = [projectId, issueIid].map(encodeURIComponent);
-
     return RequestHelper.post<IssueSchema>()(
       this,
-      `projects/${pId}/issues/${iId}/unsubscribe`,
+      endpoint`projects/${projectId}/issues/${issueIid}/unsubscribe`,
       options,
     );
   }

--- a/packages/core/src/resources/IssuesStatistics.ts
+++ b/packages/core/src/resources/IssuesStatistics.ts
@@ -1,5 +1,5 @@
 import { BaseResource } from '@gitbeaker/requester-utils';
-import { RequestHelper, BaseRequestOptions } from '../infrastructure';
+import { RequestHelper, BaseRequestOptions, endpoint } from '../infrastructure';
 
 export interface StatisticsSchema extends Record<string, unknown> {
   statistics: {
@@ -20,9 +20,9 @@ export class IssuesStatistics<C extends boolean = false> extends BaseResource<C>
     let url: string;
 
     if (projectId) {
-      url = `projects/${encodeURIComponent(projectId)}/issues_statistics`;
+      url = endpoint`projects/${projectId}/issues_statistics`;
     } else if (groupId) {
-      url = `groups/${encodeURIComponent(groupId)}/issues_statistics`;
+      url = endpoint`groups/${groupId}/issues_statistics`;
     } else {
       url = 'issues_statistics';
     }

--- a/packages/core/src/resources/Jobs.ts
+++ b/packages/core/src/resources/Jobs.ts
@@ -1,6 +1,7 @@
 import { BaseResource } from '@gitbeaker/requester-utils';
 import {
   BaseRequestOptions,
+  endpoint,
   PaginatedRequestOptions,
   RequestHelper,
   Sudo,
@@ -76,15 +77,15 @@ export interface BridgeSchema extends Record<string, unknown> {
 
 export class Jobs<C extends boolean = false> extends BaseResource<C> {
   all(projectId: string | number, options?: PaginatedRequestOptions) {
-    const pId = encodeURIComponent(projectId);
-
-    return RequestHelper.get<JobSchema[]>()(this, `projects/${pId}/jobs`, options);
+    return RequestHelper.get<JobSchema[]>()(this, endpoint`projects/${projectId}/jobs`, options);
   }
 
   cancel(projectId: string | number, jobId: number, options?: Sudo) {
-    const [pId, jId] = [projectId, jobId].map(encodeURIComponent);
-
-    return RequestHelper.post<JobSchema>()(this, `projects/${pId}/jobs/${jId}/cancel`, options);
+    return RequestHelper.post<JobSchema>()(
+      this,
+      endpoint`projects/${projectId}/jobs/${jobId}/cancel`,
+      options,
+    );
   }
 
   // TODO move
@@ -95,19 +96,12 @@ export class Jobs<C extends boolean = false> extends BaseResource<C> {
     { stream = false, ...options }: { stream?: boolean } & BaseRequestOptions = {},
   ) {
     const [pId, jId] = [projectId, jobId].map(encodeURIComponent);
+    const url = `projects/${pId}/jobs/${jId}/artifacts/${artifactPath}`;
 
     if (stream) {
-      return RequestHelper.stream(
-        this,
-        `projects/${pId}/jobs/${jId}/artifacts/${artifactPath}`,
-        options,
-      );
+      return RequestHelper.stream(this, url, options);
     }
-    return RequestHelper.get()(
-      this,
-      `projects/${pId}/jobs/${jId}/artifacts/${artifactPath}`,
-      options,
-    );
+    return RequestHelper.get()(this, url, options);
   }
 
   // TODO move
@@ -119,19 +113,12 @@ export class Jobs<C extends boolean = false> extends BaseResource<C> {
     { stream = false, ...options }: { stream?: boolean } & BaseRequestOptions = {},
   ) {
     const [pId, rId, name] = [projectId, ref, jobName].map(encodeURIComponent);
+    const url = `projects/${pId}/jobs/artifacts/${rId}/raw/${artifactPath}?job=${name}`;
 
     if (stream) {
-      return RequestHelper.stream(
-        this,
-        `projects/${pId}/jobs/artifacts/${rId}/raw/${artifactPath}?job=${name}`,
-        options,
-      );
+      return RequestHelper.stream(this, url, options);
     }
-    return RequestHelper.get()(
-      this,
-      `projects/${pId}/jobs/artifacts/${rId}/raw/${artifactPath}?job=${name}`,
-      options,
-    );
+    return RequestHelper.get()(this, url, options);
   }
 
   // TODO move
@@ -142,31 +129,24 @@ export class Jobs<C extends boolean = false> extends BaseResource<C> {
     { stream = false, ...options }: { stream?: boolean } & BaseRequestOptions = {},
   ) {
     const [pId, rId, name] = [projectId, ref, jobName].map(encodeURIComponent);
+    const url = `projects/${pId}/jobs/artifacts/${rId}/download?job=${name}`;
 
     if (stream) {
-      return RequestHelper.stream(
-        this,
-        `projects/${pId}/jobs/artifacts/${rId}/download?job=${name}`,
-        options,
-      );
+      return RequestHelper.stream(this, url, options);
     }
-    return RequestHelper.get()(
-      this,
-      `projects/${pId}/jobs/artifacts/${rId}/download?job=${name}`,
-      options,
-    );
+    return RequestHelper.get()(this, url, options);
   }
 
   downloadTraceFile(projectId: string | number, jobId: number, options?: Sudo) {
-    const [pId, jId] = [projectId, jobId].map(encodeURIComponent);
-
-    return RequestHelper.get()(this, `projects/${pId}/jobs/${jId}/trace`, options);
+    return RequestHelper.get()(this, endpoint`projects/${projectId}/jobs/${jobId}/trace`, options);
   }
 
   erase(projectId: string | number, jobId: number, options?: Sudo) {
-    const [pId, jId] = [projectId, jobId].map(encodeURIComponent);
-
-    return RequestHelper.post<JobSchema>()(this, `projects/${pId}/jobs/${jId}/erase`, options);
+    return RequestHelper.post<JobSchema>()(
+      this,
+      endpoint`projects/${projectId}/jobs/${jobId}/erase`,
+      options,
+    );
   }
 
   // TODO move
@@ -184,21 +164,27 @@ export class Jobs<C extends boolean = false> extends BaseResource<C> {
   }
 
   play(projectId: string | number, jobId: number, options?: Sudo) {
-    const [pId, jId] = [projectId, jobId].map(encodeURIComponent);
-
-    return RequestHelper.post<JobSchema>()(this, `projects/${pId}/jobs/${jId}/play`, options);
+    return RequestHelper.post<JobSchema>()(
+      this,
+      endpoint`projects/${projectId}/jobs/${jobId}/play`,
+      options,
+    );
   }
 
   retry(projectId: string | number, jobId: number, options?: Sudo) {
-    const [pId, jId] = [projectId, jobId].map(encodeURIComponent);
-
-    return RequestHelper.post<JobSchema>()(this, `projects/${pId}/jobs/${jId}/retry`, options);
+    return RequestHelper.post<JobSchema>()(
+      this,
+      endpoint`projects/${projectId}/jobs/${jobId}/retry`,
+      options,
+    );
   }
 
   show(projectId: string | number, jobId: number, options?: Sudo) {
-    const [pId, jId] = [projectId, jobId].map(encodeURIComponent);
-
-    return RequestHelper.get<JobSchema>()(this, `projects/${pId}/jobs/${jId}`, options);
+    return RequestHelper.get<JobSchema>()(
+      this,
+      endpoint`projects/${projectId}/jobs/${jobId}`,
+      options,
+    );
   }
 
   showPipelineJobs(
@@ -206,11 +192,9 @@ export class Jobs<C extends boolean = false> extends BaseResource<C> {
     pipelineId: number,
     options?: { scope?: JobScope } & Sudo,
   ) {
-    const [pId, ppId] = [projectId, pipelineId].map(encodeURIComponent);
-
     return RequestHelper.get<JobSchema[]>()(
       this,
-      `projects/${pId}/pipelines/${ppId}/jobs`,
+      endpoint`projects/${projectId}/pipelines/${pipelineId}/jobs`,
       options,
     );
   }
@@ -220,11 +204,9 @@ export class Jobs<C extends boolean = false> extends BaseResource<C> {
     pipelineId: number,
     options?: { scope?: JobScope } & Sudo,
   ) {
-    const [pId, ppId] = [projectId, pipelineId].map(encodeURIComponent);
-
     return RequestHelper.get<BridgeSchema>()(
       this,
-      `projects/${pId}/pipelines/${ppId}/bridges`,
+      endpoint`projects/${projectId}/pipelines/${pipelineId}/bridges`,
       options,
     );
   }

--- a/packages/core/src/resources/Keys.ts
+++ b/packages/core/src/resources/Keys.ts
@@ -1,6 +1,6 @@
 import { BaseResource } from '@gitbeaker/requester-utils';
 import { UserExtendedSchema } from './Users';
-import { RequestHelper, Sudo } from '../infrastructure';
+import { endpoint, RequestHelper, Sudo } from '../infrastructure';
 
 export interface KeySchema extends Record<string, unknown> {
   id: number;
@@ -13,8 +13,6 @@ export interface KeySchema extends Record<string, unknown> {
 
 export class Keys<C extends boolean = false> extends BaseResource<C> {
   show(keyId: string, options?: Sudo) {
-    const kId = encodeURIComponent(keyId);
-
-    return RequestHelper.get<KeySchema>()(this, `keys/${kId}`, options);
+    return RequestHelper.get<KeySchema>()(this, endpoint`keys/${keyId}`, options);
   }
 }

--- a/packages/core/src/resources/License.ts
+++ b/packages/core/src/resources/License.ts
@@ -36,8 +36,6 @@ export class License<C extends boolean = false> extends BaseResource<C> {
   }
 
   remove(licenceId: number, options?: Sudo) {
-    const lId = encodeURIComponent(licenceId);
-
-    return RequestHelper.del<LicenseSchema>()(this, `license/${lId}`, options);
+    return RequestHelper.del<LicenseSchema>()(this, `license/${licenceId}`, options);
   }
 }

--- a/packages/core/src/resources/MergeRequestApprovals.ts
+++ b/packages/core/src/resources/MergeRequestApprovals.ts
@@ -1,5 +1,5 @@
 import { BaseResource } from '@gitbeaker/requester-utils';
-import { BaseRequestOptions, RequestHelper, Sudo } from '../infrastructure';
+import { BaseRequestOptions, endpoint, RequestHelper, Sudo } from '../infrastructure';
 import { UserSchema } from './Users';
 import { GroupSchema } from './Groups';
 import { ProtectedBranchSchema } from './ProtectedBranches';
@@ -76,14 +76,12 @@ export class MergeRequestApprovals<C extends boolean = false> extends BaseResour
     projectId: string | number,
     { mergerequestIid, ...options }: { mergerequestIid?: number } & BaseRequestOptions = {},
   ) {
-    const pId = encodeURIComponent(projectId);
     let url: string;
 
     if (mergerequestIid) {
-      const mIid = encodeURIComponent(mergerequestIid);
-      url = `projects/${pId}/merge_requests/${mIid}/approvals`;
+      url = endpoint`projects/${projectId}/merge_requests/${mergerequestIid}/approvals`;
     } else {
-      url = `projects/${pId}/approvals`;
+      url = endpoint`projects/${projectId}/approvals`;
     }
 
     return RequestHelper.get()(this, url, options);
@@ -103,24 +101,23 @@ export class MergeRequestApprovals<C extends boolean = false> extends BaseResour
     projectId: string | number,
     { mergerequestIid, ...options }: { mergerequestIid?: number } & BaseRequestOptions = {},
   ) {
-    const pId = encodeURIComponent(projectId);
     let url: string;
 
     if (mergerequestIid) {
-      const mIid = encodeURIComponent(mergerequestIid);
-
-      url = `projects/${pId}/merge_requests/${mIid}/approvals`;
+      url = endpoint`projects/${projectId}/merge_requests/${mergerequestIid}/approvals`;
     } else {
-      url = `projects/${pId}/approvals`;
+      url = endpoint`projects/${projectId}/approvals`;
     }
 
     return RequestHelper.post()(this, url, options);
   }
 
   approvalRule(projectId: string | number, approvalRuleId: number, options: BaseRequestOptions) {
-    const [pId, aId] = [projectId, approvalRuleId].map(encodeURIComponent);
-
-    return RequestHelper.get()(this, `projects/${pId}/approval_rules/${aId}`, options);
+    return RequestHelper.get()(
+      this,
+      endpoint`projects/${projectId}/approval_rules/${approvalRuleId}`,
+      options,
+    );
   }
 
   approvalRules(
@@ -137,16 +134,14 @@ export class MergeRequestApprovals<C extends boolean = false> extends BaseResour
     projectId: string | number,
     { mergerequestIid, ...options }: { mergerequestIid?: number } & BaseRequestOptions = {},
   ): any {
-    const pId = encodeURIComponent(projectId);
-
     let url: string;
 
     if (mergerequestIid) {
-      const mIid = encodeURIComponent(mergerequestIid);
-      url = `projects/${pId}/merge_requests/${mIid}/approval_rules`;
+      url = endpoint`projects/${projectId}/merge_requests/${mergerequestIid}/approval_rules`;
     } else {
-      url = `projects/${pId}/approval_rules`;
+      url = endpoint`projects/${projectId}/approval_rules`;
     }
+
     return RequestHelper.get()(this, url, options);
   }
 
@@ -173,15 +168,12 @@ export class MergeRequestApprovals<C extends boolean = false> extends BaseResour
       ...options
     }: { mergerequestIid?: number } & ApprovalRulesRequestOptions & BaseRequestOptions = {},
   ) {
-    const pId = encodeURIComponent(projectId);
-
     let url: string;
 
     if (mergerequestIid) {
-      const mIid = encodeURIComponent(mergerequestIid);
-      url = `projects/${pId}/merge_requests/${mIid}/approval_rules`;
+      url = endpoint`projects/${projectId}/merge_requests/${mergerequestIid}/approval_rules`;
     } else {
-      url = `projects/${pId}/approval_rules`;
+      url = endpoint`projects/${projectId}/approval_rules`;
     }
 
     return RequestHelper.post()(this, url, { name, approvalsRequired, ...options });
@@ -192,11 +184,9 @@ export class MergeRequestApprovals<C extends boolean = false> extends BaseResour
     mergerequestIid: number,
     options?: { sha?: string } & BaseRequestOptions,
   ) {
-    const [pId, mIid] = [projectId, mergerequestIid].map(encodeURIComponent);
-
     return RequestHelper.get()(
       this,
-      `projects/${pId}/merge_requests/${mIid}/approval_state`,
+      endpoint`projects/${projectId}/merge_requests/${mergerequestIid}/approval_state`,
       options,
     );
   }
@@ -227,15 +217,12 @@ export class MergeRequestApprovals<C extends boolean = false> extends BaseResour
       ...options
     }: { mergerequestIid?: number } & ApprovalRulesRequestOptions & BaseRequestOptions = {},
   ) {
-    const [pId, aId] = [projectId, approvalRuleId].map(encodeURIComponent);
-
     let url: string;
 
     if (mergerequestIid) {
-      const mIid = encodeURIComponent(mergerequestIid);
-      url = `projects/${pId}/merge_requests/${mIid}/approval_rules/${aId}`;
+      url = endpoint`projects/${projectId}/merge_requests/${mergerequestIid}/approval_rules/${approvalRuleId}`;
     } else {
-      url = `projects/${pId}/approval_rules/${aId}`;
+      url = endpoint`projects/${projectId}/approval_rules/${approvalRuleId}`;
     }
 
     return RequestHelper.put()(this, url, { name, approvalsRequired, ...options });
@@ -258,15 +245,12 @@ export class MergeRequestApprovals<C extends boolean = false> extends BaseResour
     approvalRuleId: number,
     { mergerequestIid }: { mergerequestIid?: number } & Sudo = {},
   ) {
-    const [pId, aId] = [projectId, approvalRuleId].map(encodeURIComponent);
-
     let url: string;
 
     if (mergerequestIid) {
-      const mIid = encodeURIComponent(mergerequestIid);
-      url = `projects/${pId}/merge_requests/${mIid}/approval_rules/${aId}`;
+      url = endpoint`projects/${projectId}/merge_requests/${mergerequestIid}/approval_rules/${approvalRuleId}`;
     } else {
-      url = `projects/${pId}/approval_rules/${aId}`;
+      url = endpoint`projects/${projectId}/approval_rules/${approvalRuleId}`;
     }
 
     return RequestHelper.del()(this, url);
@@ -277,21 +261,17 @@ export class MergeRequestApprovals<C extends boolean = false> extends BaseResour
     mergerequestIid: number,
     options?: { sha?: string } & BaseRequestOptions,
   ) {
-    const [pId, mIid] = [projectId, mergerequestIid].map(encodeURIComponent);
-
     return RequestHelper.post<MergeRequestLevelMergeRequestApprovalSchema>()(
       this,
-      `projects/${pId}/merge_requests/${mIid}/approve`,
+      endpoint`projects/${projectId}/merge_requests/${mergerequestIid}/approve`,
       options,
     );
   }
 
   unapprove(projectId: string | number, mergerequestIid: number, options?: Sudo) {
-    const [pId, mIid] = [projectId, mergerequestIid].map(encodeURIComponent);
-
     return RequestHelper.post<void>()(
       this,
-      `projects/${pId}/merge_requests/${mIid}/unapprove`,
+      endpoint`projects/${projectId}/merge_requests/${mergerequestIid}/unapprove`,
       options,
     );
   }

--- a/packages/core/src/resources/MergeRequests.ts
+++ b/packages/core/src/resources/MergeRequests.ts
@@ -6,6 +6,7 @@ import { CommitSchema, CommitDiffSchema } from './Commits';
 import { MilestoneSchema } from '../templates/types';
 import {
   BaseRequestOptions,
+  endpoint,
   PaginatedRequestOptions,
   RequestHelper,
   Sudo,
@@ -185,11 +186,9 @@ export class MergeRequests<C extends boolean = false> extends BaseResource<C> {
     mergerequestIid: number,
     options?: AcceptMergeRequestOptions & BaseRequestOptions,
   ) {
-    const [pId, mIid] = [projectId, mergerequestIid].map(encodeURIComponent);
-
     return RequestHelper.put<MergeRequestSchema>()(
       this,
-      `projects/${pId}/merge_requests/${mIid}/merge`,
+      endpoint`projects/${projectId}/merge_requests/${mergerequestIid}/merge`,
       options,
     );
   }
@@ -200,11 +199,9 @@ export class MergeRequests<C extends boolean = false> extends BaseResource<C> {
     duration: string,
     options?: Sudo,
   ) {
-    const [pId, mIid] = [projectId, mergerequestIid].map(encodeURIComponent);
-
     return RequestHelper.post<TimeStatsSchema>()(
       this,
-      `projects/${pId}/merge_requests/${mIid}/add_spent_time`,
+      endpoint`projects/${projectId}/merge_requests/${mergerequestIid}/add_spent_time`,
       {
         duration,
         ...options,
@@ -218,11 +215,9 @@ export class MergeRequests<C extends boolean = false> extends BaseResource<C> {
     duration: string,
     options?: Sudo,
   ) {
-    const [pId, mIid] = [projectId, mergerequestIid].map(encodeURIComponent);
-
     return RequestHelper.post<TimeStatsSchema>()(
       this,
-      `projects/${pId}/merge_requests/${mIid}/time_estimate`,
+      endpoint`projects/${projectId}/merge_requests/${mergerequestIid}/time_estimate`,
       {
         duration,
         ...options,
@@ -239,9 +234,9 @@ export class MergeRequests<C extends boolean = false> extends BaseResource<C> {
     let url: string;
 
     if (projectId) {
-      url = `projects/${encodeURIComponent(projectId)}/merge_requests`;
+      url = endpoint`projects/${projectId}/merge_requests`;
     } else if (groupId) {
-      url = `groups/${encodeURIComponent(groupId)}/merge_requests`;
+      url = endpoint`groups/${groupId}/merge_requests`;
     } else {
       url = 'merge_requests';
     }
@@ -250,41 +245,33 @@ export class MergeRequests<C extends boolean = false> extends BaseResource<C> {
   }
 
   cancelOnPipelineSucess(projectId: string | number, mergerequestIid: number, options?: Sudo) {
-    const [pId, mIid] = [projectId, mergerequestIid].map(encodeURIComponent);
-
     return RequestHelper.put<MergeRequestSchema>()(
       this,
-      `projects/${pId}/merge_requests/${mIid}/cancel_merge_when_pipeline_succeeds`,
+      endpoint`projects/${projectId}/merge_requests/${mergerequestIid}/cancel_merge_when_pipeline_succeeds`,
       options,
     );
   }
 
   changes(projectId: string | number, mergerequestIid: number, options?: Sudo) {
-    const [pId, mIid] = [projectId, mergerequestIid].map(encodeURIComponent);
-
     return RequestHelper.get<MergeRequestSchema>()(
       this,
-      `projects/${pId}/merge_requests/${mIid}/changes`,
+      endpoint`projects/${projectId}/merge_requests/${mergerequestIid}/changes`,
       options,
     );
   }
 
   closesIssues(projectId: string | number, mergerequestIid: number, options?: Sudo) {
-    const [pId, mIid] = [projectId, mergerequestIid].map(encodeURIComponent);
-
     return RequestHelper.get<IssueSchema[]>()(
       this,
-      `projects/${pId}/merge_requests/${mIid}/closes_issues`,
+      endpoint`projects/${projectId}/merge_requests/${mergerequestIid}/closes_issues`,
       options,
     );
   }
 
   commits(projectId: string | number, mergerequestIid: number, options?: Sudo) {
-    const [pId, mIid] = [projectId, mergerequestIid].map(encodeURIComponent);
-
     return RequestHelper.get<CommitSchema[]>()(
       this,
-      `projects/${pId}/merge_requests/${mIid}/commits`,
+      endpoint`projects/${projectId}/merge_requests/${mergerequestIid}/commits`,
       options,
     );
   }
@@ -296,14 +283,16 @@ export class MergeRequests<C extends boolean = false> extends BaseResource<C> {
     title: string,
     options?: CreateMergeRequestOptions & BaseRequestOptions,
   ) {
-    const pId = encodeURIComponent(projectId);
-
-    return RequestHelper.post<MergeRequestSchema>()(this, `projects/${pId}/merge_requests`, {
-      sourceBranch,
-      targetBranch,
-      title,
-      ...options,
-    });
+    return RequestHelper.post<MergeRequestSchema>()(
+      this,
+      endpoint`projects/${projectId}/merge_requests`,
+      {
+        sourceBranch,
+        targetBranch,
+        title,
+        ...options,
+      },
+    );
   }
 
   edit(
@@ -311,67 +300,57 @@ export class MergeRequests<C extends boolean = false> extends BaseResource<C> {
     mergerequestIid: number,
     options?: UpdateMergeRequestOptions & BaseRequestOptions,
   ) {
-    const [pId, mIid] = [projectId, mergerequestIid].map(encodeURIComponent);
-
     return RequestHelper.put<MergeRequestSchema>()(
       this,
-      `projects/${pId}/merge_requests/${mIid}`,
+      endpoint`projects/${projectId}/merge_requests/${mergerequestIid}`,
       options,
     );
   }
 
   participants(projectId: string | number, mergerequestIid: number, options?: Sudo) {
-    const [pId, mIid] = [projectId, mergerequestIid].map(encodeURIComponent);
-
     return RequestHelper.get<Omit<UserSchema, 'created_at'>[]>()(
       this,
-      `projects/${pId}/merge_requests/${mIid}/participants`,
+      endpoint`projects/${projectId}/merge_requests/${mergerequestIid}/participants`,
       options,
     );
   }
 
   pipelines(projectId: string | number, mergerequestIid: number, options?: Sudo) {
-    const [pId, mIid] = [projectId, mergerequestIid].map(encodeURIComponent);
-
     return RequestHelper.get<Pick<PipelineSchema, 'id' | 'sha' | 'ref' | 'status'>[]>()(
       this,
-      `projects/${pId}/merge_requests/${mIid}/pipelines`,
+      endpoint`projects/${projectId}/merge_requests/${mergerequestIid}/pipelines`,
       options,
     );
   }
 
   rebase(projectId: string | number, mergerequestIid: number, options?: Sudo) {
-    const [pId, mIid] = [projectId, mergerequestIid].map(encodeURIComponent);
-
     return RequestHelper.put<RebaseSchema>()(
       this,
-      `projects/${pId}/merge_requests/${mIid}/rebase`,
+      endpoint`projects/${projectId}/merge_requests/${mergerequestIid}/rebase`,
       options,
     );
   }
 
   remove(projectId: string | number, mergerequestIid: number, options?: Sudo) {
-    const [pId, mIid] = [projectId, mergerequestIid].map(encodeURIComponent);
-
-    return RequestHelper.del()(this, `projects/${pId}/merge_requests/${mIid}`, options);
+    return RequestHelper.del()(
+      this,
+      endpoint`projects/${projectId}/merge_requests/${mergerequestIid}`,
+      options,
+    );
   }
 
   resetSpentTime(projectId: string | number, mergerequestIid: number, options?: Sudo) {
-    const [pId, mIid] = [projectId, mergerequestIid].map(encodeURIComponent);
-
     return RequestHelper.post<TimeStatsSchema>()(
       this,
-      `projects/${pId}/merge_requests/${mIid}/reset_spent_time`,
+      endpoint`projects/${projectId}/merge_requests/${mergerequestIid}/reset_spent_time`,
       options,
     );
   }
 
   resetTimeEstimate(projectId: string | number, mergerequestIid: number, options?: Sudo) {
-    const [pId, mIid] = [projectId, mergerequestIid].map(encodeURIComponent);
-
     return RequestHelper.post<TimeStatsSchema>()(
       this,
-      `projects/${pId}/merge_requests/${mIid}/reset_time_estimate`,
+      endpoint`projects/${projectId}/merge_requests/${mergerequestIid}/reset_time_estimate`,
       options,
     );
   }
@@ -381,61 +360,49 @@ export class MergeRequests<C extends boolean = false> extends BaseResource<C> {
     mergerequestIid: number,
     options?: ShowMergeRequestOptions & BaseRequestOptions,
   ) {
-    const [pId, mIid] = [projectId, mergerequestIid].map(encodeURIComponent);
-
     return RequestHelper.get<MergeRequestSchema>()(
       this,
-      `projects/${pId}/merge_requests/${mIid}`,
+      endpoint`projects/${projectId}/merge_requests/${mergerequestIid}`,
       options,
     );
   }
 
   subscribe(projectId: string | number, mergerequestIid: number, options?: Sudo) {
-    const [pId, mIid] = [projectId, mergerequestIid].map(encodeURIComponent);
-
     return RequestHelper.post<MergeRequestSchema>()(
       this,
-      `projects/${pId}/merge_requests/${mIid}/subscribe`,
+      endpoint`projects/${projectId}/merge_requests/${mergerequestIid}/subscribe`,
       options,
     );
   }
 
   timeStats(projectId: string | number, mergerequestIid: number, options?: Sudo) {
-    const [pId, mIid] = [projectId, mergerequestIid].map(encodeURIComponent);
-
     return RequestHelper.get<TimeStatsSchema>()(
       this,
-      `projects/${pId}/merge_requests/${mIid}/time_stats`,
+      endpoint`projects/${projectId}/merge_requests/${mergerequestIid}/time_stats`,
       options,
     );
   }
 
   version(projectId: string | number, mergerequestIid: number, versionId: number, options?: Sudo) {
-    const [pId, mIid, vId] = [projectId, mergerequestIid, versionId].map(encodeURIComponent);
-
     return RequestHelper.get<DiffSchema>()(
       this,
-      `projects/${pId}/merge_requests/${mIid}/versions/${vId}`,
+      endpoint`projects/${projectId}/merge_requests/${mergerequestIid}/versions/${versionId}`,
       options,
     );
   }
 
   versions(projectId: string | number, mergerequestIid: number, options?: Sudo) {
-    const [pId, mIid] = [projectId, mergerequestIid].map(encodeURIComponent);
-
     return RequestHelper.get<DiffSchema[]>()(
       this,
-      `projects/${pId}/merge_requests/${mIid}/versions`,
+      endpoint`projects/${projectId}/merge_requests/${mergerequestIid}/versions`,
       options,
     );
   }
 
   unsubscribe(projectId: string | number, mergerequestIid: number, options?: Sudo) {
-    const [pId, mIid] = [projectId, mergerequestIid].map(encodeURIComponent);
-
     return RequestHelper.post<MergeRequestSchema>()(
       this,
-      `projects/${pId}/merge_requests/${mIid}/unsubscribe`,
+      endpoint`projects/${projectId}/merge_requests/${mergerequestIid}/unsubscribe`,
       options,
     );
   }

--- a/packages/core/src/resources/Namespaces.ts
+++ b/packages/core/src/resources/Namespaces.ts
@@ -1,5 +1,5 @@
 import { BaseResource } from '@gitbeaker/requester-utils';
-import { RequestHelper, PaginatedRequestOptions, Sudo } from '../infrastructure';
+import { RequestHelper, PaginatedRequestOptions, Sudo, endpoint } from '../infrastructure';
 
 export interface NamespaceSchema extends Record<string, unknown> {
   id: number;
@@ -23,8 +23,6 @@ export class Namespaces<C extends boolean = false> extends BaseResource<C> {
   }
 
   show(namespaceId: string | number, options?: { search?: string } & Sudo) {
-    const nId = encodeURIComponent(namespaceId);
-
-    return RequestHelper.get<NamespaceSchema>()(this, `namespaces/${nId}`, options);
+    return RequestHelper.get<NamespaceSchema>()(this, endpoint`namespaces/${namespaceId}`, options);
   }
 }

--- a/packages/core/src/resources/NotificationSettings.ts
+++ b/packages/core/src/resources/NotificationSettings.ts
@@ -1,5 +1,10 @@
 import { BaseResource } from '@gitbeaker/requester-utils';
-import { BaseRequestOptions, PaginatedRequestOptions, RequestHelper } from '../infrastructure';
+import {
+  BaseRequestOptions,
+  endpoint,
+  PaginatedRequestOptions,
+  RequestHelper,
+} from '../infrastructure';
 
 // TODO: Add missing functions
 
@@ -16,13 +21,20 @@ export interface NotificationSettingSchema extends Record<string, unknown> {
   notification_email: string;
 }
 
-function url({ projectId, groupId }) {
-  let uri = '';
+interface ScopedURLOptions {
+  projectId?: string | number;
+  groupId?: string | number;
+}
+
+function url({ projectId, groupId }: ScopedURLOptions) {
+  let uri: string;
 
   if (projectId) {
-    uri += `projects/${encodeURIComponent(projectId)}/`;
+    uri = endpoint`projects/${projectId}/`;
   } else if (groupId) {
-    uri += `groups/${encodeURIComponent(groupId)}/`;
+    uri = endpoint`groups/${groupId}/`;
+  } else {
+    uri = '';
   }
 
   return `${uri}notification_settings`;
@@ -37,7 +49,7 @@ export class NotificationSettings<C extends boolean = false> extends BaseResourc
     PaginatedRequestOptions = {}) {
     return RequestHelper.get<NotificationSettingSchema[]>()(
       this,
-      url({ groupId, projectId }),
+      url({ groupId, projectId } as ScopedURLOptions),
       options,
     );
   }
@@ -53,7 +65,7 @@ export class NotificationSettings<C extends boolean = false> extends BaseResourc
     BaseRequestOptions = {}) {
     return RequestHelper.put<NotificationSettingSchema>()(
       this,
-      url({ groupId, projectId }),
+      url({ groupId, projectId } as ScopedURLOptions),
       options,
     );
   }

--- a/packages/core/src/resources/Packages.ts
+++ b/packages/core/src/resources/Packages.ts
@@ -1,6 +1,6 @@
 import { BaseResource } from '@gitbeaker/requester-utils';
 import { PipelineSchema } from './Pipelines';
-import { PaginatedRequestOptions, RequestHelper, Sudo } from '../infrastructure';
+import { endpoint, PaginatedRequestOptions, RequestHelper, Sudo } from '../infrastructure';
 
 export interface PackageSchema extends Record<string, unknown> {
   id: number;
@@ -30,9 +30,9 @@ export class Packages<C extends boolean = false> extends BaseResource<C> {
     let url: string;
 
     if (projectId) {
-      url = `projects/${encodeURIComponent(projectId)}/packages`;
+      url = endpoint`projects/${projectId}/packages`;
     } else if (groupId) {
-      url = `groups/${encodeURIComponent(groupId)}/packages`;
+      url = endpoint`groups/${groupId}/packages`;
     } else {
       throw new Error('projectId or groupId must be passed');
     }
@@ -41,33 +41,33 @@ export class Packages<C extends boolean = false> extends BaseResource<C> {
   }
 
   remove(projectId: string | number, packageId: number, options?: Sudo) {
-    const [pId, pkgId] = [projectId, packageId].map(encodeURIComponent);
-
-    return RequestHelper.del()(this, `projects/${pId}/packages/${pkgId}`, options);
+    return RequestHelper.del()(
+      this,
+      endpoint`projects/${projectId}/packages/${packageId}`,
+      options,
+    );
   }
 
   removeFile(projectId: string | number, packageId: number, projectFileId: number, options?: Sudo) {
-    const [pId, pkgId, pfId] = [projectId, packageId, projectFileId].map(encodeURIComponent);
-
     return RequestHelper.del()(
       this,
-      `projects/${pId}/packages/${pkgId}/package_files/${pfId}`,
+      endpoint`projects/${projectId}/packages/${packageId}/package_files/${projectFileId}`,
       options,
     );
   }
 
   show(projectId: string | number, packageId: number, options?: Sudo) {
-    const [pId, pkgId] = [projectId, packageId].map(encodeURIComponent);
-
-    return RequestHelper.get<PackageSchema>()(this, `projects/${pId}/packages/${pkgId}`, options);
+    return RequestHelper.get<PackageSchema>()(
+      this,
+      endpoint`projects/${projectId}/packages/${packageId}`,
+      options,
+    );
   }
 
   showFiles(projectId: string | number, packageId: number, options?: Sudo) {
-    const [pId, pkgId] = [projectId, packageId].map(encodeURIComponent);
-
     return RequestHelper.get<PackageFileSchema[]>()(
       this,
-      `projects/${pId}/packages/${pkgId}/package_files`,
+      endpoint`projects/${projectId}/packages/${packageId}/package_files`,
       options,
     );
   }

--- a/packages/core/src/resources/PagesDomains.ts
+++ b/packages/core/src/resources/PagesDomains.ts
@@ -1,6 +1,7 @@
 import { BaseResource } from '@gitbeaker/requester-utils';
 import {
   BaseRequestOptions,
+  endpoint,
   PaginatedRequestOptions,
   RequestHelper,
   Sudo,
@@ -21,43 +22,43 @@ export interface PagesDomainSchema extends Record<string, unknown> {
 
 export class PagesDomains<C extends boolean = false> extends BaseResource<C> {
   all({ projectId, ...options }: { projectId?: string | number } & PaginatedRequestOptions = {}) {
-    const url = projectId ? `projects/${encodeURIComponent(projectId)}/` : '';
+    const url = projectId ? endpoint`projects/${projectId}/` : '';
 
     return RequestHelper.get<PagesDomainSchema[]>()(this, `${url}pages/domains`, options);
   }
 
   create(projectId: string | number, domain: string, options?: BaseRequestOptions) {
-    const pId = encodeURIComponent(projectId);
-
-    return RequestHelper.post<PagesDomainSchema>()(this, `projects/${pId}/pages/domains`, {
-      domain,
-      ...options,
-    });
+    return RequestHelper.post<PagesDomainSchema>()(
+      this,
+      endpoint`projects/${projectId}/pages/domains`,
+      {
+        domain,
+        ...options,
+      },
+    );
   }
 
   edit(projectId: string | number, domain: string, options?: BaseRequestOptions) {
-    const pId = encodeURIComponent(projectId);
-
     return RequestHelper.put<PagesDomainSchema>()(
       this,
-      `projects/${pId}/pages/domains/${domain}`,
+      endpoint`projects/${projectId}/pages/domains/${domain}`,
       options,
     );
   }
 
   show(projectId: string | number, domain: string, options?: Sudo) {
-    const pId = encodeURIComponent(projectId);
-
     return RequestHelper.get<PagesDomainSchema>()(
       this,
-      `projects/${pId}/pages/domains/${domain}`,
+      endpoint`projects/${projectId}/pages/domains/${domain}`,
       options,
     );
   }
 
   remove(projectId: string | number, domain: string, options?: Sudo) {
-    const pId = encodeURIComponent(projectId);
-
-    return RequestHelper.del()(this, `projects/${pId}/pages/domains/${domain}`, options);
+    return RequestHelper.del()(
+      this,
+      endpoint`projects/${projectId}/pages/domains/${domain}`,
+      options,
+    );
   }
 }

--- a/packages/core/src/resources/PipelineScheduleVariables.ts
+++ b/packages/core/src/resources/PipelineScheduleVariables.ts
@@ -1,24 +1,25 @@
 import { BaseResource } from '@gitbeaker/requester-utils';
 import { PipelineVariableSchema } from './Pipelines';
-import { BaseRequestOptions, PaginatedRequestOptions, RequestHelper } from '../infrastructure';
+import {
+  BaseRequestOptions,
+  endpoint,
+  PaginatedRequestOptions,
+  RequestHelper,
+} from '../infrastructure';
 
 export class PipelineScheduleVariables<C extends boolean = false> extends BaseResource<C> {
   all(projectId: string | number, pipelineScheduleId: number, options?: PaginatedRequestOptions) {
-    const [pId, psId] = [projectId, pipelineScheduleId].map(encodeURIComponent);
-
     return RequestHelper.get<PipelineVariableSchema[]>()(
       this,
-      `projects/${pId}/pipeline_schedules/${psId}/variables`,
+      endpoint`projects/${projectId}/pipeline_schedules/${pipelineScheduleId}/variables`,
       options,
     );
   }
 
   create(projectId: string | number, pipelineScheduleId: number, options?: BaseRequestOptions) {
-    const [pId, psId] = [projectId, pipelineScheduleId].map(encodeURIComponent);
-
     return RequestHelper.post<PipelineVariableSchema>()(
       this,
-      `projects/${pId}/pipeline_schedules/${psId}/variables`,
+      endpoint`projects/${projectId}/pipeline_schedules/${pipelineScheduleId}/variables`,
       options,
     );
   }
@@ -29,11 +30,9 @@ export class PipelineScheduleVariables<C extends boolean = false> extends BaseRe
     keyId: string,
     options?: BaseRequestOptions,
   ) {
-    const [pId, psId, kId] = [projectId, pipelineScheduleId, keyId].map(encodeURIComponent);
-
     return RequestHelper.put<PipelineVariableSchema>()(
       this,
-      `projects/${pId}/pipeline_schedules/${psId}/variables/${kId}`,
+      endpoint`projects/${projectId}/pipeline_schedules/${pipelineScheduleId}/variables/${keyId}`,
       options,
     );
   }
@@ -44,11 +43,9 @@ export class PipelineScheduleVariables<C extends boolean = false> extends BaseRe
     keyId: string,
     options?: BaseRequestOptions,
   ) {
-    const [pId, psId, kId] = [projectId, pipelineScheduleId, keyId].map(encodeURIComponent);
-
     return RequestHelper.get<PipelineVariableSchema>()(
       this,
-      `projects/${pId}/pipeline_schedules/${psId}/variables/${kId}`,
+      endpoint`projects/${projectId}/pipeline_schedules/${pipelineScheduleId}/variables/${keyId}`,
       options,
     );
   }
@@ -59,11 +56,9 @@ export class PipelineScheduleVariables<C extends boolean = false> extends BaseRe
     keyId: string,
     options?: BaseRequestOptions,
   ) {
-    const [pId, psId, kId] = [projectId, pipelineScheduleId, keyId].map(encodeURIComponent);
-
     return RequestHelper.del<PipelineVariableSchema>()(
       this,
-      `projects/${pId}/pipeline_schedules/${psId}/variables/${kId}`,
+      endpoint`projects/${projectId}/pipeline_schedules/${pipelineScheduleId}/variables/${keyId}`,
       options,
     );
   }

--- a/packages/core/src/resources/PipelineSchedules.ts
+++ b/packages/core/src/resources/PipelineSchedules.ts
@@ -3,6 +3,7 @@ import { UserSchema } from './Users';
 import { PipelineSchema, PipelineVariableSchema } from './Pipelines';
 import {
   BaseRequestOptions,
+  endpoint,
   PaginatedRequestOptions,
   RequestHelper,
   Sudo,
@@ -27,11 +28,9 @@ export interface PipelineScheduleExtendedSchema extends PipelineScheduleSchema {
 
 export class PipelineSchedules<C extends boolean = false> extends BaseResource<C> {
   all(projectId: string | number, options?: PaginatedRequestOptions) {
-    const pId = encodeURIComponent(projectId);
-
     return RequestHelper.get<PipelineScheduleSchema[]>()(
       this,
-      `projects/${pId}/pipeline_schedules`,
+      endpoint`projects/${projectId}/pipeline_schedules`,
       options,
     );
   }
@@ -43,11 +42,9 @@ export class PipelineSchedules<C extends boolean = false> extends BaseResource<C
     cron: string,
     options?: BaseRequestOptions,
   ) {
-    const pId = encodeURIComponent(projectId);
-
     return RequestHelper.post<PipelineScheduleSchema & { variables?: PipelineVariableSchema[] }>()(
       this,
-      `projects/${pId}/pipeline_schedules`,
+      endpoint`projects/${projectId}/pipeline_schedules`,
       {
         description,
         ref,
@@ -58,41 +55,33 @@ export class PipelineSchedules<C extends boolean = false> extends BaseResource<C
   }
 
   edit(projectId: string | number, scheduleId: number, options?: BaseRequestOptions) {
-    const [pId, sId] = [projectId, scheduleId].map(encodeURIComponent);
-
     return RequestHelper.put<PipelineScheduleExtendedSchema>()(
       this,
-      `projects/${pId}/pipeline_schedules/${sId}`,
+      endpoint`projects/${projectId}/pipeline_schedules/${scheduleId}`,
       options,
     );
   }
 
   remove(projectId: string | number, scheduleId: number, options?: Sudo) {
-    const [pId, sId] = [projectId, scheduleId].map(encodeURIComponent);
-
     return RequestHelper.del<PipelineScheduleExtendedSchema>()(
       this,
-      `projects/${pId}/pipeline_schedules/${sId}`,
+      endpoint`projects/${projectId}/pipeline_schedules/${scheduleId}`,
       options,
     );
   }
 
   show(projectId: string | number, scheduleId: number, options?: Sudo) {
-    const [pId, sId] = [projectId, scheduleId].map(encodeURIComponent);
-
     return RequestHelper.get<PipelineScheduleExtendedSchema>()(
       this,
-      `projects/${pId}/pipeline_schedules/${sId}`,
+      endpoint`projects/${projectId}/pipeline_schedules/${scheduleId}`,
       options,
     );
   }
 
   takeOwnership(projectId: string | number, scheduleId: number, options?: Sudo) {
-    const [pId, sId] = [projectId, scheduleId].map(encodeURIComponent);
-
     return RequestHelper.post<PipelineScheduleExtendedSchema>()(
       this,
-      `projects/${pId}/pipeline_schedules/${sId}/take_ownership`,
+      endpoint`projects/${projectId}/pipeline_schedules/${scheduleId}/take_ownership`,
       options,
     );
   }

--- a/packages/core/src/resources/Pipelines.ts
+++ b/packages/core/src/resources/Pipelines.ts
@@ -2,6 +2,7 @@ import { BaseResource } from '@gitbeaker/requester-utils';
 import { UserSchema } from './Users';
 import {
   BaseRequestOptions,
+  endpoint,
   PaginatedRequestOptions,
   RequestHelper,
   Sudo,
@@ -54,62 +55,56 @@ export interface PipelineVariableSchema extends Record<string, unknown> {
 
 export class Pipelines<C extends boolean = false> extends BaseResource<C> {
   all(projectId: string | number, options?: PaginatedRequestOptions) {
-    const pId = encodeURIComponent(projectId);
-
-    return RequestHelper.get<PipelineSchema[]>()(this, `projects/${pId}/pipelines`, options);
+    return RequestHelper.get<PipelineSchema[]>()(
+      this,
+      endpoint`projects/${projectId}/pipelines`,
+      options,
+    );
   }
 
   create(projectId: string | number, ref: string, options?: BaseRequestOptions) {
-    const pId = encodeURIComponent(projectId);
-
-    return RequestHelper.post<PipelineSchema>()(this, `projects/${pId}/pipeline`, {
+    return RequestHelper.post<PipelineSchema>()(this, endpoint`projects/${projectId}/pipeline`, {
       ref,
       ...options,
     });
   }
 
   delete(projectId: string | number, pipelineId: number, options?: Sudo) {
-    const pId = encodeURIComponent(projectId);
-
-    return RequestHelper.del()(this, `projects/${pId}/pipelines/${pipelineId}`, options);
+    return RequestHelper.del()(
+      this,
+      endpoint`projects/${projectId}/pipelines/${pipelineId}`,
+      options,
+    );
   }
 
   show(projectId: string | number, pipelineId: number, options?: Sudo) {
-    const pId = encodeURIComponent(projectId);
-
     return RequestHelper.get<PipelineSchema>()(
       this,
-      `projects/${pId}/pipelines/${pipelineId}`,
+      endpoint`projects/${projectId}/pipelines/${pipelineId}`,
       options,
     );
   }
 
   retry(projectId: string | number, pipelineId: number, options?: Sudo) {
-    const pId = encodeURIComponent(projectId);
-
     return RequestHelper.post<PipelineExtendedSchema>()(
       this,
-      `projects/${pId}/pipelines/${pipelineId}/retry`,
+      endpoint`projects/${projectId}/pipelines/${pipelineId}/retry`,
       options,
     );
   }
 
   cancel(projectId: string | number, pipelineId: number, options?: Sudo) {
-    const pId = encodeURIComponent(projectId);
-
     return RequestHelper.post<PipelineExtendedSchema>()(
       this,
-      `projects/${pId}/pipelines/${pipelineId}/cancel`,
+      endpoint`projects/${projectId}/pipelines/${pipelineId}/cancel`,
       options,
     );
   }
 
   allVariables(projectId: string | number, pipelineId: number, options?: PaginatedRequestOptions) {
-    const [pId, pipeId] = [projectId, pipelineId].map(encodeURIComponent);
-
     return RequestHelper.get<PipelineVariableSchema[]>()(
       this,
-      `projects/${pId}/pipelines/${pipeId}/variables`,
+      endpoint`projects/${projectId}/pipelines/${pipelineId}/variables`,
       options,
     );
   }

--- a/packages/core/src/resources/ProjectHooks.ts
+++ b/packages/core/src/resources/ProjectHooks.ts
@@ -1,6 +1,7 @@
 import { BaseResource } from '@gitbeaker/requester-utils';
 import {
   BaseRequestOptions,
+  endpoint,
   PaginatedRequestOptions,
   RequestHelper,
   Sudo,
@@ -29,38 +30,40 @@ export interface ProjectHookSchema extends Record<string, unknown> {
 
 export class ProjectHooks<C extends boolean = false> extends BaseResource<C> {
   all(projectId: string | number, options?: PaginatedRequestOptions) {
-    const pId = encodeURIComponent(projectId);
-
-    return RequestHelper.get<ProjectHookSchema[]>()(this, `projects/${pId}/hooks`, options);
+    return RequestHelper.get<ProjectHookSchema[]>()(
+      this,
+      endpoint`projects/${projectId}/hooks`,
+      options,
+    );
   }
 
   show(projectId: string | number, hookId: number, options?: Sudo) {
-    const [pId, hId] = [projectId, hookId].map(encodeURIComponent);
-
-    return RequestHelper.get<ProjectHookSchema>()(this, `projects/${pId}/hooks/${hId}`, options);
+    return RequestHelper.get<ProjectHookSchema>()(
+      this,
+      endpoint`projects/${projectId}/hooks/${hookId}`,
+      options,
+    );
   }
 
   add(projectId: string | number, url: string, options?: BaseRequestOptions) {
-    const pId = encodeURIComponent(projectId);
-
-    return RequestHelper.post<ProjectHookSchema>()(this, `projects/${pId}/hooks`, {
+    return RequestHelper.post<ProjectHookSchema>()(this, endpoint`projects/${projectId}/hooks`, {
       url,
       ...options,
     });
   }
 
   edit(projectId: string | number, hookId: number, url: string, options?: BaseRequestOptions) {
-    const [pId, hId] = [projectId, hookId].map(encodeURIComponent);
-
-    return RequestHelper.put<ProjectHookSchema>()(this, `projects/${pId}/hooks/${hId}`, {
-      url,
-      ...options,
-    });
+    return RequestHelper.put<ProjectHookSchema>()(
+      this,
+      endpoint`projects/${projectId}/hooks/${hookId}`,
+      {
+        url,
+        ...options,
+      },
+    );
   }
 
   remove(projectId: string | number, hookId: number, options?: Sudo) {
-    const [pId, hId] = [projectId, hookId].map(encodeURIComponent);
-
-    return RequestHelper.del()(this, `projects/${pId}/hooks/${hId}`, options);
+    return RequestHelper.del()(this, endpoint`projects/${projectId}/hooks/${hookId}`, options);
   }
 }

--- a/packages/core/src/resources/ProjectImportExport.ts
+++ b/packages/core/src/resources/ProjectImportExport.ts
@@ -1,6 +1,6 @@
 import { BaseResource } from '@gitbeaker/requester-utils';
 import { lookup as mimeLookup } from 'mime-types';
-import { RequestHelper, Sudo, BaseRequestOptions } from '../infrastructure';
+import { RequestHelper, Sudo, BaseRequestOptions, endpoint } from '../infrastructure';
 
 export interface ExportStatusSchema extends Record<string, unknown> {
   id: number;
@@ -50,15 +50,15 @@ export const defaultMetadata = {
 
 export class ProjectImportExport<C extends boolean = false> extends BaseResource<C> {
   download(projectId: string | number, options?: Sudo) {
-    const pId = encodeURIComponent(projectId);
-
-    return RequestHelper.get()(this, `projects/${pId}/export/download`, options);
+    return RequestHelper.get()(this, endpoint`projects/${projectId}/export/download`, options);
   }
 
   exportStatus(projectId: string | number, options?: Sudo) {
-    const pId = encodeURIComponent(projectId);
-
-    return RequestHelper.get<ExportStatusSchema>()(this, `projects/${pId}/export`, options);
+    return RequestHelper.get<ExportStatusSchema>()(
+      this,
+      endpoint`projects/${projectId}/export`,
+      options,
+    );
   }
 
   import(
@@ -79,14 +79,18 @@ export class ProjectImportExport<C extends boolean = false> extends BaseResource
   }
 
   importStatus(projectId: string | number, options?: Sudo) {
-    const pId = encodeURIComponent(projectId);
-
-    return RequestHelper.get<ImportStatusSchema>()(this, `projects/${pId}/import`, options);
+    return RequestHelper.get<ImportStatusSchema>()(
+      this,
+      endpoint`projects/${projectId}/import`,
+      options,
+    );
   }
 
   schedule(projectId: string | number, options?: BaseRequestOptions) {
-    const pId = encodeURIComponent(projectId);
-
-    return RequestHelper.post<{ message: string }>()(this, `projects/${pId}/export`, options);
+    return RequestHelper.post<{ message: string }>()(
+      this,
+      endpoint`projects/${projectId}/export`,
+      options,
+    );
   }
 }

--- a/packages/core/src/resources/ProjectSnippets.ts
+++ b/packages/core/src/resources/ProjectSnippets.ts
@@ -1,6 +1,7 @@
 import { BaseResource } from '@gitbeaker/requester-utils';
 import {
   BaseRequestOptions,
+  endpoint,
   PaginatedRequestOptions,
   RequestHelper,
   Sudo,
@@ -23,15 +24,19 @@ export interface ProjectSnippetSchema extends Record<string, unknown> {
 
 export class ProjectSnippets<C extends boolean = false> extends BaseResource<C> {
   all(projectId: string | number, options?: PaginatedRequestOptions) {
-    const pId = encodeURIComponent(projectId);
-
-    return RequestHelper.get<ProjectSnippetSchema[]>()(this, `projects/${pId}/snippets`, options);
+    return RequestHelper.get<ProjectSnippetSchema[]>()(
+      this,
+      endpoint`projects/${projectId}/snippets`,
+      options,
+    );
   }
 
   content(projectId: string | number, snippetId: number, options?: Sudo) {
-    const [pId, sId] = [projectId, snippetId].map(encodeURIComponent);
-
-    return RequestHelper.get()(this, `projects/${pId}/snippets/${sId}/raw`, options);
+    return RequestHelper.get()(
+      this,
+      endpoint`projects/${projectId}/snippets/${snippetId}/raw`,
+      options,
+    );
   }
 
   create(
@@ -42,50 +47,48 @@ export class ProjectSnippets<C extends boolean = false> extends BaseResource<C> 
     visibility: SnippetVisibility,
     options?: BaseRequestOptions,
   ) {
-    const pId = encodeURIComponent(projectId);
-
-    return RequestHelper.post<ProjectSnippetSchema>()(this, `projects/${pId}/snippets`, {
-      title,
-      fileName,
-      code,
-      visibility,
-      ...options,
-    });
+    return RequestHelper.post<ProjectSnippetSchema>()(
+      this,
+      endpoint`projects/${projectId}/snippets`,
+      {
+        title,
+        fileName,
+        code,
+        visibility,
+        ...options,
+      },
+    );
   }
 
   edit(projectId: string | number, snippetId: number, options?: BaseRequestOptions) {
-    const [pId, sId] = [projectId, snippetId].map(encodeURIComponent);
-
     return RequestHelper.put<ProjectSnippetSchema>()(
       this,
-      `projects/${pId}/snippets/${sId}`,
+      endpoint`projects/${projectId}/snippets/${snippetId}`,
       options,
     );
   }
 
   remove(projectId: string | number, snippetId: number, options?: Sudo) {
-    const [pId, sId] = [projectId, snippetId].map(encodeURIComponent);
-
-    return RequestHelper.del()(this, `projects/${pId}/snippets/${sId}`, options);
+    return RequestHelper.del()(
+      this,
+      endpoint`projects/${projectId}/snippets/${snippetId}`,
+      options,
+    );
   }
 
   show(projectId: string | number, snippetId: number, options?: Sudo) {
-    const [pId, sId] = [projectId, snippetId].map(encodeURIComponent);
-
     return RequestHelper.get<ProjectSnippetSchema>()(
       this,
-      `projects/${pId}/snippets/${sId}`,
+      endpoint`projects/${projectId}/snippets/${snippetId}`,
       options,
     );
   }
 
   userAgentDetails(projectId: string | number, snippetId: number, options?: Sudo) {
-    const [pId, sId] = [projectId, snippetId].map(encodeURIComponent);
-
     return RequestHelper.get<{
       user_agent: string;
       ip_address: string;
       akismet_submitted: boolean;
-    }>()(this, `projects/${pId}/snippets/${sId}/user_agent_detail`, options);
+    }>()(this, endpoint`projects/${projectId}/snippets/${snippetId}/user_agent_detail`, options);
   }
 }

--- a/packages/core/src/resources/Projects.ts
+++ b/packages/core/src/resources/Projects.ts
@@ -6,6 +6,7 @@ import { LicenseTemplateSchema } from './LicenseTemplates';
 import { UploadMetadata, defaultMetadata } from './ProjectImportExport';
 import {
   BaseRequestOptions,
+  endpoint,
   PaginatedRequestOptions,
   RequestHelper,
   Sudo,
@@ -148,32 +149,35 @@ export class Projects<C extends boolean = false> extends BaseResource<C> {
   }
 
   archive(projectId: string | number, options?: Sudo) {
-    const pId = encodeURIComponent(projectId);
-
-    return RequestHelper.post<ProjectExtendedSchema>()(this, `projects/${pId}/archive`, options);
+    return RequestHelper.post<ProjectExtendedSchema>()(
+      this,
+      endpoint`projects/${projectId}/archive`,
+      options,
+    );
   }
 
   create({
     userId,
     ...options
   }: ({ name: string } | { path: string }) & { userId?: number } & BaseRequestOptions) {
-    const url = userId ? `projects/user/${encodeURIComponent(userId)}` : 'projects';
+    const url = userId ? `projects/user/${userId}` : 'projects';
 
     return RequestHelper.post<ProjectExtendedSchema>()(this, url, options);
   }
 
   edit(projectId: string | number, options?: BaseRequestOptions) {
-    const pId = encodeURIComponent(projectId);
-
-    return RequestHelper.put<ProjectExtendedSchema>()(this, `projects/${pId}`, options);
+    return RequestHelper.put<ProjectExtendedSchema>()(
+      this,
+      endpoint`projects/${projectId}`,
+      options,
+    );
   }
 
   fork(
     projectId: string | number,
     { forkedFromId, ...options }: { forkedFromId?: number } & BaseRequestOptions = {},
   ) {
-    const pId = encodeURIComponent(projectId);
-    let url = `projects/${pId}/fork`;
+    let url = endpoint`projects/${projectId}/fork`;
 
     if (forkedFromId) url += `/${encodeURIComponent(forkedFromId)}`;
 
@@ -181,37 +185,31 @@ export class Projects<C extends boolean = false> extends BaseResource<C> {
   }
 
   forks(projectId: string | number, options?: BaseRequestOptions) {
-    const pId = encodeURIComponent(projectId);
-
-    return RequestHelper.get<ProjectExtendedSchema[]>()(this, `projects/${pId}/forks`, options);
+    return RequestHelper.get<ProjectExtendedSchema[]>()(
+      this,
+      endpoint`projects/${projectId}/forks`,
+      options,
+    );
   }
 
   languages(projectId: string | number, options?: Sudo) {
-    const pId = encodeURIComponent(projectId);
-
     return RequestHelper.get<{ [name: string]: number }>()(
       this,
-      `projects/${pId}/languages`,
+      endpoint`projects/${projectId}/languages`,
       options,
     );
   }
 
   mirrorPull(projectId: string | number, options?: Sudo) {
-    const pId = encodeURIComponent(projectId);
-
-    return RequestHelper.post()(this, `projects/${pId}/mirror/pull`, options);
+    return RequestHelper.post()(this, endpoint`projects/${projectId}/mirror/pull`, options);
   }
 
   remove(projectId: string | number, options?: Sudo) {
-    const pId = encodeURIComponent(projectId);
-
-    return RequestHelper.del()(this, `projects/${pId}`, options);
+    return RequestHelper.del()(this, endpoint`projects/${projectId}`, options);
   }
 
   removeFork(projectId: string | number, options?: Sudo) {
-    const pId = encodeURIComponent(projectId);
-
-    return RequestHelper.del()(this, `projects/${pId}/fork`, options);
+    return RequestHelper.del()(this, endpoint`projects/${projectId}/fork`, options);
   }
 
   search(projectName: string, options?: BaseRequestOptions) {
@@ -227,9 +225,7 @@ export class Projects<C extends boolean = false> extends BaseResource<C> {
     groupAccess: number,
     options?: BaseRequestOptions,
   ) {
-    const pId = encodeURIComponent(projectId);
-
-    return RequestHelper.post()(this, `projects/${pId}/share`, {
+    return RequestHelper.post()(this, endpoint`projects/${projectId}/share`, {
       groupId,
       groupAccess,
       ...options,
@@ -237,40 +233,49 @@ export class Projects<C extends boolean = false> extends BaseResource<C> {
   }
 
   show(projectId: string | number, options?: BaseRequestOptions) {
-    const pId = encodeURIComponent(projectId);
-
-    return RequestHelper.get<ProjectExtendedSchema>()(this, `projects/${pId}`, options);
+    return RequestHelper.get<ProjectExtendedSchema>()(
+      this,
+      endpoint`projects/${projectId}`,
+      options,
+    );
   }
 
   star(projectId: string | number, options?: Sudo) {
-    const pId = encodeURIComponent(projectId);
-
-    return RequestHelper.post<ProjectExtendedSchema>()(this, `projects/${pId}/star`, options);
+    return RequestHelper.post<ProjectExtendedSchema>()(
+      this,
+      endpoint`projects/${projectId}/star`,
+      options,
+    );
   }
 
   transfer(projectId: string | number, namespaceId: string | number) {
-    const pId = encodeURIComponent(projectId);
-    return RequestHelper.put<ProjectExtendedSchema>()(this, `projects/${pId}/transfer`, {
-      namespace: namespaceId,
-    });
+    return RequestHelper.put<ProjectExtendedSchema>()(
+      this,
+      endpoint`projects/${projectId}/transfer`,
+      {
+        namespace: namespaceId,
+      },
+    );
   }
 
   unarchive(projectId: string | number, options?: Sudo) {
-    const pId = encodeURIComponent(projectId);
-
-    return RequestHelper.post<ProjectExtendedSchema>()(this, `projects/${pId}/unarchive`, options);
+    return RequestHelper.post<ProjectExtendedSchema>()(
+      this,
+      endpoint`projects/${projectId}/unarchive`,
+      options,
+    );
   }
 
   unshare(projectId: string | number, groupId: string | number, options?: Sudo) {
-    const [pId, gId] = [projectId, groupId].map(encodeURIComponent);
-
-    return RequestHelper.del()(this, `projects/${pId}/share/${gId}`, options);
+    return RequestHelper.del()(this, endpoint`projects/${projectId}/share/${groupId}`, options);
   }
 
   unstar(projectId: string | number, options?: Sudo) {
-    const pId = encodeURIComponent(projectId);
-
-    return RequestHelper.post<ProjectExtendedSchema>()(this, `projects/${pId}/unstar`, options);
+    return RequestHelper.post<ProjectExtendedSchema>()(
+      this,
+      endpoint`projects/${projectId}/unstar`,
+      options,
+    );
   }
 
   upload(
@@ -278,15 +283,18 @@ export class Projects<C extends boolean = false> extends BaseResource<C> {
     content: string,
     { metadata, ...options }: { metadata?: UploadMetadata } & BaseRequestOptions = {},
   ) {
-    const pId = encodeURIComponent(projectId);
     const meta = { ...defaultMetadata, ...metadata };
 
     if (!meta.contentType) meta.contentType = mimeLookup(meta.filename);
 
-    return RequestHelper.post<ProjectFileUploadSchema>()(this, `projects/${pId}/uploads`, {
-      isForm: true,
-      file: [content, meta],
-      ...options,
-    });
+    return RequestHelper.post<ProjectFileUploadSchema>()(
+      this,
+      endpoint`projects/${projectId}/uploads`,
+      {
+        isForm: true,
+        file: [content, meta],
+        ...options,
+      },
+    );
   }
 }

--- a/packages/core/src/resources/ProtectedBranches.ts
+++ b/packages/core/src/resources/ProtectedBranches.ts
@@ -1,6 +1,7 @@
 import { BaseResource } from '@gitbeaker/requester-utils';
 import {
   BaseRequestOptions,
+  endpoint,
   PaginatedRequestOptions,
   RequestHelper,
   Sudo,
@@ -24,39 +25,39 @@ export interface ProtectedBranchSchema extends Record<string, unknown> {
 
 export class ProtectedBranches<C extends boolean = false> extends BaseResource<C> {
   all(projectId: string | number, options: { search?: string } & PaginatedRequestOptions = {}) {
-    const pId = encodeURIComponent(projectId);
-
     return RequestHelper.get<ProtectedBranchSchema[]>()(
       this,
-      `projects/${pId}/protected_branches`,
+      endpoint`projects/${projectId}/protected_branches`,
       options,
     );
   }
 
   protect(projectId: string | number, branchName: string, options?: BaseRequestOptions) {
-    const pId = encodeURIComponent(projectId);
-
-    return RequestHelper.post<ProtectedBranchSchema>()(this, `projects/${pId}/protected_branches`, {
-      query: {
-        name: branchName,
-        ...options,
+    return RequestHelper.post<ProtectedBranchSchema>()(
+      this,
+      endpoint`projects/${projectId}/protected_branches`,
+      {
+        query: {
+          name: branchName,
+          ...options,
+        },
       },
-    });
+    );
   }
 
   show(projectId: string | number, branchName: string, options?: Sudo) {
-    const [pId, bName] = [projectId, branchName].map(encodeURIComponent);
-
     return RequestHelper.get<ProtectedBranchSchema>()(
       this,
-      `projects/${pId}/protected_branches/${bName}`,
+      endpoint`projects/${projectId}/protected_branches/${branchName}`,
       options,
     );
   }
 
   unprotect(projectId: string | number, branchName: string, options?: Sudo) {
-    const [pId, bName] = [projectId, branchName].map(encodeURIComponent);
-
-    return RequestHelper.del()(this, `projects/${pId}/protected_branches/${bName}`, options);
+    return RequestHelper.del()(
+      this,
+      endpoint`projects/${projectId}/protected_branches/${branchName}`,
+      options,
+    );
   }
 }

--- a/packages/core/src/resources/ProtectedTags.ts
+++ b/packages/core/src/resources/ProtectedTags.ts
@@ -1,6 +1,7 @@
 import { BaseResource } from '@gitbeaker/requester-utils';
 import {
   BaseRequestOptions,
+  endpoint,
   PaginatedRequestOptions,
   RequestHelper,
   Sudo,
@@ -18,37 +19,37 @@ export interface ProtectedTagSchema extends Record<string, unknown> {
 
 export class ProtectedTags<C extends boolean = false> extends BaseResource<C> {
   all(projectId: string | number, options?: PaginatedRequestOptions) {
-    const pId = encodeURIComponent(projectId);
-
     return RequestHelper.get<ProtectedTagSchema[]>()(
       this,
-      `projects/${pId}/protected_tags`,
+      endpoint`projects/${projectId}/protected_tags`,
       options,
     );
   }
 
   protect(projectId: string | number, tagName: string, options?: BaseRequestOptions) {
-    const pId = encodeURIComponent(projectId);
-
-    return RequestHelper.post<ProtectedTagSchema>()(this, `projects/${pId}/protected_tags`, {
-      name: tagName,
-      ...options,
-    });
+    return RequestHelper.post<ProtectedTagSchema>()(
+      this,
+      endpoint`projects/${projectId}/protected_tags`,
+      {
+        name: tagName,
+        ...options,
+      },
+    );
   }
 
   show(projectId: string | number, tagName: string, options?: Sudo) {
-    const [pId, tName] = [projectId, tagName].map(encodeURIComponent);
-
     return RequestHelper.get<ProtectedTagSchema>()(
       this,
-      `projects/${pId}/protected_tags/${tName}`,
+      endpoint`projects/${projectId}/protected_tags/${tagName}`,
       options,
     );
   }
 
   unprotect(projectId: string | number, tagName: string, options?: Sudo) {
-    const [pId, tName] = [projectId, tagName].map(encodeURIComponent);
-
-    return RequestHelper.del()(this, `projects/${pId}/protected_tags/${tName}`, options);
+    return RequestHelper.del()(
+      this,
+      endpoint`projects/${projectId}/protected_tags/${tagName}`,
+      options,
+    );
   }
 }

--- a/packages/core/src/resources/PushRules.ts
+++ b/packages/core/src/resources/PushRules.ts
@@ -1,5 +1,5 @@
 import { BaseResource } from '@gitbeaker/requester-utils';
-import { RequestHelper, BaseRequestOptions, Sudo } from '../infrastructure';
+import { RequestHelper, BaseRequestOptions, Sudo, endpoint } from '../infrastructure';
 
 export interface PushRulesSchema extends Record<string, unknown> {
   id: number;
@@ -20,26 +20,34 @@ export interface PushRulesSchema extends Record<string, unknown> {
 
 export class PushRules<C extends boolean = false> extends BaseResource<C> {
   create(projectId: string | number, options?: BaseRequestOptions) {
-    const pId = encodeURIComponent(projectId);
-
-    return RequestHelper.post<PushRulesSchema>()(this, `projects/${pId}/push_rule`, options);
+    return RequestHelper.post<PushRulesSchema>()(
+      this,
+      endpoint`projects/${projectId}/push_rule`,
+      options,
+    );
   }
 
   edit(projectId: string | number, options?: BaseRequestOptions) {
-    const pId = encodeURIComponent(projectId);
-
-    return RequestHelper.put<PushRulesSchema>()(this, `projects/${pId}/push_rule`, options);
+    return RequestHelper.put<PushRulesSchema>()(
+      this,
+      endpoint`projects/${projectId}/push_rule`,
+      options,
+    );
   }
 
   remove(projectId: string | number, options?: Sudo) {
-    const pId = encodeURIComponent(projectId);
-
-    return RequestHelper.del<PushRulesSchema>()(this, `projects/${pId}/push_rule`, options);
+    return RequestHelper.del<PushRulesSchema>()(
+      this,
+      endpoint`projects/${projectId}/push_rule`,
+      options,
+    );
   }
 
   show(projectId: string | number, options?: Sudo) {
-    const pId = encodeURIComponent(projectId);
-
-    return RequestHelper.get<PushRulesSchema>()(this, `projects/${pId}/push_rule`, options);
+    return RequestHelper.get<PushRulesSchema>()(
+      this,
+      endpoint`projects/${projectId}/push_rule`,
+      options,
+    );
   }
 }

--- a/packages/core/src/resources/ReleaseLinks.ts
+++ b/packages/core/src/resources/ReleaseLinks.ts
@@ -1,5 +1,5 @@
 import { BaseResource } from '@gitbeaker/requester-utils';
-import { RequestHelper, PaginatedRequestOptions, Sudo } from '../infrastructure';
+import { RequestHelper, PaginatedRequestOptions, Sudo, endpoint } from '../infrastructure';
 
 export interface ReleaseLinkSchema extends Record<string, unknown> {
   id: number;
@@ -11,11 +11,9 @@ export interface ReleaseLinkSchema extends Record<string, unknown> {
 
 export class ReleaseLinks<C extends boolean = false> extends BaseResource<C> {
   all(projectId: string | number, tagName: string, options?: PaginatedRequestOptions) {
-    const [pId, tId] = [projectId, tagName].map(encodeURIComponent);
-
     return RequestHelper.get<ReleaseLinkSchema[]>()(
       this,
-      `projects/${pId}/releases/${tId}/assets/links`,
+      endpoint`projects/${projectId}/releases/${tagName}/assets/links`,
       options,
     );
   }
@@ -27,11 +25,9 @@ export class ReleaseLinks<C extends boolean = false> extends BaseResource<C> {
     url: string,
     options?: Sudo & { filePath?: string; linkType?: string },
   ) {
-    const [pId, tId] = [projectId, tagName].map(encodeURIComponent);
-
     return RequestHelper.post<ReleaseLinkSchema>()(
       this,
-      `projects/${pId}/releases/${tId}/assets/links`,
+      endpoint`projects/${projectId}/releases/${tagName}/assets/links`,
       {
         name,
         url,
@@ -46,31 +42,25 @@ export class ReleaseLinks<C extends boolean = false> extends BaseResource<C> {
     linkId: number,
     options?: Sudo & { name?: string; url?: string; filePath?: string; linkType?: string },
   ) {
-    const [pId, tId, lId] = [projectId, tagName, linkId].map(encodeURIComponent);
-
     return RequestHelper.put<ReleaseLinkSchema>()(
       this,
-      `projects/${pId}/releases/${tId}/assets/links/${lId}`,
+      endpoint`projects/${projectId}/releases/${tagName}/assets/links/${linkId}`,
       options,
     );
   }
 
   remove(projectId: string | number, tagName: string, linkId: number, options?: Sudo) {
-    const [pId, tId, lId] = [projectId, tagName, linkId].map(encodeURIComponent);
-
     return RequestHelper.del()(
       this,
-      `projects/${pId}/releases/${tId}/assets/links/${lId}`,
+      endpoint`projects/${projectId}/releases/${tagName}/assets/links/${linkId}`,
       options,
     );
   }
 
   show(projectId: string | number, tagName: string, linkId: number, options?: Sudo) {
-    const [pId, tId, lId] = [projectId, tagName, linkId].map(encodeURIComponent);
-
     return RequestHelper.get<ReleaseLinkSchema>()(
       this,
-      `projects/${pId}/releases/${tId}/assets/links/${lId}`,
+      endpoint`projects/${projectId}/releases/${tagName}/assets/links/${linkId}`,
       options,
     );
   }

--- a/packages/core/src/resources/Releases.ts
+++ b/packages/core/src/resources/Releases.ts
@@ -4,6 +4,7 @@ import { CommitSchema } from './Commits';
 import { MilestoneSchema } from '../templates/types';
 import {
   BaseRequestOptions,
+  endpoint,
   PaginatedRequestOptions,
   RequestHelper,
   Sudo,
@@ -52,32 +53,38 @@ export interface ReleaseSchema extends Record<string, unknown> {
 // TODO: Add missing functions
 export class Releases<C extends boolean = false> extends BaseResource<C> {
   all(projectId: string | number, options?: PaginatedRequestOptions) {
-    const pId = encodeURIComponent(projectId);
-
-    return RequestHelper.get<ReleaseSchema[]>()(this, `projects/${pId}/releases`, options);
+    return RequestHelper.get<ReleaseSchema[]>()(
+      this,
+      endpoint`projects/${projectId}/releases`,
+      options,
+    );
   }
 
   create(projectId: string | number, options?: BaseRequestOptions) {
-    const pId = encodeURIComponent(projectId);
-
-    return RequestHelper.post<ReleaseSchema>()(this, `projects/${pId}/releases`, options);
+    return RequestHelper.post<ReleaseSchema>()(
+      this,
+      endpoint`projects/${projectId}/releases`,
+      options,
+    );
   }
 
   edit(projectId: string | number, tagName: string, options?: BaseRequestOptions) {
-    const [pId, tId] = [projectId, tagName].map(encodeURIComponent);
-
-    return RequestHelper.put<ReleaseSchema>()(this, `projects/${pId}/releases/${tId}`, options);
+    return RequestHelper.put<ReleaseSchema>()(
+      this,
+      endpoint`projects/${projectId}/releases/${tagName}`,
+      options,
+    );
   }
 
   remove(projectId: string | number, tagName: string, options?: Sudo) {
-    const [pId, tId] = [projectId, tagName].map(encodeURIComponent);
-
-    return RequestHelper.del()(this, `projects/${pId}/releases/${tId}`, options);
+    return RequestHelper.del()(this, endpoint`projects/${projectId}/releases/${tagName}`, options);
   }
 
   show(projectId: string | number, tagName: string, options?: Sudo) {
-    const [pId, tId] = [projectId, tagName].map(encodeURIComponent);
-
-    return RequestHelper.get<ReleaseSchema>()(this, `projects/${pId}/releases/${tId}`, options);
+    return RequestHelper.get<ReleaseSchema>()(
+      this,
+      endpoint`projects/${projectId}/releases/${tagName}`,
+      options,
+    );
   }
 }

--- a/packages/core/src/resources/Repositories.ts
+++ b/packages/core/src/resources/Repositories.ts
@@ -1,6 +1,6 @@
 import { BaseResource } from '@gitbeaker/requester-utils';
 import { CommitSchema, CommitDiffSchema } from './Commits';
-import { RequestHelper, Sudo, BaseRequestOptions } from '../infrastructure';
+import { RequestHelper, Sudo, BaseRequestOptions, endpoint } from '../infrastructure';
 
 type ArchiveType = 'tar.gz' | 'tar.bz2' | 'tbz' | 'tbz2' | 'tb2' | 'bz2' | 'tar' | 'zip';
 
@@ -36,11 +36,9 @@ export interface RepositoryTreeSchema extends Record<string, unknown> {
 
 export class Repositories<C extends boolean = false> extends BaseResource<C> {
   compare(projectId: string | number, from: string, to: string, options?: Sudo) {
-    const pId = encodeURIComponent(projectId);
-
     return RequestHelper.get<RepositoryCompareSchema>()(
       this,
-      `projects/${pId}/repository/compare`,
+      endpoint`projects/${projectId}/repository/compare`,
       {
         from,
         to,
@@ -50,63 +48,55 @@ export class Repositories<C extends boolean = false> extends BaseResource<C> {
   }
 
   contributors(projectId: string | number, options?: Sudo) {
-    const pId = encodeURIComponent(projectId);
-
     return RequestHelper.get<RepositoryContributorSchema[]>()(
       this,
-      `projects/${pId}/repository/contributors`,
+      endpoint`projects/${projectId}/repository/contributors`,
       options,
     );
   }
 
   mergeBase(projectId: string | number, refs: string[], options?: Sudo) {
-    const pId = encodeURIComponent(projectId);
-
-    return RequestHelper.get<CommitSchema>()(this, `projects/${pId}/repository/merge_base`, {
-      refs,
-      ...options,
-    });
+    return RequestHelper.get<CommitSchema>()(
+      this,
+      endpoint`projects/${projectId}/repository/merge_base`,
+      {
+        refs,
+        ...options,
+      },
+    );
   }
 
   showArchive(
     projectId: string | number,
     { fileType = 'tar.gz', ...options }: { fileType?: ArchiveType } & Sudo = {},
   ) {
-    const pId = encodeURIComponent(projectId);
-
     return RequestHelper.get()(
       this,
-      `projects/${pId}/repository/archive.${fileType}`,
+      endpoint`projects/${projectId}/repository/archive.${fileType}`,
       options as Record<string, unknown>,
     ) as unknown as Promise<string>;
   }
 
   showBlob(projectId: string | number, sha: string, options?: Sudo) {
-    const pId = encodeURIComponent(projectId);
-
     return RequestHelper.get()(
       this,
-      `projects/${pId}/repository/blobs/${sha}`,
+      endpoint`projects/${projectId}/repository/blobs/${sha}`,
       options,
     ) as unknown as Promise<Blob>;
   }
 
   showBlobRaw(projectId: string | number, sha: string, options?: Sudo) {
-    const pId = encodeURIComponent(projectId);
-
     return RequestHelper.get()(
       this,
-      `projects/${pId}/repository/blobs/${sha}/raw`,
+      endpoint`projects/${projectId}/repository/blobs/${sha}/raw`,
       options,
     ) as unknown as Promise<Blob>;
   }
 
   tree(projectId: string | number, options?: BaseRequestOptions) {
-    const pId = encodeURIComponent(projectId);
-
     return RequestHelper.get<RepositoryTreeSchema[]>()(
       this,
-      `projects/${pId}/repository/tree`,
+      endpoint`projects/${projectId}/repository/tree`,
       options,
     );
   }

--- a/packages/core/src/resources/RepositoryFiles.ts
+++ b/packages/core/src/resources/RepositoryFiles.ts
@@ -1,6 +1,6 @@
 import { BaseResource } from '@gitbeaker/requester-utils';
 import { CommitSchema } from './Commits';
-import { RequestHelper, BaseRequestOptions, Sudo } from '../infrastructure';
+import { RequestHelper, BaseRequestOptions, endpoint, Sudo } from '../infrastructure';
 
 export interface RepositoryFileExtendedSchema extends Record<string, unknown> {
   file_name: string;
@@ -34,11 +34,9 @@ export class RepositoryFiles<C extends boolean = false> extends BaseResource<C> 
     commitMessage: string,
     options?: BaseRequestOptions,
   ) {
-    const [pId, path] = [projectId, filePath].map(encodeURIComponent);
-
     return RequestHelper.post<RepositoryFileSchema>()(
       this,
-      `projects/${pId}/repository/files/${path}`,
+      endpoint`projects/${projectId}/repository/files/${filePath}`,
       {
         branch,
         content,
@@ -56,11 +54,9 @@ export class RepositoryFiles<C extends boolean = false> extends BaseResource<C> 
     commitMessage: string,
     options?: BaseRequestOptions,
   ) {
-    const [pId, path] = [projectId, filePath].map(encodeURIComponent);
-
     return RequestHelper.put<RepositoryFileSchema>()(
       this,
-      `projects/${pId}/repository/files/${path}`,
+      endpoint`projects/${projectId}/repository/files/${filePath}`,
       {
         branch,
         content,
@@ -77,9 +73,7 @@ export class RepositoryFiles<C extends boolean = false> extends BaseResource<C> 
     commitMessage: string,
     options?: BaseRequestOptions,
   ) {
-    const [pId, path] = [projectId, filePath].map(encodeURIComponent);
-
-    return RequestHelper.del()(this, `projects/${pId}/repository/files/${path}`, {
+    return RequestHelper.del()(this, endpoint`projects/${projectId}/repository/files/${filePath}`, {
       branch,
       commitMessage,
       ...options,
@@ -87,11 +81,9 @@ export class RepositoryFiles<C extends boolean = false> extends BaseResource<C> 
   }
 
   show(projectId: string | number, filePath: string, ref: string, options?: Sudo) {
-    const [pId, path] = [projectId, filePath].map(encodeURIComponent);
-
     return RequestHelper.get<RepositoryFileExtendedSchema>()(
       this,
-      `projects/${pId}/repository/files/${path}`,
+      endpoint`projects/${projectId}/repository/files/${filePath}`,
       {
         ref,
         ...options,
@@ -100,21 +92,17 @@ export class RepositoryFiles<C extends boolean = false> extends BaseResource<C> 
   }
 
   showBlame(projectId: string | number, filePath: string, options?: Sudo) {
-    const [pId, path] = [projectId, filePath].map(encodeURIComponent);
-
     return RequestHelper.get<RepositoryFileBlameSchema[]>()(
       this,
-      `projects/${pId}/repository/files/${path}/blame`,
+      endpoint`projects/${projectId}/repository/files/${filePath}/blame`,
       options,
     );
   }
 
   showRaw(projectId: string | number, filePath: string, options?: BaseRequestOptions) {
-    const [pId, path] = [projectId, filePath].map(encodeURIComponent);
-
     return RequestHelper.get()(
       this,
-      `projects/${pId}/repository/files/${path}/raw`,
+      endpoint`projects/${projectId}/repository/files/${filePath}/raw`,
       options,
     ) as unknown as Promise<Blob>;
   }

--- a/packages/core/src/resources/RepositorySubmodules.ts
+++ b/packages/core/src/resources/RepositorySubmodules.ts
@@ -1,5 +1,5 @@
 import { BaseResource } from '@gitbeaker/requester-utils';
-import { BaseRequestOptions, RequestHelper } from '../infrastructure';
+import { BaseRequestOptions, endpoint, RequestHelper } from '../infrastructure';
 
 export interface RepositorySubmoduleSchema extends Record<string, unknown> {
   id: string;
@@ -25,11 +25,9 @@ export class RepositorySubmodules<C extends boolean = false> extends BaseResourc
     commit_sha: string,
     options?: BaseRequestOptions,
   ) {
-    const [pId, sm] = [projectId, submodule].map(encodeURIComponent);
-
     return RequestHelper.put<RepositorySubmoduleSchema>()(
       this,
-      `projects/${pId}/repository/submodules/${sm}`,
+      endpoint`projects/${projectId}/repository/submodules/${submodule}`,
       {
         branch,
         commit_sha,

--- a/packages/core/src/resources/Runners.ts
+++ b/packages/core/src/resources/Runners.ts
@@ -3,6 +3,7 @@ import { ProjectSchema } from './Projects';
 import { JobSchema } from './Jobs';
 import {
   BaseRequestOptions,
+  endpoint,
   PaginatedRequestOptions,
   RequestHelper,
   Sudo,
@@ -37,7 +38,7 @@ export interface RunnerExtendedSchema extends RunnerSchema {
 
 export class Runners<C extends boolean = false> extends BaseResource<C> {
   all({ projectId, ...options }: { projectId?: string | number } & PaginatedRequestOptions = {}) {
-    const url = projectId ? `projects/${encodeURIComponent(projectId)}/runners` : 'runners/all';
+    const url = projectId ? endpoint`projects/${projectId}/runners` : 'runners/all';
 
     return RequestHelper.get<RunnerSchema[]>()(this, url, options);
   }
@@ -47,41 +48,31 @@ export class Runners<C extends boolean = false> extends BaseResource<C> {
   }
 
   edit(runnerId: number, options?: BaseRequestOptions) {
-    const rId = encodeURIComponent(runnerId);
-
-    return RequestHelper.put<RunnerExtendedSchema>()(this, `runners/${rId}`, options);
+    return RequestHelper.put<RunnerExtendedSchema>()(this, `runners/${runnerId}`, options);
   }
 
   enable(projectId: string | number, runnerId: number, options?: Sudo) {
     const [pId, rId] = [projectId, runnerId].map(encodeURIComponent);
 
-    return RequestHelper.post<RunnerSchema>()(this, `projects/${pId}/runners`, {
+    return RequestHelper.post<RunnerSchema>()(this, endpoint`projects/${pId}/runners`, {
       runnerId: rId,
       ...options,
     });
   }
 
   disable(projectId: string | number, runnerId: number, options?: Sudo) {
-    const [pId, rId] = [projectId, runnerId].map(encodeURIComponent);
-
-    return RequestHelper.del()(this, `projects/${pId}/runners/${rId}`, options);
+    return RequestHelper.del()(this, endpoint`projects/${projectId}/runners/${runnerId}`, options);
   }
 
   jobs(runnerId: number, options?: Sudo) {
-    const rId = encodeURIComponent(runnerId);
-
-    return RequestHelper.get<JobSchema[]>()(this, `runners/${rId}/jobs`, options);
+    return RequestHelper.get<JobSchema[]>()(this, `runners/${runnerId}/jobs`, options);
   }
 
   remove(runnerId: number, options?: Sudo) {
-    const rId = encodeURIComponent(runnerId);
-
-    return RequestHelper.del()(this, `runners/${rId}`, options);
+    return RequestHelper.del()(this, `runners/${runnerId}`, options);
   }
 
   show(runnerId: number, options?: Sudo) {
-    const rId = encodeURIComponent(runnerId);
-
-    return RequestHelper.get<RunnerExtendedSchema>()(this, `runners/${rId}`, options);
+    return RequestHelper.get<RunnerExtendedSchema>()(this, `runners/${runnerId}`, options);
   }
 }

--- a/packages/core/src/resources/Search.ts
+++ b/packages/core/src/resources/Search.ts
@@ -1,5 +1,5 @@
 import { BaseResource } from '@gitbeaker/requester-utils';
-import { RequestHelper, BaseRequestOptions } from '../infrastructure';
+import { RequestHelper, BaseRequestOptions, endpoint } from '../infrastructure';
 
 export interface SearchResultSchema extends Record<string, unknown> {
   id: number;
@@ -30,12 +30,14 @@ export class Search<C extends boolean = false> extends BaseResource<C> {
       ...options
     }: { projectId?: string | number; groupId?: string | number } & BaseRequestOptions = {},
   ) {
-    let url = '';
+    let url: string;
 
     if (projectId) {
-      url += `projects/${encodeURIComponent(projectId)}/`;
+      url = endpoint`projects/${projectId}/`;
     } else if (groupId) {
-      url += `groups/${encodeURIComponent(groupId)}/`;
+      url = endpoint`groups/${groupId}/`;
+    } else {
+      url = '';
     }
 
     return RequestHelper.get<SearchResultSchema[]>()(this, `${url}search`, {

--- a/packages/core/src/resources/Services.ts
+++ b/packages/core/src/resources/Services.ts
@@ -4,6 +4,7 @@ import {
   BaseRequestOptions,
   PaginatedRequestOptions,
   Sudo,
+  endpoint,
 } from '../infrastructure';
 
 export type SupportedService =
@@ -63,33 +64,33 @@ export interface ServiceSchema extends Record<string, unknown> {
 
 export class Services<C extends boolean = false> extends BaseResource<C> {
   all(projectId: string | number, options?: PaginatedRequestOptions) {
-    const pId = encodeURIComponent(projectId);
-
-    return RequestHelper.get<ServiceSchema[]>()(this, `projects/${pId}/services`, options);
+    return RequestHelper.get<ServiceSchema[]>()(
+      this,
+      endpoint`projects/${projectId}/services`,
+      options,
+    );
   }
 
   edit(projectId: string | number, serviceName: SupportedService, options?: BaseRequestOptions) {
-    const pId = encodeURIComponent(projectId);
-
     return RequestHelper.put<ServiceSchema>()(
       this,
-      `projects/${pId}/services/${serviceName}`,
+      endpoint`projects/${projectId}/services/${serviceName}`,
       options,
     );
   }
 
   remove(projectId: string | number, serviceName: SupportedService, options?: Sudo) {
-    const pId = encodeURIComponent(projectId);
-
-    return RequestHelper.del()(this, `projects/${pId}/services/${serviceName}`, options);
+    return RequestHelper.del()(
+      this,
+      endpoint`projects/${projectId}/services/${serviceName}`,
+      options,
+    );
   }
 
   show(projectId: string | number, serviceName: SupportedService, options?: Sudo) {
-    const pId = encodeURIComponent(projectId);
-
     return RequestHelper.get<ServiceSchema>()(
       this,
-      `projects/${pId}/services/${serviceName}`,
+      endpoint`projects/${projectId}/services/${serviceName}`,
       options,
     );
   }

--- a/packages/core/src/resources/Snippets.ts
+++ b/packages/core/src/resources/Snippets.ts
@@ -47,9 +47,7 @@ export class Snippets<C extends boolean = false> extends BaseResource<C> {
   }
 
   content(snippetId: number, options?: Sudo) {
-    const sId = encodeURIComponent(snippetId);
-
-    return RequestHelper.get()(this, `snippets/${sId}/raw`, options);
+    return RequestHelper.get()(this, `snippets/${snippetId}/raw`, options);
   }
 
   create(
@@ -69,29 +67,21 @@ export class Snippets<C extends boolean = false> extends BaseResource<C> {
   }
 
   edit(snippetId: number, options?: BaseRequestOptions) {
-    const sId = encodeURIComponent(snippetId);
-
-    return RequestHelper.put<SnippetExtendedSchema>()(this, `snippets/${sId}`, options);
+    return RequestHelper.put<SnippetExtendedSchema>()(this, `snippets/${snippetId}`, options);
   }
 
   remove(snippetId: number, options?: Sudo) {
-    const sId = encodeURIComponent(snippetId);
-
-    return RequestHelper.del()(this, `snippets/${sId}`, options);
+    return RequestHelper.del()(this, `snippets/${snippetId}`, options);
   }
 
   show(snippetId: number, options?: Sudo) {
-    const sId = encodeURIComponent(snippetId);
-
-    return RequestHelper.get<SnippetSchema>()(this, `snippets/${sId}`, options);
+    return RequestHelper.get<SnippetSchema>()(this, `snippets/${snippetId}`, options);
   }
 
   userAgentDetails(snippetId: number, options?: Sudo) {
-    const sId = encodeURIComponent(snippetId);
-
     return RequestHelper.get<UserAgentDetailSchema>()(
       this,
-      `snippets/${sId}/user_agent_detail`,
+      `snippets/${snippetId}/user_agent_detail`,
       options,
     );
   }

--- a/packages/core/src/resources/SystemHooks.ts
+++ b/packages/core/src/resources/SystemHooks.ts
@@ -27,14 +27,10 @@ export class SystemHooks<C extends boolean = false> extends BaseResource<C> {
   }
 
   edit(hookId: number, url: string, options?: BaseRequestOptions) {
-    const hId = encodeURIComponent(hookId);
-
-    return RequestHelper.put<SystemHookSchema>()(this, `hooks/${hId}`, { url, ...options });
+    return RequestHelper.put<SystemHookSchema>()(this, `hooks/${hookId}`, { url, ...options });
   }
 
   remove(hookId: number, options?: Sudo) {
-    const hId = encodeURIComponent(hookId);
-
-    return RequestHelper.del()(this, `hooks/${hId}`, options);
+    return RequestHelper.del()(this, `hooks/${hookId}`, options);
   }
 }

--- a/packages/core/src/resources/Tags.ts
+++ b/packages/core/src/resources/Tags.ts
@@ -3,6 +3,7 @@ import { CommitSchema } from './Commits';
 import { ReleaseSchema } from './Releases';
 import {
   BaseRequestOptions,
+  endpoint,
   PaginatedRequestOptions,
   RequestHelper,
   Sudo,
@@ -19,26 +20,34 @@ export interface TagSchema extends Record<string, unknown> {
 
 export class Tags<C extends boolean = false> extends BaseResource<C> {
   all(projectId: string | number, options?: PaginatedRequestOptions) {
-    const pId = encodeURIComponent(projectId);
-
-    return RequestHelper.get<TagSchema[]>()(this, `projects/${pId}/repository/tags`, options);
+    return RequestHelper.get<TagSchema[]>()(
+      this,
+      endpoint`projects/${projectId}/repository/tags`,
+      options,
+    );
   }
 
   create(projectId: string | number, options?: BaseRequestOptions) {
-    const pId = encodeURIComponent(projectId);
-
-    return RequestHelper.post<TagSchema>()(this, `projects/${pId}/repository/tags`, options);
+    return RequestHelper.post<TagSchema>()(
+      this,
+      endpoint`projects/${projectId}/repository/tags`,
+      options,
+    );
   }
 
   remove(projectId: string | number, tagName: string, options?: Sudo) {
-    const [pId, tId] = [projectId, tagName].map(encodeURIComponent);
-
-    return RequestHelper.del()(this, `projects/${pId}/repository/tags/${tId}`, options);
+    return RequestHelper.del()(
+      this,
+      endpoint`projects/${projectId}/repository/tags/${tagName}`,
+      options,
+    );
   }
 
   show(projectId: string | number, tagName: string, options?: Sudo) {
-    const [pId, tId] = [projectId, tagName].map(encodeURIComponent);
-
-    return RequestHelper.get<TagSchema>()(this, `projects/${pId}/repository/tags/${tId}`, options);
+    return RequestHelper.get<TagSchema>()(
+      this,
+      endpoint`projects/${projectId}/repository/tags/${tagName}`,
+      options,
+    );
   }
 }

--- a/packages/core/src/resources/Todos.ts
+++ b/packages/core/src/resources/Todos.ts
@@ -2,7 +2,7 @@ import { BaseResource } from '@gitbeaker/requester-utils';
 import { UserSchema } from './Users';
 import { ProjectSchema } from './Projects';
 import { MilestoneSchema } from '../templates/types';
-import { RequestHelper, PaginatedRequestOptions, Sudo } from '../infrastructure';
+import { RequestHelper, PaginatedRequestOptions, Sudo, endpoint } from '../infrastructure';
 
 export interface TodoSchema extends Record<string, unknown> {
   id: number;
@@ -59,7 +59,7 @@ export class Todos<C extends boolean = false> extends BaseResource<C> {
 
     return RequestHelper.post<TodoSchema>()(
       this,
-      `projects/${projectId}/${resourceAPI}/${resourceId}/todo`,
+      endpoint`projects/${projectId}/${resourceAPI}/${resourceId}/todo`,
       options,
     );
   }
@@ -79,6 +79,7 @@ export class Todos<C extends boolean = false> extends BaseResource<C> {
         options as Record<string, unknown>,
       );
     }
+
     return RequestHelper.post<void>()(this, url.join('/'), options as Record<string, unknown>);
   }
 }

--- a/packages/core/src/resources/Triggers.ts
+++ b/packages/core/src/resources/Triggers.ts
@@ -2,6 +2,7 @@ import { BaseResource } from '@gitbeaker/requester-utils';
 import { UserSchema } from './Users';
 import {
   BaseRequestOptions,
+  endpoint,
   PaginatedRequestOptions,
   RequestHelper,
   Sudo,
@@ -20,23 +21,25 @@ export interface PipelineTriggerSchema extends Record<string, unknown> {
 // TODO: Rename PipelineTriggers
 export class Triggers<C extends boolean = false> extends BaseResource<C> {
   add(projectId: string | number, options?: BaseRequestOptions) {
-    const pId = encodeURIComponent(projectId);
-
-    return RequestHelper.post<PipelineTriggerSchema>()(this, `projects/${pId}/triggers`, options);
+    return RequestHelper.post<PipelineTriggerSchema>()(
+      this,
+      endpoint`projects/${projectId}/triggers`,
+      options,
+    );
   }
 
   all(projectId: string | number, options?: PaginatedRequestOptions) {
-    const pId = encodeURIComponent(projectId);
-
-    return RequestHelper.get<PipelineTriggerSchema[]>()(this, `projects/${pId}/triggers`, options);
+    return RequestHelper.get<PipelineTriggerSchema[]>()(
+      this,
+      endpoint`projects/${projectId}/triggers`,
+      options,
+    );
   }
 
   edit(projectId: string | number, triggerId: number, options?: BaseRequestOptions) {
-    const [pId, tId] = [projectId, triggerId].map(encodeURIComponent);
-
     return RequestHelper.put<PipelineTriggerSchema>()(
       this,
-      `projects/${pId}/triggers/${tId}`,
+      endpoint`projects/${projectId}/triggers/${triggerId}`,
       options,
     );
   }
@@ -47,7 +50,6 @@ export class Triggers<C extends boolean = false> extends BaseResource<C> {
     token: string,
     { variables }: { variables?: Record<string, string> } = {},
   ) {
-    const pId = encodeURIComponent(projectId);
     const hapiVariables = {};
 
     if (variables) {
@@ -56,7 +58,7 @@ export class Triggers<C extends boolean = false> extends BaseResource<C> {
       });
     }
 
-    return RequestHelper.post()(this, `projects/${pId}/trigger/pipeline`, {
+    return RequestHelper.post()(this, endpoint`projects/${projectId}/trigger/pipeline`, {
       isForm: true,
       ref,
       token,
@@ -65,17 +67,17 @@ export class Triggers<C extends boolean = false> extends BaseResource<C> {
   }
 
   remove(projectId: string | number, triggerId: number, options?: Sudo) {
-    const [pId, tId] = [projectId, triggerId].map(encodeURIComponent);
-
-    return RequestHelper.del()(this, `projects/${pId}/triggers/${tId}`, options);
+    return RequestHelper.del()(
+      this,
+      endpoint`projects/${projectId}/triggers/${triggerId}`,
+      options,
+    );
   }
 
   show(projectId: string | number, triggerId: number, options?: Sudo) {
-    const [pId, tId] = [projectId, triggerId].map(encodeURIComponent);
-
     return RequestHelper.get<PipelineTriggerSchema>()(
       this,
-      `projects/${pId}/triggers/${tId}`,
+      endpoint`projects/${projectId}/triggers/${triggerId}`,
       options,
     );
   }

--- a/packages/core/src/resources/UserEmails.ts
+++ b/packages/core/src/resources/UserEmails.ts
@@ -7,8 +7,7 @@ export interface UserEmailSchema extends Record<string, unknown> {
   confirmed_at: string;
 }
 
-const url = (userId?: number) =>
-  userId ? `users/${encodeURIComponent(userId)}/emails` : 'user/emails';
+const url = (userId?: number) => (userId ? `users/${userId}/emails` : 'user/emails');
 
 export class UserEmails<C extends boolean = false> extends BaseResource<C> {
   all({ userId, ...options }: { userId?: number } & PaginatedRequestOptions = {}) {
@@ -23,9 +22,7 @@ export class UserEmails<C extends boolean = false> extends BaseResource<C> {
   }
 
   show(emailId: number, options?: BaseRequestOptions) {
-    const eId = encodeURIComponent(emailId);
-
-    return RequestHelper.get<UserEmailSchema>()(this, `user/emails/${eId}`, options);
+    return RequestHelper.get<UserEmailSchema>()(this, `user/emails/${emailId}`, options);
   }
 
   remove(emailId: number, { userId, ...options }: { userId?: number } & BaseRequestOptions = {}) {

--- a/packages/core/src/resources/UserGPGKeys.ts
+++ b/packages/core/src/resources/UserGPGKeys.ts
@@ -7,8 +7,7 @@ export interface UserGPGKeySchema extends Record<string, unknown> {
   created_at: string;
 }
 
-const url = (userId?: number) =>
-  userId ? `users/${encodeURIComponent(userId)}/gpg_keys` : 'user/gpg_keys';
+const url = (userId?: number) => (userId ? `users/${userId}/gpg_keys` : 'user/gpg_keys');
 
 export class UserGPGKeys<C extends boolean = false> extends BaseResource<C> {
   all({ userId, ...options }: { userId?: number } & PaginatedRequestOptions = {}) {

--- a/packages/core/src/resources/UserImpersonationTokens.ts
+++ b/packages/core/src/resources/UserImpersonationTokens.ts
@@ -18,11 +18,9 @@ export interface UserImpersonationTokenSchema extends Record<string, unknown> {
 
 export class UserImpersonationTokens<C extends boolean = false> extends BaseResource<C> {
   all(userId: number, options?: { state?: ImpersonationTokenState } & PaginatedRequestOptions) {
-    const uId = encodeURIComponent(userId);
-
     return RequestHelper.get<UserImpersonationTokenSchema[]>()(
       this,
-      `users/${uId}/impersonation_tokens`,
+      `users/${userId}/impersonation_tokens`,
       options,
     );
   }
@@ -35,11 +33,9 @@ export class UserImpersonationTokens<C extends boolean = false> extends BaseReso
     expiresAt: string,
     options?: Sudo,
   ) {
-    const uId = encodeURIComponent(userId);
-
     return RequestHelper.post<UserImpersonationTokenSchema>()(
       this,
-      `users/${uId}/impersonation_tokens`,
+      `users/${userId}/impersonation_tokens`,
       {
         name,
         expiresAt,
@@ -50,18 +46,14 @@ export class UserImpersonationTokens<C extends boolean = false> extends BaseReso
   }
 
   show(userId: number, tokenId: number, options?: Sudo) {
-    const [uId, tId] = [userId, tokenId].map(encodeURIComponent);
-
     return RequestHelper.get<UserImpersonationTokenSchema>()(
       this,
-      `users/${uId}/impersonation_tokens/${tId}`,
+      `users/${userId}/impersonation_tokens/${tokenId}`,
       options,
     );
   }
 
   revoke(userId: number, tokenId: number, options?: Sudo) {
-    const [uId, tId] = [userId, tokenId].map(encodeURIComponent);
-
-    return RequestHelper.del()(this, `users/${uId}/impersonation_tokens/${tId}`, options);
+    return RequestHelper.del()(this, `users/${userId}/impersonation_tokens/${tokenId}`, options);
   }
 }

--- a/packages/core/src/resources/UserSSHKeys.ts
+++ b/packages/core/src/resources/UserSSHKeys.ts
@@ -8,8 +8,7 @@ export interface UserSSHKeySchema extends Record<string, unknown> {
   created_at: string;
 }
 
-const url = (userId?: number) =>
-  userId ? `users/${encodeURIComponent(userId)}/keys` : 'user/keys';
+const url = (userId?: number) => (userId ? `users/${userId}/keys` : 'user/keys');
 
 export class UserSSHKeys<C extends boolean = false> extends BaseResource<C> {
   all({ userId, ...options }: { userId?: number } & PaginatedRequestOptions = {}) {

--- a/packages/core/src/resources/Users.ts
+++ b/packages/core/src/resources/Users.ts
@@ -59,15 +59,11 @@ export class Users<C extends boolean = false> extends BaseResource<C> {
   }
 
   projects(userId: number, options?: Sudo) {
-    const uId = encodeURIComponent(userId);
-
-    return RequestHelper.get<ProjectExtendedSchema[]>()(this, `users/${uId}/projects`, options);
+    return RequestHelper.get<ProjectExtendedSchema[]>()(this, `users/${userId}/projects`, options);
   }
 
   block(userId: number, options?: Sudo) {
-    const uId = encodeURIComponent(userId);
-
-    return RequestHelper.post()(this, `users/${uId}/block`, options);
+    return RequestHelper.post()(this, `users/${userId}/block`, options);
   }
 
   create(options?: BaseRequestOptions) {
@@ -79,15 +75,11 @@ export class Users<C extends boolean = false> extends BaseResource<C> {
   }
 
   edit(userId: number, options?: BaseRequestOptions) {
-    const uId = encodeURIComponent(userId);
-
-    return RequestHelper.put<UserSchema>()(this, `users/${uId}`, options);
+    return RequestHelper.put<UserSchema>()(this, `users/${userId}`, options);
   }
 
   events(userId: number, options?: BaseRequestOptions & EventOptions) {
-    const uId = encodeURIComponent(userId);
-
-    return RequestHelper.get<EventSchema[]>()(this, `users/${uId}/events`, options);
+    return RequestHelper.get<EventSchema[]>()(this, `users/${userId}/events`, options);
   }
 
   search(emailOrUsername: string, options?: Sudo) {
@@ -98,21 +90,15 @@ export class Users<C extends boolean = false> extends BaseResource<C> {
   }
 
   show(userId: number, options?: BaseRequestOptions) {
-    const uId = encodeURIComponent(userId);
-
-    return RequestHelper.get<UserSchema>()(this, `users/${uId}`, options);
+    return RequestHelper.get<UserSchema>()(this, `users/${userId}`, options);
   }
 
   remove(userId: number, options?: Sudo) {
-    const uId = encodeURIComponent(userId);
-
-    return RequestHelper.del()(this, `users/${uId}`, options);
+    return RequestHelper.del()(this, `users/${userId}`, options);
   }
 
   unblock(userId: number, options?: Sudo) {
-    const uId = encodeURIComponent(userId);
-
-    return RequestHelper.post()(this, `users/${uId}/unblock`, options);
+    return RequestHelper.post()(this, `users/${userId}/unblock`, options);
   }
 
   username(username: string, options?: Sudo) {

--- a/packages/core/src/resources/VulnerabilityFindings.ts
+++ b/packages/core/src/resources/VulnerabilityFindings.ts
@@ -1,5 +1,5 @@
 import { BaseResource } from '@gitbeaker/requester-utils';
-import { PaginatedRequestOptions, RequestHelper } from '../infrastructure';
+import { endpoint, PaginatedRequestOptions, RequestHelper } from '../infrastructure';
 
 export interface VulnerabilityFindingIdentifier {
   external_type: string;
@@ -72,11 +72,9 @@ export class VulnerabilityFindings<C extends boolean = false> extends BaseResour
       pipelineId?: string | number;
     } & PaginatedRequestOptions,
   ) {
-    const pId = encodeURIComponent(projectId);
-
     return RequestHelper.get<VulnerabilityFindingSchema[]>()(
       this,
-      `projects/${pId}/vulnerability_findings`,
+      endpoint`projects/${projectId}/vulnerability_findings`,
       options,
     );
   }

--- a/packages/core/src/resources/Wikis.ts
+++ b/packages/core/src/resources/Wikis.ts
@@ -1,6 +1,7 @@
 import { BaseResource } from '@gitbeaker/requester-utils';
 import {
   BaseRequestOptions,
+  endpoint,
   PaginatedRequestOptions,
   RequestHelper,
   Sudo,
@@ -15,32 +16,30 @@ export interface WikiSchema extends Record<string, unknown> {
 
 export class Wikis<C extends boolean = false> extends BaseResource<C> {
   all(projectId: string | number, options?: PaginatedRequestOptions) {
-    const pId = encodeURIComponent(projectId);
-
-    return RequestHelper.get<WikiSchema[]>()(this, `projects/${pId}/wikis`, options);
+    return RequestHelper.get<WikiSchema[]>()(this, endpoint`projects/${projectId}/wikis`, options);
   }
 
   create(projectId: string | number, options?: BaseRequestOptions) {
-    const pId = encodeURIComponent(projectId);
-
-    return RequestHelper.post<WikiSchema>()(this, `projects/${pId}/wikis`, options);
+    return RequestHelper.post<WikiSchema>()(this, endpoint`projects/${projectId}/wikis`, options);
   }
 
   edit(projectId: string | number, slug: string, options?: BaseRequestOptions) {
-    const [pId, s] = [projectId, slug].map(encodeURIComponent);
-
-    return RequestHelper.put<WikiSchema>()(this, `projects/${pId}/wikis/${s}`, options);
+    return RequestHelper.put<WikiSchema>()(
+      this,
+      endpoint`projects/${projectId}/wikis/${slug}`,
+      options,
+    );
   }
 
   show(projectId: string | number, slug: string, options?: Sudo) {
-    const [pId, s] = [projectId, slug].map(encodeURIComponent);
-
-    return RequestHelper.get<WikiSchema>()(this, `projects/${pId}/wikis/${s}`, options);
+    return RequestHelper.get<WikiSchema>()(
+      this,
+      endpoint`projects/${projectId}/wikis/${slug}`,
+      options,
+    );
   }
 
   remove(projectId: string | number, slug: string, options?: Sudo) {
-    const [pId, s] = [projectId, slug].map(encodeURIComponent);
-
-    return RequestHelper.del()(this, `projects/${pId}/wikis/${s}`, options);
+    return RequestHelper.del()(this, endpoint`projects/${projectId}/wikis/${slug}`, options);
   }
 }

--- a/packages/core/src/templates/ResourceAccessRequests.ts
+++ b/packages/core/src/templates/ResourceAccessRequests.ts
@@ -1,5 +1,5 @@
 import { BaseResource, BaseResourceOptions } from '@gitbeaker/requester-utils';
-import { RequestHelper, Sudo } from '../infrastructure';
+import { endpoint, RequestHelper, Sudo } from '../infrastructure';
 
 export type AccessLevel = 0 | 5 | 10 | 20 | 30 | 40 | 50;
 
@@ -18,15 +18,14 @@ export class ResourceAccessRequests<C extends boolean = false> extends BaseResou
   }
 
   all(resourceId: string | number) {
-    const rId = encodeURIComponent(resourceId);
-
-    return RequestHelper.get<AccessRequestSchema[]>()(this, `${rId}/access_requests`);
+    return RequestHelper.get<AccessRequestSchema[]>()(
+      this,
+      endpoint`${resourceId}/access_requests`,
+    );
   }
 
   request(resourceId: string | number) {
-    const rId = encodeURIComponent(resourceId);
-
-    return RequestHelper.post<AccessRequestSchema>()(this, `${rId}/access_requests`);
+    return RequestHelper.post<AccessRequestSchema>()(this, endpoint`${resourceId}/access_requests`);
   }
 
   approve(
@@ -34,18 +33,14 @@ export class ResourceAccessRequests<C extends boolean = false> extends BaseResou
     userId: number,
     options?: { accessLevel?: AccessLevel } & Sudo,
   ) {
-    const [rId, uId] = [resourceId, userId].map(encodeURIComponent);
-
     return RequestHelper.post<AccessRequestSchema>()(
       this,
-      `${rId}/access_requests/${uId}/approve`,
+      endpoint`${resourceId}/access_requests/${userId}/approve`,
       options,
     );
   }
 
   deny(resourceId: string | number, userId: number) {
-    const [rId, uId] = [resourceId, userId].map(encodeURIComponent);
-
-    return RequestHelper.del()(this, `${rId}/access_requests/${uId}`);
+    return RequestHelper.del()(this, endpoint`${resourceId}/access_requests/${userId}`);
   }
 }

--- a/packages/core/src/templates/ResourceBadges.ts
+++ b/packages/core/src/templates/ResourceBadges.ts
@@ -1,6 +1,7 @@
 import { BaseResource, BaseResourceOptions } from '@gitbeaker/requester-utils';
 import {
   BaseRequestOptions,
+  endpoint,
   PaginatedRequestOptions,
   RequestHelper,
   Sudo,
@@ -22,42 +23,38 @@ export class ResourceBadges<C extends boolean = false> extends BaseResource<C> {
   }
 
   add(resourceId: string | number, options?: BaseRequestOptions) {
-    const rId = encodeURIComponent(resourceId);
-
-    return RequestHelper.post<BadgeSchema>()(this, `${rId}/badges`, options);
+    return RequestHelper.post<BadgeSchema>()(this, endpoint`${resourceId}/badges`, options);
   }
 
   all(resourceId: string | number, options?: PaginatedRequestOptions) {
-    const rId = encodeURIComponent(resourceId);
-
-    return RequestHelper.get<BadgeSchema[]>()(this, `${rId}/badges`, options);
+    return RequestHelper.get<BadgeSchema[]>()(this, endpoint`${resourceId}/badges`, options);
   }
 
   edit(resourceId: string | number, badgeId: number, options?: BaseRequestOptions) {
-    const [rId, bId] = [resourceId, badgeId].map(encodeURIComponent);
-
-    return RequestHelper.put<BadgeSchema>()(this, `${rId}/badges/${bId}`, options);
+    return RequestHelper.put<BadgeSchema>()(
+      this,
+      endpoint`${resourceId}/badges/${badgeId}`,
+      options,
+    );
   }
 
   preview(resourceId: string | number, linkUrl: string, imageUrl: string, options?: Sudo) {
-    const rId = encodeURIComponent(resourceId);
-
     return RequestHelper.get<Omit<BadgeSchema, 'id' | 'name' | 'kind'>>()(
       this,
-      `${rId}/badges/render`,
+      endpoint`${resourceId}/badges/render`,
       { linkUrl, imageUrl, ...options },
     );
   }
 
   remove(resourceId: string | number, badgeId: number, options?: Sudo) {
-    const [rId, bId] = [resourceId, badgeId].map(encodeURIComponent);
-
-    return RequestHelper.del()(this, `${rId}/badges/${bId}`, options);
+    return RequestHelper.del()(this, endpoint`${resourceId}/badges/${badgeId}`, options);
   }
 
   show(resourceId: string | number, badgeId: number, options?: Sudo) {
-    const [rId, bId] = [resourceId, badgeId].map(encodeURIComponent);
-
-    return RequestHelper.get<BadgeSchema>()(this, `${rId}/badges/${bId}`, options);
+    return RequestHelper.get<BadgeSchema>()(
+      this,
+      endpoint`${resourceId}/badges/${badgeId}`,
+      options,
+    );
   }
 }

--- a/packages/core/src/templates/ResourceCustomAttributes.ts
+++ b/packages/core/src/templates/ResourceCustomAttributes.ts
@@ -1,5 +1,5 @@
 import { BaseResource, BaseResourceOptions } from '@gitbeaker/requester-utils';
-import { PaginatedRequestOptions, RequestHelper, Sudo } from '../infrastructure';
+import { endpoint, PaginatedRequestOptions, RequestHelper, Sudo } from '../infrastructure';
 
 export interface CustomAttributeSchema extends Record<string, unknown> {
   key: string;
@@ -12,32 +12,36 @@ export class ResourceCustomAttributes<C extends boolean = false> extends BaseRes
   }
 
   all(resourceId: string | number, options?: PaginatedRequestOptions) {
-    const rId = encodeURIComponent(resourceId);
-
-    return RequestHelper.get<CustomAttributeSchema[]>()(this, `${rId}/custom_attributes`, options);
+    return RequestHelper.get<CustomAttributeSchema[]>()(
+      this,
+      endpoint`${resourceId}/custom_attributes`,
+      options,
+    );
   }
 
   set(resourceId: string | number, customAttributeId: number, value: string, options?: Sudo) {
-    const [rId, cId] = [resourceId, customAttributeId].map(encodeURIComponent);
-
-    return RequestHelper.put<CustomAttributeSchema>()(this, `${rId}/custom_attributes/${cId}`, {
-      value,
-      ...options,
-    });
+    return RequestHelper.put<CustomAttributeSchema>()(
+      this,
+      endpoint`${resourceId}/custom_attributes/${customAttributeId}`,
+      {
+        value,
+        ...options,
+      },
+    );
   }
 
   remove(resourceId: string | number, customAttributeId: number, options?: Sudo) {
-    const [rId, cId] = [resourceId, customAttributeId].map(encodeURIComponent);
-
-    return RequestHelper.del()(this, `${rId}/custom_attributes/${cId}`, options);
+    return RequestHelper.del()(
+      this,
+      endpoint`${resourceId}/custom_attributes/${customAttributeId}`,
+      options,
+    );
   }
 
   show(resourceId: string | number, customAttributeId: number, options?: Sudo) {
-    const [rId, cId] = [resourceId, customAttributeId].map(encodeURIComponent);
-
     return RequestHelper.get<CustomAttributeSchema>()(
       this,
-      `${rId}/custom_attributes/${cId}`,
+      endpoint`${resourceId}/custom_attributes/${customAttributeId}`,
       options,
     );
   }

--- a/packages/core/src/templates/ResourceDeployTokens.ts
+++ b/packages/core/src/templates/ResourceDeployTokens.ts
@@ -1,6 +1,7 @@
 import { BaseResource, BaseResourceOptions } from '@gitbeaker/requester-utils';
 import {
   BaseRequestOptions,
+  endpoint,
   PaginatedRequestOptions,
   RequestHelper,
   Sudo,
@@ -33,15 +34,11 @@ export class ResourceDeployTokens<C extends boolean = false> extends BaseResourc
     tokenScopes: DeployTokenScope[],
     options?: BaseRequestOptions,
   ) {
-    return RequestHelper.post<DeployTokenSchema>()(
-      this,
-      `${encodeURIComponent(resourceId)}/deploy_tokens`,
-      {
-        name: tokenName,
-        scopes: tokenScopes,
-        ...options,
-      },
-    );
+    return RequestHelper.post<DeployTokenSchema>()(this, endpoint`${resourceId}/deploy_tokens`, {
+      name: tokenName,
+      scopes: tokenScopes,
+      ...options,
+    });
   }
 
   all({
@@ -56,15 +53,13 @@ export class ResourceDeployTokens<C extends boolean = false> extends BaseResourc
   } & PaginatedRequestOptions = {}) {
     const prefix =
       resourceId || projectId || groupId
-        ? `${encodeURIComponent((resourceId || projectId || groupId) as string)}/`
+        ? endpoint`${(resourceId || projectId || groupId) as string}/`
         : '';
 
     return RequestHelper.get<DeployTokenSchema[]>()(this, `${prefix}deploy_tokens`, options);
   }
 
   remove(resourceId: string | number, tokenId: number, options?: Sudo) {
-    const [rId, tId] = [resourceId, tokenId].map(encodeURIComponent);
-
-    return RequestHelper.del()(this, `${rId}/deploy_tokens/${tId}`, options);
+    return RequestHelper.del()(this, endpoint`${resourceId}/deploy_tokens/${tokenId}`, options);
   }
 }

--- a/packages/core/src/templates/ResourceDiscussions.ts
+++ b/packages/core/src/templates/ResourceDiscussions.ts
@@ -2,6 +2,7 @@ import { BaseResource, BaseResourceOptions } from '@gitbeaker/requester-utils';
 import { UserSchema } from '../resources/Users';
 import {
   BaseRequestOptions,
+  endpoint,
   PaginatedRequestOptions,
   RequestHelper,
   Sudo,
@@ -57,14 +58,10 @@ export class ResourceDiscussions<C extends boolean = false> extends BaseResource
     body: string,
     options?: BaseRequestOptions,
   ) {
-    const [rId, r2Id, dId, nId] = [resourceId, resource2Id, discussionId, noteId].map(
-      encodeURIComponent,
-    );
-
     return RequestHelper.post()(
       this,
-      `${rId}/${this.resource2Type}/${r2Id}/discussions/${dId}/notes`,
-      { query: { body }, noteId: nId, ...options },
+      endpoint`${resourceId}/${this.resource2Type}/${resource2Id}/discussions/${discussionId}/notes`,
+      { query: { body }, noteId, ...options },
     );
   }
 
@@ -73,11 +70,9 @@ export class ResourceDiscussions<C extends boolean = false> extends BaseResource
     resource2Id: string | number,
     options?: PaginatedRequestOptions,
   ) {
-    const [rId, r2Id] = [resourceId, resource2Id].map(encodeURIComponent);
-
     return RequestHelper.get<DiscussionSchema[]>()(
       this,
-      `${rId}/${this.resource2Type}/${r2Id}/discussions`,
+      endpoint`${resourceId}/${this.resource2Type}/${resource2Id}/discussions`,
       options,
     );
   }
@@ -88,11 +83,9 @@ export class ResourceDiscussions<C extends boolean = false> extends BaseResource
     body: string,
     options?: BaseRequestOptions,
   ) {
-    const [rId, r2Id] = [resourceId, resource2Id].map(encodeURIComponent);
-
     return RequestHelper.post<DiscussionSchema>()(
       this,
-      `${rId}/${this.resource2Type}/${r2Id}/discussions`,
+      endpoint`${resourceId}/${this.resource2Type}/${resource2Id}/discussions`,
       {
         query: { body },
         ...options,
@@ -107,13 +100,9 @@ export class ResourceDiscussions<C extends boolean = false> extends BaseResource
     noteId: number,
     { body, ...options }: BaseRequestOptions & { body?: string } = {},
   ) {
-    const [rId, r2Id, dId, nId] = [resourceId, resource2Id, discussionId, noteId].map(
-      encodeURIComponent,
-    );
-
     return RequestHelper.put<DiscussionSchema>()(
       this,
-      `${rId}/${this.resource2Type}/${r2Id}/discussions/${dId}/notes/${nId}`,
+      endpoint`${resourceId}/${this.resource2Type}/${resource2Id}/discussions/${discussionId}/notes/${noteId}`,
       {
         query: { body },
         ...options,
@@ -128,13 +117,9 @@ export class ResourceDiscussions<C extends boolean = false> extends BaseResource
     noteId: number,
     options?: Sudo,
   ) {
-    const [rId, r2Id, dId, nId] = [resourceId, resource2Id, discussionId, noteId].map(
-      encodeURIComponent,
-    );
-
     return RequestHelper.del()(
       this,
-      `${rId}/${this.resource2Type}/${r2Id}/discussions/${dId}/notes/${nId}`,
+      endpoint`${resourceId}/${this.resource2Type}/${resource2Id}/discussions/${discussionId}/notes/${noteId}`,
       options,
     );
   }
@@ -145,11 +130,9 @@ export class ResourceDiscussions<C extends boolean = false> extends BaseResource
     discussionId: string | number,
     options?: Sudo,
   ) {
-    const [rId, r2Id, dId] = [resourceId, resource2Id, discussionId].map(encodeURIComponent);
-
     return RequestHelper.get<DiscussionSchema>()(
       this,
-      `${rId}/${this.resource2Type}/${r2Id}/discussions/${dId}`,
+      endpoint`${resourceId}/${this.resource2Type}/${resource2Id}/discussions/${discussionId}`,
       options,
     );
   }

--- a/packages/core/src/templates/ResourceIssueBoards.ts
+++ b/packages/core/src/templates/ResourceIssueBoards.ts
@@ -3,6 +3,7 @@ import { MilestoneSchema } from './ResourceMilestones';
 import { LabelSchema } from './ResourceLabels';
 import {
   BaseRequestOptions,
+  endpoint,
   PaginatedRequestOptions,
   RequestHelper,
   Sudo,
@@ -30,15 +31,14 @@ export class ResourceIssueBoards<C extends boolean = false> extends BaseResource
   }
 
   all(resourceId: string | number, options?: PaginatedRequestOptions) {
-    const rId = encodeURIComponent(resourceId);
-
-    return RequestHelper.get<IssueBoardSchema[]>()(this, `${rId}/boards`, options);
+    return RequestHelper.get<IssueBoardSchema[]>()(this, endpoint`${resourceId}/boards`, options);
   }
 
   create(resourceId: string | number, name: string, options?: Sudo) {
-    const rId = encodeURIComponent(resourceId);
-
-    return RequestHelper.post<IssueBoardSchema>()(this, `${rId}/boards`, { name, ...options });
+    return RequestHelper.post<IssueBoardSchema>()(this, endpoint`${resourceId}/boards`, {
+      name,
+      ...options,
+    });
   }
 
   createList(
@@ -47,18 +47,18 @@ export class ResourceIssueBoards<C extends boolean = false> extends BaseResource
     labelId: number | string,
     options?: Sudo,
   ) {
-    const [rId, bId] = [resourceId, boardId].map(encodeURIComponent);
-
-    return RequestHelper.post<IssueBoardListSchema>()(this, `${rId}/boards/${bId}/lists`, {
-      labelId,
-      ...options,
-    });
+    return RequestHelper.post<IssueBoardListSchema>()(
+      this,
+      endpoint`${resourceId}/boards/${boardId}/lists`,
+      {
+        labelId,
+        ...options,
+      },
+    );
   }
 
   edit(resourceId: string | number, boardId: number, options?: BaseRequestOptions) {
-    const [rId, bId] = [resourceId, boardId].map(encodeURIComponent);
-
-    return RequestHelper.put()(this, `${rId}/boards/${bId}`, options);
+    return RequestHelper.put()(this, endpoint`${resourceId}/boards/${boardId}`, options);
   }
 
   editList(
@@ -68,44 +68,48 @@ export class ResourceIssueBoards<C extends boolean = false> extends BaseResource
     position: number,
     options?: Sudo,
   ) {
-    const [rId, bId, lId] = [resourceId, boardId, listId].map(encodeURIComponent);
-
-    return RequestHelper.put<IssueBoardListSchema>()(this, `${rId}/boards/${bId}/lists/${lId}`, {
-      position,
-      ...options,
-    });
+    return RequestHelper.put<IssueBoardListSchema>()(
+      this,
+      endpoint`${resourceId}/boards/${boardId}/lists/${listId}`,
+      {
+        position,
+        ...options,
+      },
+    );
   }
 
   lists(resourceId: string | number, boardId: number, options?: Sudo) {
-    const [rId, bId] = [resourceId, boardId].map(encodeURIComponent);
-
-    return RequestHelper.get<IssueBoardListSchema[]>()(this, `${rId}/boards/${bId}/lists`, options);
+    return RequestHelper.get<IssueBoardListSchema[]>()(
+      this,
+      endpoint`${resourceId}/boards/${boardId}/lists`,
+      options,
+    );
   }
 
   remove(resourceId: string | number, boardId: number, options?: Sudo) {
-    const [rId, bId] = [resourceId, boardId].map(encodeURIComponent);
-
-    return RequestHelper.del()(this, `${rId}/boards/${bId}`, options);
+    return RequestHelper.del()(this, endpoint`${resourceId}/boards/${boardId}`, options);
   }
 
   removeList(resourceId: string | number, boardId: number, listId: number, options?: Sudo) {
-    const [rId, bId, lId] = [resourceId, boardId, listId].map(encodeURIComponent);
-
-    return RequestHelper.del()(this, `${rId}/boards/${bId}/lists/${lId}`, options);
+    return RequestHelper.del()(
+      this,
+      endpoint`${resourceId}/boards/${boardId}/lists/${listId}`,
+      options,
+    );
   }
 
   show(resourceId: string | number, boardId: number, options?: Sudo) {
-    const [rId, bId] = [resourceId, boardId].map(encodeURIComponent);
-
-    return RequestHelper.get<IssueBoardSchema>()(this, `${rId}/boards/${bId}`, options);
+    return RequestHelper.get<IssueBoardSchema>()(
+      this,
+      endpoint`${resourceId}/boards/${boardId}`,
+      options,
+    );
   }
 
   showList(resourceId: string | number, boardId: number, listId: number, options?: Sudo) {
-    const [rId, bId, lId] = [resourceId, boardId, listId].map(encodeURIComponent);
-
     return RequestHelper.get<IssueBoardListSchema>()(
       this,
-      `${rId}/boards/${bId}/lists/${lId}`,
+      endpoint`${resourceId}/boards/${boardId}/lists/${listId}`,
       options,
     );
   }

--- a/packages/core/src/templates/ResourceLabels.ts
+++ b/packages/core/src/templates/ResourceLabels.ts
@@ -5,6 +5,7 @@ import {
   RequestHelper,
   Sudo,
   ShowExpanded,
+  endpoint,
 } from '../infrastructure';
 
 export interface LabelSchema extends Record<string, unknown> {
@@ -28,9 +29,7 @@ export class ResourceLabels<C extends boolean = false> extends BaseResource<C> {
   }
 
   all(resourceId: string | number, options?: PaginatedRequestOptions) {
-    const rId = encodeURIComponent(resourceId);
-
-    return RequestHelper.get<LabelSchema[]>()(this, `${rId}/labels`, options);
+    return RequestHelper.get<LabelSchema[]>()(this, endpoint`${resourceId}/labels`, options);
   }
 
   create(
@@ -39,9 +38,7 @@ export class ResourceLabels<C extends boolean = false> extends BaseResource<C> {
     color: string,
     options?: BaseRequestOptions,
   ) {
-    const rId = encodeURIComponent(resourceId);
-
-    return RequestHelper.post<LabelSchema>()(this, `${rId}/labels`, {
+    return RequestHelper.post<LabelSchema>()(this, endpoint`${resourceId}/labels`, {
       name: labelName,
       color,
       ...options,
@@ -49,21 +46,23 @@ export class ResourceLabels<C extends boolean = false> extends BaseResource<C> {
   }
 
   edit(resourceId: string | number, labelId: number | string, options?: BaseRequestOptions) {
-    const [rId, lId] = [resourceId, labelId].map(encodeURIComponent);
-
-    return RequestHelper.put<LabelSchema>()(this, `${rId}/labels/${lId}`, options);
+    return RequestHelper.put<LabelSchema>()(
+      this,
+      endpoint`${resourceId}/labels/${labelId}`,
+      options,
+    );
   }
 
   remove(resourceId: string | number, labelId: number | string, options?: Sudo & ShowExpanded) {
-    const [rId, lId] = [resourceId, labelId].map(encodeURIComponent);
-
-    return RequestHelper.del()(this, `${rId}/labels/${lId}`, options);
+    return RequestHelper.del()(this, endpoint`${resourceId}/labels/${labelId}`, options);
   }
 
   subscribe(resourceId: string | number, labelId: number | string, options?: Sudo & ShowExpanded) {
-    const [rId, lId] = [resourceId, labelId].map(encodeURIComponent);
-
-    return RequestHelper.post<LabelSchema>()(this, `${rId}/issues/${lId}/subscribe`, options);
+    return RequestHelper.post<LabelSchema>()(
+      this,
+      endpoint`${resourceId}/issues/${labelId}/subscribe`,
+      options,
+    );
   }
 
   unsubscribe(
@@ -71,8 +70,10 @@ export class ResourceLabels<C extends boolean = false> extends BaseResource<C> {
     labelId: number | string,
     options?: Sudo & ShowExpanded,
   ) {
-    const [rId, lId] = [resourceId, labelId].map(encodeURIComponent);
-
-    return RequestHelper.post<LabelSchema>()(this, `${rId}/issues/${lId}/unsubscribe`, options);
+    return RequestHelper.post<LabelSchema>()(
+      this,
+      endpoint`${resourceId}/issues/${labelId}/unsubscribe`,
+      options,
+    );
   }
 }

--- a/packages/core/src/templates/ResourceMembers.ts
+++ b/packages/core/src/templates/ResourceMembers.ts
@@ -1,6 +1,7 @@
 import { BaseResource, BaseResourceOptions } from '@gitbeaker/requester-utils';
 import {
   BaseRequestOptions,
+  endpoint,
   PaginatedRequestOptions,
   RequestHelper,
   Sudo,
@@ -39,10 +40,8 @@ export class ResourceMembers<C extends boolean = false> extends BaseResource<C> 
     accessLevel: AccessLevel,
     options?: BaseRequestOptions,
   ) {
-    const [rId, uId] = [resourceId, userId].map(encodeURIComponent);
-
-    return RequestHelper.post<MemberSchema>()(this, `${rId}/members`, {
-      userId: uId,
+    return RequestHelper.post<MemberSchema>()(this, endpoint`${resourceId}/members`, {
+      userId: String(userId),
       accessLevel,
       ...options,
     });
@@ -66,9 +65,7 @@ export class ResourceMembers<C extends boolean = false> extends BaseResource<C> 
     accessLevel: AccessLevel,
     options?: BaseRequestOptions,
   ) {
-    const [rId, uId] = [resourceId, userId].map(encodeURIComponent);
-
-    return RequestHelper.put<MemberSchema>()(this, `${rId}/members/${uId}`, {
+    return RequestHelper.put<MemberSchema>()(this, endpoint`${resourceId}/members/${userId}`, {
       accessLevel,
       ...options,
     });
@@ -94,8 +91,6 @@ export class ResourceMembers<C extends boolean = false> extends BaseResource<C> 
   }
 
   remove(resourceId: string | number, userId: number, options?: Sudo) {
-    const [rId, uId] = [resourceId, userId].map(encodeURIComponent);
-
-    return RequestHelper.del()(this, `${rId}/members/${uId}`, options);
+    return RequestHelper.del()(this, endpoint`${resourceId}/members/${userId}`, options);
   }
 }

--- a/packages/core/src/templates/ResourceMilestones.ts
+++ b/packages/core/src/templates/ResourceMilestones.ts
@@ -4,6 +4,7 @@ import {
   PaginatedRequestOptions,
   BaseRequestOptions,
   Sudo,
+  endpoint,
 } from '../infrastructure';
 import { IssueSchema } from '../resources/Issues';
 import { MergeRequestSchema } from '../resources/MergeRequests';
@@ -29,42 +30,49 @@ export class ResourceMilestones<C extends boolean = false> extends BaseResource<
   }
 
   all(resourceId: string | number, options?: PaginatedRequestOptions) {
-    const rId = encodeURIComponent(resourceId);
-
-    return RequestHelper.get<MilestoneSchema[]>()(this, `${rId}/milestones`, options);
+    return RequestHelper.get<MilestoneSchema[]>()(
+      this,
+      endpoint`${resourceId}/milestones`,
+      options,
+    );
   }
 
   create(resourceId: string | number, title: string, options?: BaseRequestOptions) {
-    const rId = encodeURIComponent(resourceId);
-
-    return RequestHelper.post<MilestoneSchema>()(this, `${rId}/milestones`, { title, ...options });
+    return RequestHelper.post<MilestoneSchema>()(this, endpoint`${resourceId}/milestones`, {
+      title,
+      ...options,
+    });
   }
 
   edit(resourceId: string | number, milestoneId: number, options?: BaseRequestOptions) {
-    const [rId, mId] = [resourceId, milestoneId].map(encodeURIComponent);
-
-    return RequestHelper.put<MilestoneSchema>()(this, `${rId}/milestones/${mId}`, options);
+    return RequestHelper.put<MilestoneSchema>()(
+      this,
+      endpoint`${resourceId}/milestones/${milestoneId}`,
+      options,
+    );
   }
 
   issues(resourceId: string | number, milestoneId: number, options?: Sudo) {
-    const [rId, mId] = [resourceId, milestoneId].map(encodeURIComponent);
-
-    return RequestHelper.get<IssueSchema[]>()(this, `${rId}/milestones/${mId}/issues`, options);
+    return RequestHelper.get<IssueSchema[]>()(
+      this,
+      endpoint`${resourceId}/milestones/${milestoneId}/issues`,
+      options,
+    );
   }
 
   mergeRequests(resourceId: string | number, milestoneId: number, options?: Sudo) {
-    const [rId, mId] = [resourceId, milestoneId].map(encodeURIComponent);
-
     return RequestHelper.get<MergeRequestSchema[]>()(
       this,
-      `${rId}/milestones/${mId}/merge_requests`,
+      endpoint`${resourceId}/milestones/${milestoneId}/merge_requests`,
       options,
     );
   }
 
   show(resourceId: string | number, milestoneId: number, options?: Sudo) {
-    const [rId, mId] = [resourceId, milestoneId].map(encodeURIComponent);
-
-    return RequestHelper.get<MilestoneSchema>()(this, `${rId}/milestones/${mId}`, options);
+    return RequestHelper.get<MilestoneSchema>()(
+      this,
+      endpoint`${resourceId}/milestones/${milestoneId}`,
+      options,
+    );
   }
 }

--- a/packages/core/src/templates/ResourceNotes.ts
+++ b/packages/core/src/templates/ResourceNotes.ts
@@ -5,6 +5,7 @@ import {
   PaginatedRequestOptions,
   BaseRequestOptions,
   Sudo,
+  endpoint,
 } from '../infrastructure';
 
 export interface NoteSchema extends Record<string, unknown> {
@@ -30,11 +31,9 @@ export class ResourceNotes<C extends boolean = false> extends BaseResource<C> {
     resource2Id: string | number,
     options?: PaginatedRequestOptions,
   ) {
-    const [rId, r2Id] = [resourceId, resource2Id].map(encodeURIComponent);
-
     return RequestHelper.get<NoteSchema[]>()(
       this,
-      `${rId}/${this.resource2Type}/${r2Id}/notes`,
+      endpoint`${resourceId}/${this.resource2Type}/${resource2Id}/notes`,
       options,
     );
   }
@@ -45,12 +44,14 @@ export class ResourceNotes<C extends boolean = false> extends BaseResource<C> {
     body: string,
     options?: BaseRequestOptions,
   ) {
-    const [rId, r2Id] = [resourceId, resource2Id].map(encodeURIComponent);
-
-    return RequestHelper.post<NoteSchema>()(this, `${rId}/${this.resource2Type}/${r2Id}/notes`, {
-      body,
-      ...options,
-    });
+    return RequestHelper.post<NoteSchema>()(
+      this,
+      endpoint`${resourceId}/${this.resource2Type}/${resource2Id}/notes`,
+      {
+        body,
+        ...options,
+      },
+    );
   }
 
   edit(
@@ -60,11 +61,9 @@ export class ResourceNotes<C extends boolean = false> extends BaseResource<C> {
     body: string,
     options?: BaseRequestOptions,
   ) {
-    const [rId, r2Id, nId] = [resourceId, resource2Id, noteId].map(encodeURIComponent);
-
     return RequestHelper.put<NoteSchema>()(
       this,
-      `${rId}/${this.resource2Type}/${r2Id}/notes/${nId}`,
+      endpoint`${resourceId}/${this.resource2Type}/${resource2Id}/notes/${noteId}`,
       {
         body,
         ...options,
@@ -78,17 +77,17 @@ export class ResourceNotes<C extends boolean = false> extends BaseResource<C> {
     noteId: number,
     options?: Sudo,
   ) {
-    const [rId, r2Id, nId] = [resourceId, resource2Id, noteId].map(encodeURIComponent);
-
-    return RequestHelper.del()(this, `${rId}/${this.resource2Type}/${r2Id}/notes/${nId}`, options);
+    return RequestHelper.del()(
+      this,
+      endpoint`${resourceId}/${this.resource2Type}/${resource2Id}/notes/${noteId}`,
+      options,
+    );
   }
 
   show(resourceId: string | number, resource2Id: string | number, noteId: number, options?: Sudo) {
-    const [rId, r2Id, nId] = [resourceId, resource2Id, noteId].map(encodeURIComponent);
-
     return RequestHelper.get<NoteSchema>()(
       this,
-      `${rId}/${this.resource2Type}/${r2Id}/notes/${nId}`,
+      endpoint`${resourceId}/${this.resource2Type}/${resource2Id}/notes/${noteId}`,
       options,
     );
   }

--- a/packages/core/src/templates/ResourceTemplates.ts
+++ b/packages/core/src/templates/ResourceTemplates.ts
@@ -16,8 +16,6 @@ export class ResourceTemplates<C extends boolean = false> extends BaseResource<C
   }
 
   show(key: string | number, options?: Sudo) {
-    const rId = encodeURIComponent(key);
-
-    return RequestHelper.get<TemplateSchema>()(this, `${rId}`, options);
+    return RequestHelper.get<TemplateSchema>()(this, encodeURIComponent(key), options);
   }
 }

--- a/packages/core/src/templates/ResourceVariables.ts
+++ b/packages/core/src/templates/ResourceVariables.ts
@@ -1,5 +1,5 @@
 import { BaseResource, BaseResourceOptions } from '@gitbeaker/requester-utils';
-import { RequestHelper, PaginatedRequestOptions } from '../infrastructure';
+import { RequestHelper, PaginatedRequestOptions, endpoint } from '../infrastructure';
 
 export interface VariableSchema extends Record<string, unknown> {
   variable_type: 'env_var' | 'file';
@@ -16,32 +16,30 @@ export class ResourceVariables<C extends boolean> extends BaseResource<C> {
   }
 
   all(resourceId: string | number, options?: PaginatedRequestOptions) {
-    const rId = encodeURIComponent(resourceId);
-
-    return RequestHelper.get<VariableSchema[]>()(this, `${rId}/variables`, options);
+    return RequestHelper.get<VariableSchema[]>()(this, endpoint`${resourceId}/variables`, options);
   }
 
   create(resourceId: string | number, options?: VariableSchema) {
-    const rId = encodeURIComponent(resourceId);
-
-    return RequestHelper.post<VariableSchema>()(this, `${rId}/variables`, options);
+    return RequestHelper.post<VariableSchema>()(this, endpoint`${resourceId}/variables`, options);
   }
 
   edit(resourceId: string | number, keyId: string, options?: Omit<VariableSchema, 'key'>) {
-    const [rId, kId] = [resourceId, keyId].map(encodeURIComponent);
-
-    return RequestHelper.put<VariableSchema>()(this, `${rId}/variables/${kId}`, options);
+    return RequestHelper.put<VariableSchema>()(
+      this,
+      endpoint`${resourceId}/variables/${keyId}`,
+      options,
+    );
   }
 
   show(resourceId: string | number, keyId: string, options?: PaginatedRequestOptions) {
-    const [rId, kId] = [resourceId, keyId].map(encodeURIComponent);
-
-    return RequestHelper.get<VariableSchema>()(this, `${rId}/variables/${kId}`, options);
+    return RequestHelper.get<VariableSchema>()(
+      this,
+      endpoint`${resourceId}/variables/${keyId}`,
+      options,
+    );
   }
 
   remove(resourceId: string | number, keyId: string, options?: PaginatedRequestOptions) {
-    const [rId, kId] = [resourceId, keyId].map(encodeURIComponent);
-
-    return RequestHelper.del()(this, `${rId}/variables/${kId}`, options);
+    return RequestHelper.del()(this, endpoint`${resourceId}/variables/${keyId}`, options);
   }
 }

--- a/packages/core/test/unit/infrastructure/Utils.ts
+++ b/packages/core/test/unit/infrastructure/Utils.ts
@@ -1,5 +1,5 @@
 import FormData from 'form-data';
-import { getAPIMap, appendFormFromObject } from '../../../src/infrastructure';
+import { getAPIMap, appendFormFromObject, endpoint } from '../../../src/infrastructure';
 
 jest.mock(
   '../../../dist/map.json',
@@ -30,5 +30,23 @@ describe('appendFormFromObject', () => {
     const form = appendFormFromObject(data);
 
     expect(form).toBeInstanceOf(FormData);
+  });
+});
+
+describe('endpoint', () => {
+  it('should encode parameters correctly', () => {
+    const projectId = 1;
+    const filePath = 'path/to/file';
+    const url = endpoint`/projects/${projectId}/repository/files/${filePath}`;
+
+    expect(url).toBe('/projects/1/repository/files/path%2Fto%2Ffile');
+  });
+
+  it('should give error if all parameters are number', () => {
+    const projectId = 1;
+    // @ts-expect-error No need to use `endpoint` if all parameters are number.
+    const url: string = endpoint`/projects/${projectId}`;
+
+    expect(url).toBe('/projects/1');
   });
 });

--- a/packages/core/test/unit/resources/FeatureFlags.ts
+++ b/packages/core/test/unit/resources/FeatureFlags.ts
@@ -27,26 +27,26 @@ describe('Instantiating FeatureFlags service', () => {
 });
 
 describe('FeatureFlags.all', () => {
-  it('should request GET /projects/:id/features_flags without options', async () => {
+  it('should request GET /projects/:id/feature_flags without options', async () => {
     await service.all(1);
 
-    expect(RequestHelper.get()).toHaveBeenCalledWith(service, 'projects/1/features_flags', {});
+    expect(RequestHelper.get()).toHaveBeenCalledWith(service, 'projects/1/feature_flags', {});
   });
 
-  it('should request GET /projects/:id/features_flags', async () => {
+  it('should request GET /projects/:id/feature_flags', async () => {
     await service.all(1, { scopes: 'enabled' });
 
-    expect(RequestHelper.get()).toHaveBeenCalledWith(service, 'projects/1/features_flags', {
+    expect(RequestHelper.get()).toHaveBeenCalledWith(service, 'projects/1/feature_flags', {
       scopes: 'enabled',
     });
   });
 });
 
 describe('FeatureFlags.create', () => {
-  it('should request POST /projects/:id/features_flags', async () => {
+  it('should request POST /projects/:id/feature_flags', async () => {
     await service.create(1, 'name', '1');
 
-    expect(RequestHelper.post()).toHaveBeenCalledWith(service, 'projects/1/features_flags', {
+    expect(RequestHelper.post()).toHaveBeenCalledWith(service, 'projects/1/feature_flags', {
       version: '1',
       name: 'name',
     });
@@ -54,32 +54,32 @@ describe('FeatureFlags.create', () => {
 });
 
 describe('FeatureFlags.edit', () => {
-  it('should request PUT /projects/:id/features_flags/:flag_name', async () => {
+  it('should request PUT /projects/:id/feature_flags/:flag_name', async () => {
     await service.edit(1, 'name', { test: 1 });
 
-    expect(RequestHelper.put()).toHaveBeenCalledWith(service, 'projects/1/features_flags/name', {
+    expect(RequestHelper.put()).toHaveBeenCalledWith(service, 'projects/1/feature_flags/name', {
       test: 1,
     });
   });
 });
 
 describe('FeatureFlags.remove', () => {
-  it('should request DEL /projects/:id/features_flags/:flag_name', async () => {
+  it('should request DEL /projects/:id/feature_flags/:flag_name', async () => {
     await service.remove(1, 'name', { sudo: 1 });
 
-    expect(RequestHelper.del()).toHaveBeenCalledWith(service, 'projects/1/features_flags/name', {
+    expect(RequestHelper.del()).toHaveBeenCalledWith(service, 'projects/1/feature_flags/name', {
       sudo: 1,
     });
   });
 });
 
 describe('FeatureFlags.show', () => {
-  it('should request GET /projects/:id/features_flags/:flag_name', async () => {
+  it('should request GET /projects/:id/feature_flags/:flag_name', async () => {
     await service.show(1, 'name');
 
     expect(RequestHelper.get()).toHaveBeenCalledWith(
       service,
-      'projects/1/features_flags/name',
+      'projects/1/feature_flags/name',
       undefined,
     );
   });

--- a/packages/core/test/unit/templates/ResourceDiscussions.ts
+++ b/packages/core/test/unit/templates/ResourceDiscussions.ts
@@ -32,7 +32,7 @@ describe('ResourceDiscussions.addNote', () => {
       service,
       '1/resource2/2/discussions/3/notes',
       {
-        noteId: '4',
+        noteId: 4,
         query: {
           body: 'test',
         },


### PR DESCRIPTION
Use tagged template to simplify endpoint generating. For example:

```ts
// Before
const [pId, path] = [projectId, filePath].map(encodeURIComponent);
const url = `projects/${pId}/repository/files/${path}`;

// After
const url = endpoint`projects/${projectId}/repository/files/${filePath}`;
```