### PR TITLE
fix(resources): missing project default branch possible undefined value

### DIFF
--- a/packages/core/src/resources/Projects.ts
+++ b/packages/core/src/resources/Projects.ts
@@ -17,7 +17,7 @@ import { AccessLevel } from '../templates/types';
 export interface ProjectSchema extends Record<string, unknown> {
   id: number;
   description?: string;
-  default_branch: string;
+  default_branch?: string;
   ssh_url_to_repo: string;
   http_url_to_repo: string;
   web_url: string;


### PR DESCRIPTION
If a project can exists with disabled repository, so the `default_branch` property is not provided.