### PR TITLE
Settings cors to same-origin conditionally for protected api route

### DIFF
--- a/packages/core/src/resources/Projects.ts
+++ b/packages/core/src/resources/Projects.ts
@@ -750,7 +750,10 @@ export class Projects<C extends boolean = false> extends BaseResource<C> {
     );
   }
 
-  upload<E extends boolean = false>(
+  /* Upload file to be used a reference within an issue, merge request or
+     comment
+  */
+  uploadForReference<E extends boolean = false>(
     projectId: string | number,
     file: { content: Blob; filename: string },
     options?: Sudo & ShowExpanded<E>,

--- a/packages/rest/src/Requester.ts
+++ b/packages/rest/src/Requester.ts
@@ -85,6 +85,8 @@ async function throwFailedRequestError(response: Response) {
     description = content;
   }
 
+  console.log(description);
+
   throw new Error(response.statusText, {
     cause: {
       description,

--- a/packages/rest/src/Requester.ts
+++ b/packages/rest/src/Requester.ts
@@ -85,8 +85,6 @@ async function throwFailedRequestError(response: Response) {
     description = content;
   }
 
-  console.log(description);
-
   throw new Error(response.statusText, {
     cause: {
       description,

--- a/packages/rest/test/e2e/browser/resources/Projects.ts
+++ b/packages/rest/test/e2e/browser/resources/Projects.ts
@@ -59,6 +59,6 @@ describe('Projects API', () => {
       [GITLAB_URL, GITLAB_PERSONAL_ACCESS_TOKEN, TEST_ID],
     );
 
-    expect(Object.keys(response)).toMatchObject(['branch', 'file_path']);
+    expect(Object.keys(response)).toMatchObject(['file_path', 'branch']);
   });
 });

--- a/packages/rest/test/e2e/browser/resources/Projects.ts
+++ b/packages/rest/test/e2e/browser/resources/Projects.ts
@@ -36,30 +36,29 @@ describe('Projects API', () => {
       async ([host, token, testId]) => {
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
-        const { Projects } = window.gitbeaker;
-        const resource = new Projects({
+        const { Gitlab } = window.gitbeaker;
+        const resource = new Gitlab({
           host,
           token,
         });
 
-        const project = await resource.create({
+        const project = await resource.Projects.create({
           name: `Project File Upload E2E Test - Browser ${testId}`,
         });
 
-        const blob = new Blob(['TESTING FILE UPLOAD'], {
-          type: 'text/plain',
-        });
-
-        const results = await resource.upload(project.id, {
-          content: blob,
-          filename: 'testfile.txt',
-        });
+        const results = await resource.RepositoryFiles.create(
+          project.id,
+          'testfile.txt',
+          'main',
+          'TESTING FILE UPLOAD',
+          'init commit',
+        );
 
         return results;
       },
       [GITLAB_URL, GITLAB_PERSONAL_ACCESS_TOKEN, TEST_ID],
     );
 
-    expect(Object.keys(response)).toMatchObject(['alt', 'url', 'full_path', 'markdown']);
+    expect(Object.keys(response)).toMatchObject(['branch', 'file_path']);
   });
 });

--- a/packages/rest/test/integration/nodejs/resources/Issues.ts
+++ b/packages/rest/test/integration/nodejs/resources/Issues.ts
@@ -5,19 +5,17 @@ const {
   GITLAB_URL = '',
   TEST_ID = Date.now().toString(),
 } = process.env;
+const CREDENTIALS = {
+  host: GITLAB_URL,
+  token: GITLAB_PERSONAL_ACCESS_TOKEN,
+};
 
 let issueAPI: InstanceType<typeof Issues<false>>;
 let projectAPI: InstanceType<typeof Projects<false>>;
 
 beforeAll(() => {
-  issueAPI = new Issues({
-    host: GITLAB_URL,
-    token: GITLAB_PERSONAL_ACCESS_TOKEN,
-  });
-  projectAPI = new Projects({
-    host: GITLAB_URL,
-    token: GITLAB_PERSONAL_ACCESS_TOKEN,
-  });
+  issueAPI = new Issues(CREDENTIALS);
+  projectAPI = new Projects(CREDENTIALS);
 });
 
 describe('Issues.all', () => {

--- a/packages/rest/test/integration/nodejs/resources/Lint.ts
+++ b/packages/rest/test/integration/nodejs/resources/Lint.ts
@@ -1,19 +1,17 @@
 import { Lint, Projects } from '../../../../src';
 
 const { GITLAB_PERSONAL_ACCESS_TOKEN = '', GITLAB_URL = '', TEST_ID = Date.now() } = process.env;
+const CREDENTIALS = {
+  host: GITLAB_URL,
+  token: GITLAB_PERSONAL_ACCESS_TOKEN,
+};
 
 let projectAPI: InstanceType<typeof Projects<false>>;
 let lintAPI: InstanceType<typeof Lint<false>>;
 
 beforeEach(() => {
-  lintAPI = new Lint({
-    host: GITLAB_URL,
-    token: GITLAB_PERSONAL_ACCESS_TOKEN,
-  });
-  projectAPI = new Projects({
-    host: GITLAB_URL,
-    token: GITLAB_PERSONAL_ACCESS_TOKEN,
-  });
+  lintAPI = new Lint(CREDENTIALS);
+  projectAPI = new Projects(CREDENTIALS);
 });
 
 describe('Lint.lint', () => {

--- a/packages/rest/test/integration/nodejs/resources/Projects.ts
+++ b/packages/rest/test/integration/nodejs/resources/Projects.ts
@@ -47,7 +47,7 @@ describe('Projects.all', () => {
   });
 });
 
-describe('Projects.upload', () => {
+describe('Projects.uploadForReference', () => {
   it('should upload a text file', async () => {
     const project = await service.create({
       name: `Project Upload Integration Test Text File - NodeJS ${TEST_ID}`,
@@ -57,7 +57,10 @@ describe('Projects.upload', () => {
       type: 'text/plain',
     });
 
-    const results = await service.upload(project.id, { content: blob, filename: 'testfile.txt' });
+    const results = await service.uploadForReference(project.id, {
+      content: blob,
+      filename: 'testfile.txt',
+    });
 
     expect(results).toContainKeys(['alt', 'url', 'full_path', 'markdown']);
   });

--- a/packages/rest/test/integration/nodejs/resources/Repositories.ts
+++ b/packages/rest/test/integration/nodejs/resources/Repositories.ts
@@ -35,6 +35,8 @@ describe('Repositories.showArchive', () => {
   });
 
   it('should show repository archive in zip format', async () => {
+    console.log(project.id);
+
     const blob = await repositoryAPI.showArchive(project.id, { sha: 'main', fileType: 'zip' });
 
     expect(blob).toBeInstanceOf(Blob);

--- a/packages/rest/test/integration/nodejs/resources/Repositories.ts
+++ b/packages/rest/test/integration/nodejs/resources/Repositories.ts
@@ -36,6 +36,6 @@ describe('Repositories.showArchive', () => {
   it('should show repository archive in zip format', async () => {
     const blob = await repositoryAPI.showArchive(project.id, { sha: 'main', fileType: 'zip' });
 
-    expect(blob).toBeInstanceOf(Blob);
+    expect(blob).toBeInstanceOf(ArrayBuffer);
   });
 });

--- a/packages/rest/test/integration/nodejs/resources/Repositories.ts
+++ b/packages/rest/test/integration/nodejs/resources/Repositories.ts
@@ -1,21 +1,21 @@
-import { Projects, Repositories } from '../../../../src';
+import { Projects, Repositories, RepositoryFiles } from '../../../../src';
 
 const { GITLAB_PERSONAL_ACCESS_TOKEN = '', GITLAB_URL = '', TEST_ID = Date.now() } = process.env;
+
+const CREDENTIALS = {
+  host: GITLAB_URL,
+  token: GITLAB_PERSONAL_ACCESS_TOKEN,
+};
 
 let repositoryAPI: InstanceType<typeof Repositories<false>>;
 
 beforeEach(() => {
-  repositoryAPI = new Repositories({
-    host: GITLAB_URL,
-    token: GITLAB_PERSONAL_ACCESS_TOKEN,
-  });
+  repositoryAPI = new Repositories(CREDENTIALS);
 });
 
 describe('Repositories.showArchive', () => {
-  const projectAPI = new Projects({
-    host: GITLAB_URL,
-    token: GITLAB_PERSONAL_ACCESS_TOKEN,
-  });
+  const projectAPI = new Projects(CREDENTIALS);
+  const repositoryFilesAPI = new RepositoryFiles(CREDENTIALS);
 
   let project: Awaited<ReturnType<typeof projectAPI.create<false>>>;
 
@@ -24,19 +24,16 @@ describe('Repositories.showArchive', () => {
       name: `Repositories Integration Test - NodeJS ${TEST_ID}`,
     });
 
-    const blob = new Blob(['TESTING FILE UPLOAD'], {
-      type: 'text/plain',
-    });
-
-    await projectAPI.upload(project.id, {
-      content: blob,
-      filename: 'testfile.txt',
-    });
+    await repositoryFilesAPI.create(
+      project.id,
+      'testfile.txt',
+      'main',
+      'TESTING FILE UPLOAD',
+      'init commit',
+    );
   });
 
   it('should show repository archive in zip format', async () => {
-    console.log(project.id);
-
     const blob = await repositoryAPI.showArchive(project.id, { sha: 'main', fileType: 'zip' });
 
     expect(blob).toBeInstanceOf(Blob);

--- a/packages/rest/test/unit/Requester.ts
+++ b/packages/rest/test/unit/Requester.ts
@@ -198,7 +198,7 @@ describe('defaultRequestHandler', () => {
       prefixUrl: 'http://test.com',
     } as RequestOptions);
 
-    expect(MockFetch).toHaveBeenCalledWith(new URL('http://test.com/testurl'));
+    expect(MockFetch).toHaveBeenCalledWith(new URL('http://test.com/testurl'), { mode: undefined });
   });
 
   it('should handle a searchParams correctly', async () => {
@@ -222,7 +222,9 @@ describe('defaultRequestHandler', () => {
       prefixUrl: 'http://test.com',
     } as RequestOptions);
 
-    expect(MockFetch).toHaveBeenCalledWith(new URL('http://test.com/testurl/123?test=4'));
+    expect(MockFetch).toHaveBeenCalledWith(new URL('http://test.com/testurl/123?test=4'), {
+      mode: undefined,
+    });
   });
 
   it('should add same-origin mode for repository/archive endpoint', async () => {
@@ -241,9 +243,9 @@ describe('defaultRequestHandler', () => {
       },
     }));
 
-    await defaultRequestHandler('http://test.com/respository/archive');
+    await defaultRequestHandler('http://test.com/repository/archive');
 
-    expect(MockFetch).toHaveBeenCalledWith(new URL('http://test.com/respository/archive'), {
+    expect(MockFetch).toHaveBeenCalledWith(new URL('http://test.com/repository/archive'), {
       mode: 'same-origin',
     });
   });
@@ -292,21 +294,27 @@ describe('defaultRequestHandler', () => {
       prefixUrl: 'http://test.com/projects',
     } as RequestOptions);
 
-    expect(MockFetch).toHaveBeenCalledWith(new URL('http://test.com/projects/testurl/123?test=4'));
+    expect(MockFetch).toHaveBeenCalledWith(new URL('http://test.com/projects/testurl/123?test=4'), {
+      mode: undefined,
+    });
 
     await defaultRequestHandler('123/testurl', {
       searchParams: 'test=4',
       prefixUrl: 'http://test.com/projects',
     } as RequestOptions);
 
-    expect(MockFetch).toHaveBeenCalledWith(new URL('http://test.com/projects/123/testurl?test=4'));
+    expect(MockFetch).toHaveBeenCalledWith(new URL('http://test.com/projects/123/testurl?test=4'), {
+      mode: undefined,
+    });
 
     await defaultRequestHandler('123/testurl', {
       searchParams: 'test=4',
       prefixUrl: 'http://test.com/projects/',
     } as RequestOptions);
 
-    expect(MockFetch).toHaveBeenCalledWith(new URL('http://test.com/projects/123/testurl?test=4'));
+    expect(MockFetch).toHaveBeenCalledWith(new URL('http://test.com/projects/123/testurl?test=4'), {
+      mode: undefined,
+    });
   });
 });
 

--- a/packages/rest/test/unit/Requester.ts
+++ b/packages/rest/test/unit/Requester.ts
@@ -198,9 +198,7 @@ describe('defaultRequestHandler', () => {
       prefixUrl: 'http://test.com',
     } as RequestOptions);
 
-    expect(MockFetch).toHaveBeenCalledWith(new URL('http://test.com/testurl'), {
-      mode: 'no-cors',
-    });
+    expect(MockFetch).toHaveBeenCalledWith(new URL('http://test.com/testurl'));
   });
 
   it('should handle a searchParams correctly', async () => {
@@ -224,8 +222,52 @@ describe('defaultRequestHandler', () => {
       prefixUrl: 'http://test.com',
     } as RequestOptions);
 
-    expect(MockFetch).toHaveBeenCalledWith(new URL('http://test.com/testurl/123?test=4'), {
-      mode: 'no-cors',
+    expect(MockFetch).toHaveBeenCalledWith(new URL('http://test.com/testurl/123?test=4'));
+  });
+
+  it('should add same-origin mode for repository/archive endpoint', async () => {
+    MockFetch.mockImplementationOnce(() => ({
+      json: () => Promise.resolve({}),
+      text: () => Promise.resolve(JSON.stringify({})),
+      ok: true,
+      status: 200,
+      headers: {
+        entries() {
+          return [['content-type', 'application/json']];
+        },
+        get() {
+          return 'application/json';
+        },
+      },
+    }));
+
+    await defaultRequestHandler('http://test.com/respository/archive');
+
+    expect(MockFetch).toHaveBeenCalledWith(new URL('http://test.com/respository/archive'), {
+      mode: 'same-origin',
+    });
+  });
+
+  it('should use default mode (cors) for non-repository/archive endpoints', async () => {
+    MockFetch.mockImplementationOnce(() => ({
+      json: () => Promise.resolve({}),
+      text: () => Promise.resolve(JSON.stringify({})),
+      ok: true,
+      status: 200,
+      headers: {
+        entries() {
+          return [['content-type', 'application/json']];
+        },
+        get() {
+          return 'application/json';
+        },
+      },
+    }));
+
+    await defaultRequestHandler('http://test.com/test/something');
+
+    expect(MockFetch).toHaveBeenCalledWith(new URL('http://test.com/test/something'), {
+      mode: undefined,
     });
   });
 
@@ -250,27 +292,21 @@ describe('defaultRequestHandler', () => {
       prefixUrl: 'http://test.com/projects',
     } as RequestOptions);
 
-    expect(MockFetch).toHaveBeenCalledWith(new URL('http://test.com/projects/testurl/123?test=4'), {
-      mode: 'no-cors',
-    });
+    expect(MockFetch).toHaveBeenCalledWith(new URL('http://test.com/projects/testurl/123?test=4'));
 
     await defaultRequestHandler('123/testurl', {
       searchParams: 'test=4',
       prefixUrl: 'http://test.com/projects',
     } as RequestOptions);
 
-    expect(MockFetch).toHaveBeenCalledWith(new URL('http://test.com/projects/123/testurl?test=4'), {
-      mode: 'no-cors',
-    });
+    expect(MockFetch).toHaveBeenCalledWith(new URL('http://test.com/projects/123/testurl?test=4'));
 
     await defaultRequestHandler('123/testurl', {
       searchParams: 'test=4',
       prefixUrl: 'http://test.com/projects/',
     } as RequestOptions);
 
-    expect(MockFetch).toHaveBeenCalledWith(new URL('http://test.com/projects/123/testurl?test=4'), {
-      mode: 'no-cors',
-    });
+    expect(MockFetch).toHaveBeenCalledWith(new URL('http://test.com/projects/123/testurl?test=4'));
   });
 });
 


### PR DESCRIPTION
Due to the [hotlinking](https://gitlab.com/gitlab-org/gitlab/-/blob/master/lib/gitlab/hotlinking_detector.rb?ref_type=heads) restrictions on the archive endpoint, this PR sets the cors property of fetch to same-origin for those routes. Ideally, the cors mode could be ignored/ removed by default, but the native fetch support does not allow this at the moment.

fixes #3248 
fixes #3232 (for everything but the repository archive endpoint)
