### PR TITLE
Add 'Camelize'  from '@gitbeaker/core' export

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,7 @@
 /* ---------------- Resources --------------- */
 export * from './resources';
 export type {
+  Camelize,
   UserAgentDetailSchema,
   IsForm,
   Sudo,


### PR DESCRIPTION
When we set `camelize: true`, the `@gitbeaker/core`  uses the `Camelize` type, but we can't use this type in another typescript function because it's not exported.