### PR TITLE
feat: add EpicLinks resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ GroupLabels
 GroupDeployTokens
 Epics
 EpicIssues
+EpicLInks
 EpicNotes
 EpicDiscussions
 

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -21,6 +21,7 @@ export const {
   GroupDeployTokens,
   Epics,
   EpicIssues,
+  EpicLinks,
   EpicNotes,
   EpicDiscussions,
 

--- a/packages/core/src/resources/EpicLinks.ts
+++ b/packages/core/src/resources/EpicLinks.ts
@@ -1,0 +1,79 @@
+import { BaseResource } from '@gitbeaker/requester-utils';
+import { BaseRequestOptions, endpoint, RequestHelper } from '../infrastructure';
+import { EpicSchema } from './Epics';
+
+/**
+ * ## Epic Links API
+ *
+ * > Introduced in GitLab 11.8.
+ *
+ * Manages parent-child epic relationships.
+ *
+ * https://docs.gitlab.com/ee/api/epic_links.html
+ *
+ */
+
+export class EpicLinks<C extends boolean = false> extends BaseResource<C> {
+  // https://docs.gitlab.com/ee/api/epic_links.html#list-epics-related-to-a-given-epic
+  all(groupId: string | number, epicIid: number, options?: BaseRequestOptions) {
+    return RequestHelper.get<EpicSchema[]>()(
+      this,
+      endpoint`groups/${groupId}/epics/${epicIid}/epics`,
+      options,
+    );
+  }
+
+  // https://docs.gitlab.com/ee/api/epic_links.html#assign-a-child-epic
+  assign(
+    groupId: string | number,
+    epicIid: number,
+    childEpicId: number,
+    options?: BaseRequestOptions,
+  ) {
+    return RequestHelper.post<EpicSchema>()(
+      this,
+      endpoint`groups/${groupId}/epics/${epicIid}/epics/${childEpicId}`,
+      options,
+    );
+  }
+
+  // https://docs.gitlab.com/ee/api/epic_links.html#create-and-assign-a-child-epic
+  create(groupId: string | number, epicIid: number, title: string, options?: BaseRequestOptions) {
+    return RequestHelper.post<EpicSchema>()(
+      this,
+      endpoint`groups/${groupId}/epics/${epicIid}/epics`,
+      {
+        title,
+        ...options,
+      },
+    );
+  }
+
+  // https://docs.gitlab.com/ee/api/epic_links.html#re-order-a-child-epic
+  reorder(
+    groupId: string | number,
+    epicIid: number,
+    childEpicId: number,
+    options?: BaseRequestOptions,
+  ) {
+    return RequestHelper.put<EpicSchema>()(
+      this,
+      endpoint`groups/${groupId}/epics/${epicIid}/epics/${childEpicId}`,
+      options,
+    );
+  }
+
+  // https://docs.gitlab.com/ee/api/epic_links.html#unassign-a-child-epic
+  unassign(
+    groupId: string | number,
+    epicIid: number,
+    childEpicId: number,
+    options?: BaseRequestOptions,
+  ) {
+    return RequestHelper.del<EpicSchema>()(
+      this,
+      endpoint`groups/${groupId}/epics/${epicIid}/epics/${childEpicId}`,
+      options,
+    );
+  }
+}

--- a/packages/core/src/resources/Gitlab.ts
+++ b/packages/core/src/resources/Gitlab.ts
@@ -14,6 +14,7 @@ import { GroupLabels } from './GroupLabels';
 import { GroupDeployTokens } from './GroupDeployTokens';
 import { Epics } from './Epics';
 import { EpicIssues } from './EpicIssues';
+import { EpicLinks } from './EpicLinks';
 import { EpicNotes } from './EpicNotes';
 import { EpicDiscussions } from './EpicDiscussions';
 import { Users } from './Users';
@@ -116,6 +117,7 @@ type BundledService<C extends boolean = false> = {
   GroupDeployTokens: GroupDeployTokens<C>;
   Epics: Epics<C>;
   EpicIssues: EpicIssues<C>;
+  EpicLinks: EpicLinks<C>;
   EpicNotes: EpicNotes<C>;
   EpicDiscussions: EpicDiscussions<C>;
   Users: Users<C>;
@@ -216,6 +218,7 @@ const resources = {
   GroupDeployTokens,
   Epics,
   EpicIssues,
+  EpicLinks,
   EpicNotes,
   EpicDiscussions,
   Users,

--- a/packages/core/src/resources/index.ts
+++ b/packages/core/src/resources/index.ts
@@ -12,6 +12,7 @@ export { GroupLabels } from './GroupLabels';
 export { GroupDeployTokens } from './GroupDeployTokens';
 export { Epics } from './Epics';
 export { EpicIssues } from './EpicIssues';
+export { EpicLinks } from './EpicLinks';
 export { EpicNotes } from './EpicNotes';
 export { EpicDiscussions } from './EpicDiscussions';
 

--- a/packages/core/test/unit/resources/EpicLinks.ts
+++ b/packages/core/test/unit/resources/EpicLinks.ts
@@ -1,0 +1,81 @@
+import { RequestHelper } from '../../../src/infrastructure';
+import { EpicLinks } from '../../../src';
+
+jest.mock(
+  '../../../src/infrastructure/RequestHelper',
+  () => require('../../__mocks__/RequestHelper').default,
+);
+
+let service: EpicLinks;
+
+beforeEach(() => {
+  service = new EpicLinks({
+    requesterFn: jest.fn(),
+    token: 'abcdefg',
+    requestTimeout: 3000,
+  });
+});
+
+describe('Instantiating EpicLinks service', () => {
+  it('should create a valid service object', () => {
+    expect(service).toBeInstanceOf(EpicLinks);
+    expect(service.url).toBeDefined();
+    expect(service.rejectUnauthorized).toBeTruthy();
+    expect(service.headers).toMatchObject({ 'private-token': 'abcdefg' });
+    expect(service.requestTimeout).toBe(3000);
+  });
+});
+
+describe('EpicLinks.all', () => {
+  it('should request GET /groups/:id/epics/:id/epics', async () => {
+    await service.all(1, 2);
+
+    expect(RequestHelper.get()).toHaveBeenCalledWith(service, 'groups/1/epics/2/epics', undefined);
+  });
+});
+
+describe('EpicLinks.assign', () => {
+  it('should request POST /groups/:id/epics/:id/epics/:id', async () => {
+    await service.assign(1, 2, 3);
+
+    expect(RequestHelper.post()).toHaveBeenCalledWith(
+      service,
+      'groups/1/epics/2/epics/3',
+      undefined,
+    );
+  });
+});
+
+describe('EpicLinks.create', () => {
+  it('should request POST /groups/:id/epics/:id/epics', async () => {
+    await service.create(1, 2, 'Testing epic links', { confidential: false });
+
+    expect(RequestHelper.post()).toHaveBeenCalledWith(service, 'groups/1/epics/2/epics', {
+      title: 'Testing epic links',
+      confidential: false,
+    });
+  });
+});
+
+describe('EpicLinks.reorder', () => {
+  it('should request PUT /groups/:id/epics/:id/epics/:id', async () => {
+    await service.reorder(1, 2, 3, { move_before_id: 3, move_after_id: 1 });
+
+    expect(RequestHelper.put()).toHaveBeenCalledWith(service, 'groups/1/epics/2/epics/3', {
+      move_before_id: 3,
+      move_after_id: 1,
+    });
+  });
+});
+
+describe('EpicLinks.unassign', () => {
+  it('should request DEL /groups/:id/epics/:id/epics/:id', async () => {
+    await service.unassign(1, 2, 3);
+
+    expect(RequestHelper.del()).toHaveBeenCalledWith(
+      service,
+      'groups/1/epics/2/epics/3',
+      undefined,
+    );
+  });
+});

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -21,6 +21,7 @@ export const {
   GroupDeployTokens,
   Epics,
   EpicIssues,
+  EpicLinks,
   EpicNotes,
   EpicDiscussions,
 


### PR DESCRIPTION
At my real-world job, we use multi-level epics to a ridiculous degree. Without this `EpicLinks` resource, the only way to construct an epic hierarchy is by pulling down the entire epic list and then iterating through to find those with the desired `parent_id`. This is a standard GitLab resource and would be really great to have in gitbeaker.

https://docs.gitlab.com/ee/api/epic_links.html