### PR TITLE
Added fix for Group Access tokens requests

### DIFF
--- a/packages/core/src/resources/GroupAccessTokens.ts
+++ b/packages/core/src/resources/GroupAccessTokens.ts
@@ -39,6 +39,6 @@ export interface GroupAccessTokens<C extends boolean = false> extends ResourceAc
 export class GroupAccessTokens<C extends boolean = false> extends ResourceAccessTokens<C> {
   constructor(options: BaseResourceOptions<C>) {
     /* istanbul ignore next */
-    super('projects', options);
+    super('groups', options);
   }
 }


### PR DESCRIPTION
The url used for group access tokens was wrong, it was using 'Projects' instead of 'Groups'