### PR TITLE
fix(#3011): add missing `erased_at` property to `JobSchema`

### DIFF
--- a/packages/core/src/resources/Jobs.ts
+++ b/packages/core/src/resources/Jobs.ts
@@ -40,6 +40,7 @@ export interface JobSchema extends Record<string, unknown> {
   created_at: Date;
   started_at?: Date;
   finished_at?: Date;
+  erased_at?: Date;
   duration?: number;
   user: UserSchema;
   commit: CommitSchema;


### PR DESCRIPTION
fixes #3011 