### PR TITLE
Fix camelize types

### DIFF
--- a/packages/core/src/resources/Gitlab.ts
+++ b/packages/core/src/resources/Gitlab.ts
@@ -302,7 +302,9 @@ const resources = {
   Wikis,
 };
 
-export class Gitlab<C extends boolean = false> extends (class {} as new () => BundledService) {
+export class Gitlab<C extends boolean = false> extends (class {} as new <
+  Camelize extends boolean = false,
+>() => BundledService<Camelize>)<C> {
   constructor(options: BaseResourceOptions<C>) {
     super();
 


### PR DESCRIPTION
Currently resources types are not camelized as they should be when the lib is instantiated with the `camelize` option.
```ts
  import { Gitlab } from '@gitbeaker/browser'

  const gl = new Gitlab({
    token,
    host: 'http://smthg.example',
    camelize: true,
  })

  // The return type here is not camelized
  return gl.Users.current()
```

This is because the type Camelize is "lost" in the chain and does not reach the resource types, this PR fixes this typing problem.