### PR TITLE
Add options to query Deployments more fully. Fix a bug in MergeRequests.

### DIFF
--- a/packages/core/src/resources/Deployments.ts
+++ b/packages/core/src/resources/Deployments.ts
@@ -39,8 +39,17 @@ export type DeploymentSchema = {
   environment: EnvironmentSchema;
 };
 
+export interface AllDeploymentsOptions {
+  order_by?: 'id' | 'iid' | 'created_at' | 'updated_at' | 'ref';
+  sort?: 'asc' | 'desc';
+  updated_after?: string;
+  updated_before?: string;
+  environment?: string;
+  status?: 'created' | 'running' | 'success' | 'failed' | 'canceled' | 'blocked';
+}
+
 export class Deployments<C extends boolean = false> extends BaseResource<C> {
-  all(projectId: string | number, options?: PaginatedRequestOptions) {
+  all(projectId: string | number, options?: PaginatedRequestOptions & AllDeploymentsOptions) {
     return RequestHelper.get<DeploymentSchema[]>()(
       this,
       endpoint`projects/${projectId}/deployments`,

--- a/packages/core/src/resources/MergeRequests.ts
+++ b/packages/core/src/resources/MergeRequests.ts
@@ -57,7 +57,7 @@ export interface UpdateMergeRequestOptions {
 
 export interface AllMergeRequestsOptions {
   state?: 'opened' | 'closed' | 'locked' | 'merged';
-  orderBy?: 'created_at' | 'updated_at';
+  order_by?: 'created_at' | 'updated_at';
   sort?: 'asc' | 'desc';
   milestone?: 'None' | string;
   view?: string;


### PR DESCRIPTION
    fix(merge-requests): fix snake_case naming of order_by prop in MergeRequestsOptions
    feat(deployments): add options for querying deployments

Basically, we want to query deployments by updated date, we now can. And the merge requests options "orderBy" was not gonna work as GitLab consumes "order_by" instead.