### PR TITLE
Add MergeRequestNoteAwardEmojis class

### DIFF
--- a/packages/core/src/resources/Gitlab.ts
+++ b/packages/core/src/resources/Gitlab.ts
@@ -90,6 +90,7 @@ import { MergeRequestLabelEvents } from './MergeRequestLabelEvents';
 import { MergeRequestMilestoneEvents } from './MergeRequestMilestoneEvents';
 import { MergeRequestNotes } from './MergeRequestNotes';
 import { MergeRequestDraftNotes } from './MergeRequestDraftNotes';
+import { MergeRequestNoteAwardEmojis } from './MergeRequestNoteAwardEmojis';
 import { MergeRequests } from './MergeRequests';
 import { MergeTrains } from './MergeTrains';
 import { PackageRegistry } from './PackageRegistry';
@@ -274,6 +275,7 @@ export interface Gitlab<C extends boolean = false> extends BaseResource<C> {
   MergeRequestMilestoneEvents: MergeRequestMilestoneEvents<C>;
   MergeRequestDraftNotes: MergeRequestDraftNotes<C>;
   MergeRequestNotes: MergeRequestNotes<C>;
+  MergeRequestNoteAwardEmojis: MergeRequestNoteAwardEmojis<C>;
   MergeRequests: MergeRequests<C>;
   MergeTrains: MergeTrains<C>;
   PackageRegistry: PackageRegistry<C>;
@@ -456,6 +458,7 @@ const resources = {
   MergeRequestMilestoneEvents,
   MergeRequestDraftNotes,
   MergeRequestNotes,
+  MergeRequestNoteAwardEmojis,
   MergeRequests,
   MergeTrains,
   PackageRegistry,

--- a/packages/core/src/resources/MergeRequestNoteAwardEmojis.ts
+++ b/packages/core/src/resources/MergeRequestNoteAwardEmojis.ts
@@ -1,0 +1,53 @@
+import type { BaseResourceOptions } from '@gitbeaker/requester-utils';
+import { ResourceNoteAwardEmojis } from '../templates';
+import type { AwardEmojiSchema } from '../templates/ResourceAwardEmojis';
+import type {
+  GitlabAPIResponse,
+  PaginationRequestOptions,
+  PaginationTypes,
+  ShowExpanded,
+  Sudo,
+} from '../infrastructure';
+
+export interface MergeRequestNoteAwardEmojis<C extends boolean = false>
+  extends ResourceNoteAwardEmojis<C> {
+  all<E extends boolean = false, P extends PaginationTypes = 'offset'>(
+    projectId: string | number,
+    mergeRequestIId: number,
+    noteId: number,
+    options?: PaginationRequestOptions<P> & Sudo & ShowExpanded<E>,
+  ): Promise<GitlabAPIResponse<AwardEmojiSchema[], C, E, P>>;
+
+  award<E extends boolean = false>(
+    projectId: string | number,
+    mergeRequestIId: number,
+    noteId: number,
+    name: string,
+    options?: Sudo & ShowExpanded<E>,
+  ): Promise<GitlabAPIResponse<AwardEmojiSchema, C, E, void>>;
+
+  remove<E extends boolean = false>(
+    projectId: string | number,
+    mergeRequestIId: number,
+    noteId: number,
+    awardId: number,
+    options?: Sudo & ShowExpanded<E>,
+  ): Promise<GitlabAPIResponse<void, C, E, void>>;
+
+  show<E extends boolean = false>(
+    projectId: string | number,
+    mergeRequestIId: number,
+    noteId: number,
+    awardId: number,
+    options?: Sudo & ShowExpanded<E>,
+  ): Promise<GitlabAPIResponse<AwardEmojiSchema, C, E, void>>;
+}
+
+export class MergeRequestNoteAwardEmojis<
+  C extends boolean = false,
+> extends ResourceNoteAwardEmojis<C> {
+  constructor(options: BaseResourceOptions<C>) {
+    /* istanbul ignore next */
+    super('merge_requests', options);
+  }
+}

--- a/packages/core/src/resources/index.ts
+++ b/packages/core/src/resources/index.ts
@@ -89,6 +89,7 @@ export * from './MergeRequestLabelEvents';
 export * from './MergeRequestMilestoneEvents';
 export * from './MergeRequestDraftNotes';
 export * from './MergeRequestNotes';
+export * from './MergeRequestNoteAwardEmojis';
 export * from './MergeRequests';
 export * from './MergeTrains';
 export * from './PackageRegistry';

--- a/packages/core/test/e2e/map.ts
+++ b/packages/core/test/e2e/map.ts
@@ -89,6 +89,7 @@ describe('API Map', () => {
       'MergeRequestMilestoneEvents',
       'MergeRequestDraftNotes',
       'MergeRequestNotes',
+      'MergeRequestNoteAwardEmojis',
       'MergeRequests',
       'MergeTrains',
       'PackageRegistry',

--- a/packages/rest/src/index.ts
+++ b/packages/rest/src/index.ts
@@ -97,6 +97,7 @@ export const {
   MergeRequestMilestoneEvents,
   MergeRequestDraftNotes,
   MergeRequestNotes,
+  MergeRequestNoteAwardEmojis,
   MergeRequests,
   MergeTrains,
   PackageRegistry,

--- a/packages/rest/test/e2e/browser/index.ts
+++ b/packages/rest/test/e2e/browser/index.ts
@@ -93,6 +93,7 @@ describe('Browser Import', () => {
     'MergeRequestMilestoneEvents',
     'MergeRequestDraftNotes',
     'MergeRequestNotes',
+    'MergeRequestNoteAwardEmojis',
     'MergeRequests',
     'MergeTrains',
     'PackageRegistry',


### PR DESCRIPTION
While not explicitly documented in the Gitlab API spec, you can add awards to comments/notes on merge requests aswell: https://docs.gitlab.com/ee/api/award_emoji.html#add-reactions-to-comments

Essentially copied IssueNoteAwardEmojis class and pasted the new one anywhere the other one was mentioned aswell.