### PR TITLE
Adding HTTP Proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,6 +459,10 @@ If your Gitlab server is running via HTTPS, the proper way to pass in your certi
 
 > **NOTE**: _Using `process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0'` will not work with the `gitlab` library. The `rejectUnauthorized` key is the only way to allow insecure certificates to be bypassed._
 
+#### Handling HTTP(S) Proxy
+
+If you need to reach a Gitlab server using a proxy (corporate proxy, for example), use the `GLOBAL_AGENT_HTTPS_PROXY` environment key.
+
 #### Non JSON/Text Responses
 
 For responses such as file data that may be returned from the API, the data is exposed as a buffer. For example, when trying to write a file, this can be done like:

--- a/packages/node/src/GotRequester.ts
+++ b/packages/node/src/GotRequester.ts
@@ -1,6 +1,7 @@
 import Got from 'got';
 import { decamelizeKeys } from 'xcase';
 import delay from 'delay';
+import 'global-agent/bootstrap';
 import {
   DefaultResourceOptions,
   DefaultRequestReturn,


### PR DESCRIPTION
This PR aims to add the possibility to set a HTTP proxy, using environment variables. It answers to the following issue (and implemented a solution using the advice given here) : [Is there a way to set proxy settings ?](https://github.com/jdalrymple/gitbeaker/issues/2014)

So from now, you can set `GLOBAL_AGENT_HTTPS_PROXY` if you have proxy needs, and it will work 👌 

## Pull Request Process

- [X] Ensure any install or build dependencies are removed before the end of the layer when doing a build.
- [X] Update the README.md with details of changes to the interface, this includes new environment variables, exposed ports, useful file locations and container parameters.
- [ ] Increase the version numbers in any examples files and the README.md to the new version that this Pull Request would represent. The versioning scheme we use is [SemVer](http://semver.org/).

## Additionnal notes

The solution implemented uses 'global-agent`, but it looks like it didn't need a `npm install global-agent` to add it to the `package.json`, I suppose it's included in another lib used by the package (maybe `got` ?). If you want me to add it "in case of", I can do that !

Thanks in advance for checking that PR 😄 

closes #2014 