### PR TITLE
Fix type of the customAttributeId

### DIFF
--- a/packages/core/src/resources/GroupCustomAttributes.ts
+++ b/packages/core/src/resources/GroupCustomAttributes.ts
@@ -12,16 +12,16 @@ export interface GroupCustomAttributes<C extends boolean = false>
 
   set(
     groupId: string | number,
-    customAttributeId: number,
+    customAttributeId: string,
     value: string,
     options?: Sudo,
   ): Promise<CamelizedRecord<C, CustomAttributeSchema>>;
 
-  remove(groupId: string | number, customAttributeId: number, options?: Sudo): Promise<void>;
+  remove(groupId: string | number, customAttributeId: string, options?: Sudo): Promise<void>;
 
   show(
     groupId: string | number,
-    customAttributeId: number,
+    customAttributeId: string,
     options?: Sudo,
   ): Promise<CamelizedRecord<C, CustomAttributeSchema>>;
 }

--- a/packages/core/src/resources/ProjectCustomAttributes.ts
+++ b/packages/core/src/resources/ProjectCustomAttributes.ts
@@ -12,16 +12,16 @@ export interface ProjectCustomAttributes<C extends boolean = false>
 
   set(
     projectId: string | number,
-    customAttributeId: number,
+    customAttributeId: string,
     value: string,
     options?: Sudo,
   ): Promise<CamelizedRecord<C, CustomAttributeSchema>>;
 
-  remove(projectId: string | number, customAttributeId: number, options?: Sudo): Promise<void>;
+  remove(projectId: string | number, customAttributeId: string, options?: Sudo): Promise<void>;
 
   show(
     projectId: string | number,
-    customAttributeId: number,
+    customAttributeId: string,
     options?: Sudo,
   ): Promise<CamelizedRecord<C, CustomAttributeSchema>>;
 }

--- a/packages/core/src/resources/UserCustomAttributes.ts
+++ b/packages/core/src/resources/UserCustomAttributes.ts
@@ -12,16 +12,16 @@ export interface UserCustomAttributes<C extends boolean = false>
 
   set(
     userId: string | number,
-    customAttributeId: number,
+    customAttributeId: string,
     value: string,
     options?: Sudo,
   ): Promise<CamelizedRecord<C, CustomAttributeSchema>>;
 
-  remove(userId: string | number, customAttributeId: number, options?: Sudo): Promise<void>;
+  remove(userId: string | number, customAttributeId: string, options?: Sudo): Promise<void>;
 
   show(
     userId: string | number,
-    customAttributeId: number,
+    customAttributeId: string,
     options?: Sudo,
   ): Promise<CamelizedRecord<C, CustomAttributeSchema>>;
 }

--- a/packages/core/src/templates/ResourceCustomAttributes.ts
+++ b/packages/core/src/templates/ResourceCustomAttributes.ts
@@ -19,7 +19,7 @@ export class ResourceCustomAttributes<C extends boolean = false> extends BaseRes
     );
   }
 
-  set(resourceId: string | number, customAttributeId: number, value: string, options?: Sudo) {
+  set(resourceId: string | number, customAttributeId: string, value: string, options?: Sudo) {
     return RequestHelper.put<CustomAttributeSchema>()(
       this,
       endpoint`${resourceId}/custom_attributes/${customAttributeId}`,
@@ -30,7 +30,7 @@ export class ResourceCustomAttributes<C extends boolean = false> extends BaseRes
     );
   }
 
-  remove(resourceId: string | number, customAttributeId: number, options?: Sudo) {
+  remove(resourceId: string | number, customAttributeId: string, options?: Sudo) {
     return RequestHelper.del()(
       this,
       endpoint`${resourceId}/custom_attributes/${customAttributeId}`,
@@ -38,7 +38,7 @@ export class ResourceCustomAttributes<C extends boolean = false> extends BaseRes
     );
   }
 
-  show(resourceId: string | number, customAttributeId: number, options?: Sudo) {
+  show(resourceId: string | number, customAttributeId: string, options?: Sudo) {
     return RequestHelper.get<CustomAttributeSchema>()(
       this,
       endpoint`${resourceId}/custom_attributes/${customAttributeId}`,


### PR DESCRIPTION
Set `string` type for the custom attribute key, as described in [docs](https://docs.gitlab.com/ee/api/custom_attributes.html#single-custom-attribute).