### PR TITLE
feat(resources): group hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ GroupRunners
 GroupVariables
 GroupLabels
 GroupDeployTokens
+GroupHooks
 Epics
 EpicIssues
 EpicNotes

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -19,6 +19,7 @@ export const {
   GroupVariables,
   GroupLabels,
   GroupDeployTokens,
+  GroupHooks,
   Epics,
   EpicIssues,
   EpicNotes,

--- a/packages/core/src/resources/Gitlab.ts
+++ b/packages/core/src/resources/Gitlab.ts
@@ -12,6 +12,7 @@ import { GroupRunners } from './GroupRunners';
 import { GroupVariables } from './GroupVariables';
 import { GroupLabels } from './GroupLabels';
 import { GroupDeployTokens } from './GroupDeployTokens';
+import { GroupHooks } from './GroupHooks';
 import { Epics } from './Epics';
 import { EpicIssues } from './EpicIssues';
 import { EpicNotes } from './EpicNotes';
@@ -114,6 +115,7 @@ type BundledService<C extends boolean = false> = {
   GroupVariables: GroupVariables<C>;
   GroupLabels: GroupLabels<C>;
   GroupDeployTokens: GroupDeployTokens<C>;
+  GroupHooks: GroupHooks<C>;
   Epics: Epics<C>;
   EpicIssues: EpicIssues<C>;
   EpicNotes: EpicNotes<C>;
@@ -214,6 +216,7 @@ const resources = {
   GroupVariables,
   GroupLabels,
   GroupDeployTokens,
+  GroupHooks,
   Epics,
   EpicIssues,
   EpicNotes,

--- a/packages/core/src/resources/GroupHooks.ts
+++ b/packages/core/src/resources/GroupHooks.ts
@@ -1,0 +1,69 @@
+import { BaseResource } from '@gitbeaker/requester-utils';
+import {
+  BaseRequestOptions,
+  endpoint,
+  PaginatedRequestOptions,
+  RequestHelper,
+  Sudo,
+} from '../infrastructure';
+
+export interface GroupHookSchema extends Record<string, unknown> {
+  id: number;
+  url: string;
+  group_id: number;
+  push_events: boolean;
+  issues_events: boolean;
+  confidential_issues_events: boolean;
+  merge_requests_events: boolean;
+  tag_push_events: boolean;
+  note_events: boolean;
+  confidential_note_events: boolean;
+  job_events: boolean;
+  pipeline_events: boolean;
+  wiki_page_events: boolean;
+  deployment_events: boolean;
+  releases_events: boolean;
+  subgroup_events: boolean;
+  enable_ssl_verification: boolean;
+  created_at: string;
+}
+
+export class GroupHooks<C extends boolean = false> extends BaseResource<C> {
+  all(groupId: string | number, options?: PaginatedRequestOptions) {
+    return RequestHelper.get<GroupHookSchema[]>()(
+      this,
+      endpoint`groups/${groupId}/hooks`,
+      options,
+    );
+  }
+
+  show(groupId: string | number, hookId: number, options?: Sudo) {
+    return RequestHelper.get<GroupHookSchema>()(
+      this,
+      endpoint`groups/${groupId}/hooks/${hookId}`,
+      options,
+    );
+  }
+
+  add(groupId: string | number, url: string, options?: BaseRequestOptions) {
+    return RequestHelper.post<GroupHookSchema>()(this, endpoint`groups/${groupId}/hooks`, {
+      url,
+      ...options,
+    });
+  }
+
+  edit(groupId: string | number, hookId: number, url: string, options?: BaseRequestOptions) {
+    return RequestHelper.put<GroupHookSchema>()(
+      this,
+      endpoint`groups/${groupId}/hooks/${hookId}`,
+      {
+        url,
+        ...options,
+      },
+    );
+  }
+
+  remove(groupId: string | number, hookId: number, options?: Sudo) {
+    return RequestHelper.del()(this, endpoint`groups/${groupId}/hooks/${hookId}`, options);
+  }
+}

--- a/packages/core/src/resources/index.ts
+++ b/packages/core/src/resources/index.ts
@@ -10,6 +10,7 @@ export { GroupRunners } from './GroupRunners';
 export { GroupVariables } from './GroupVariables';
 export { GroupLabels } from './GroupLabels';
 export { GroupDeployTokens } from './GroupDeployTokens';
+export { GroupHooks } from './GroupHooks';
 export { Epics } from './Epics';
 export { EpicIssues } from './EpicIssues';
 export { EpicNotes } from './EpicNotes';

--- a/packages/core/src/resources/types.ts
+++ b/packages/core/src/resources/types.ts
@@ -2,6 +2,7 @@
 export { GroupSchema, GroupDetailSchema } from './Groups';
 export { GroupBadgeSchema } from './GroupBadges';
 export { GroupIssueBoardSchema } from './GroupIssueBoards';
+export { GroupHookSchema } from './GroupHooks';
 export { EpicSchema } from './Epics';
 export { EpicIssueSchema } from './EpicIssues';
 export { EpicNoteSchema } from './EpicNotes';

--- a/packages/core/test/unit/resources/GroupHooks.ts
+++ b/packages/core/test/unit/resources/GroupHooks.ts
@@ -1,0 +1,87 @@
+import { RequestHelper } from '../../../src/infrastructure';
+import { GroupHooks } from '../../../src';
+
+jest.mock(
+  '../../../src/infrastructure/RequestHelper',
+  () => require('../../__mocks__/RequestHelper').default,
+);
+
+let service: GroupHooks;
+
+beforeEach(() => {
+  service = new GroupHooks({
+    requesterFn: jest.fn(),
+    token: 'abcdefg',
+    requestTimeout: 3000,
+  });
+});
+
+describe('Instantiating GroupHooks service', () => {
+  it('should create a valid service object', () => {
+    expect(service).toBeInstanceOf(GroupHooks);
+    expect(service.url).toBeDefined();
+    expect(service.rejectUnauthorized).toBeTruthy();
+    expect(service.headers).toMatchObject({ 'private-token': 'abcdefg' });
+    expect(service.requestTimeout).toBe(3000);
+  });
+});
+
+describe('GroupHooks.all', () => {
+  it('should request GET /groups/:id/hooks without options', async () => {
+    await service.all(1);
+
+    expect(RequestHelper.get()).toHaveBeenCalledWith(service, 'groups/1/hooks', undefined);
+  });
+
+  it('should request GET /groups/:id/hooks with options', async () => {
+    await service.all(1, { test: 1 });
+
+    expect(RequestHelper.get()).toHaveBeenCalledWith(service, 'groups/1/hooks', { test: 1 });
+  });
+});
+
+describe('GroupHooks.add', () => {
+  it('should request POST /groups/:id/hooks', async () => {
+    await service.add(1, 'url');
+
+    expect(RequestHelper.post()).toHaveBeenCalledWith(service, 'groups/1/hooks', {
+      url: 'url',
+    });
+  });
+});
+
+describe('GroupHooks.edit', () => {
+  it('should request PUT /groups/:id/hooks/:hook_id', async () => {
+    await service.edit(1, 2, 'url');
+
+    expect(RequestHelper.put()).toHaveBeenCalledWith(service, 'groups/1/hooks/2', { url: 'url' });
+  });
+});
+
+describe('GroupHooks.show', () => {
+  it('should request GET /groups/:id/hooks/:hook_id without options', async () => {
+    await service.show(1, 2);
+
+    expect(RequestHelper.get()).toHaveBeenCalledWith(service, 'groups/1/hooks/2', undefined);
+  });
+
+  it('should request GET /groups/:id/hooks/:hook_id with options', async () => {
+    await service.show(1, 2, { sudo: 1 });
+
+    expect(RequestHelper.get()).toHaveBeenCalledWith(service, 'groups/1/hooks/2', { sudo: 1 });
+  });
+});
+
+describe('GroupHooks.remove', () => {
+  it('should request DEL /groups/:id/hooks/:hook_id with options', async () => {
+    await service.remove(1, 2, { sudo: 1 });
+
+    expect(RequestHelper.del()).toHaveBeenCalledWith(service, 'groups/1/hooks/2', { sudo: 1 });
+  });
+
+  it('should request DEL /groups/:id/hooks/:hook_id without options', async () => {
+    await service.remove(1, 2);
+
+    expect(RequestHelper.del()).toHaveBeenCalledWith(service, 'groups/1/hooks/2', undefined);
+  });
+});

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -19,6 +19,7 @@ export const {
   GroupVariables,
   GroupLabels,
   GroupDeployTokens,
+  GroupHooks,
   Epics,
   EpicIssues,
   EpicNotes,


### PR DESCRIPTION
closes #2512 

In a nutshell: A basic structure copy of `ProjectHooks`  with an update of the schema for `GroupHookSchema`.