### PR TITLE
docs(package/rest/README.md): fixes invalid orderBy example

### DIFF
--- a/packages/rest/README.md
+++ b/packages/rest/README.md
@@ -235,7 +235,7 @@ Similarly, support for [Keyset pagination](https://docs.gitlab.com/ee/api/#keyse
 const { data } = await api.Projects.all({
   pagination: 'keyset',
   sort: 'asc',
-  orderBy: 'created_by',
+  orderBy: 'created_at',
 });
 ```
 


### PR DESCRIPTION
This MR only fixed a typo in the pagination example