### PR TITLE
Typing: make sure CommitSchema type is okay

### DIFF
--- a/packages/core/src/resources/Commits.ts
+++ b/packages/core/src/resources/Commits.ts
@@ -30,16 +30,16 @@ export interface CommitAction {
 export interface CommitSchema extends Record<string, unknown> {
   id: string;
   short_id: string;
-  created_at: Date;
+  created_at: string;
   parent_ids?: string[];
   title: string;
   message: string;
   author_name: string;
   author_email: string;
-  authored_date?: Date;
+  authored_date?: string;
   committer_name?: string;
   committer_email?: string;
-  committed_date?: Date;
+  committed_date?: string;
   web_url: string;
 }
 


### PR DESCRIPTION
It was set as "Date" except they do not get hydrated on get so they should be string.

In a TypeScript environment, they are taken as date but actually are strings. This commits makes it so they are considered as what they are: strings. Alternative would be to auto-hydrate them through Date.parse but that would be breaking API.