### PR TITLE
fix(MR): allow reviewerId to be "Any" or "None"

### DIFF
--- a/packages/core/src/resources/MergeRequests.ts
+++ b/packages/core/src/resources/MergeRequests.ts
@@ -75,7 +75,7 @@ export interface AllMergeRequestsOptions {
   assigneeUsername?: string;
   approverIds?: Array<number>;
   approvedByIds?: Array<number>;
-  reviewerId?: number;
+  reviewerId?: number | 'Any' | 'None';
   reviewerUsername?: string;
   myReactionEmoji?: string;
   sourceBranch?: string;
@@ -230,7 +230,10 @@ export class MergeRequests<C extends boolean = false> extends BaseResource<C> {
     projectId,
     groupId,
     ...options
-  }: { projectId?: string | number; groupId?: string | number } & AllMergeRequestsOptions &
+  }: {
+    projectId?: string | number;
+    groupId?: string | number;
+  } & AllMergeRequestsOptions &
     PaginatedRequestOptions = {}) {
     let url: string;
 


### PR DESCRIPTION
https://docs.gitlab.com/ee/api/merge_requests.html


As documented by Gitlab:
>Returns merge requests which have the user as a [reviewer](https://docs.gitlab.com/ee/user/project/merge_requests/getting_started.html#reviewer) with the given user id. `None` returns merge requests with no reviewers. `Any` returns merge requests with any reviewer. Mutually exclusive with reviewer_username.