### PR TITLE
Fix ExternalStatusChecks arguments

### DIFF
--- a/packages/core/src/resources/ExternalStatusChecks.ts
+++ b/packages/core/src/resources/ExternalStatusChecks.ts
@@ -110,7 +110,7 @@ export class ExternalStatusChecks<C extends boolean = false> extends BaseResourc
     projectId: string | number,
     mergerequestIId: number,
     sha: string,
-    externalCheckStatusId: number,
+    externalStatusCheckId: number,
     options?: { status?: 'passed' | 'failed' } & Sudo & ShowExpanded<E>,
   ): Promise<GitlabAPIResponse<ProjectExternalStatusCheckSchema, C, E, void>> {
     return RequestHelper.post<ProjectExternalStatusCheckSchema>()(
@@ -118,7 +118,7 @@ export class ExternalStatusChecks<C extends boolean = false> extends BaseResourc
       endpoint`projects/${projectId}/merge_requests/${mergerequestIId}/status_check_responses`,
       {
         sha,
-        external_status_check_id: externalCheckStatusId,
+        externalStatusCheckId,
         ...options,
       },
     );

--- a/packages/core/src/resources/ExternalStatusChecks.ts
+++ b/packages/core/src/resources/ExternalStatusChecks.ts
@@ -123,22 +123,4 @@ export class ExternalStatusChecks<C extends boolean = false> extends BaseResourc
       },
     );
   }
-
-  show<E extends boolean = false>(
-    projectId: string | number,
-    mergerequestIId: number,
-    sha: string,
-    externalCheckStatusId: number,
-    options?: Sudo & ShowExpanded<E>,
-  ): Promise<GitlabAPIResponse<ProjectExternalStatusCheckSchema, C, E, void>> {
-    return RequestHelper.get<ProjectExternalStatusCheckSchema>()(
-      this,
-      endpoint`projects/${projectId}/merge_requests/${mergerequestIId}/status_checks`,
-      {
-        sha,
-        external_status_check_id: externalCheckStatusId,
-        ...options,
-      },
-    );
-  }
 }

--- a/packages/core/src/resources/ExternalStatusChecks.ts
+++ b/packages/core/src/resources/ExternalStatusChecks.ts
@@ -118,7 +118,7 @@ export class ExternalStatusChecks<C extends boolean = false> extends BaseResourc
       endpoint`projects/${projectId}/merge_requests/${mergerequestIId}/status_check_responses`,
       {
         sha,
-        externalCheckStatusId,
+        external_status_check_id: externalCheckStatusId,
         ...options,
       },
     );
@@ -131,12 +131,12 @@ export class ExternalStatusChecks<C extends boolean = false> extends BaseResourc
     externalCheckStatusId: number,
     options?: Sudo & ShowExpanded<E>,
   ): Promise<GitlabAPIResponse<ProjectExternalStatusCheckSchema, C, E, void>> {
-    return RequestHelper.post<ProjectExternalStatusCheckSchema>()(
+    return RequestHelper.get<ProjectExternalStatusCheckSchema>()(
       this,
-      endpoint`projects/${projectId}/merge_requests/${mergerequestIId}/status_check_responses`,
+      endpoint`projects/${projectId}/merge_requests/${mergerequestIId}/status_checks`,
       {
         sha,
-        externalCheckStatusId,
+        external_status_check_id: externalCheckStatusId,
         ...options,
       },
     );

--- a/packages/core/test/unit/resources/ExternalStatusChecks.ts
+++ b/packages/core/test/unit/resources/ExternalStatusChecks.ts
@@ -97,7 +97,7 @@ describe('ExternalStatusChecks.set', () => {
       'projects/1/merge_requests/2/status_check_responses',
       {
         sha: 'sha',
-        external_status_check_id: 3,
+        externalStatusCheckId: 3,
       },
     );
   });

--- a/packages/core/test/unit/resources/ExternalStatusChecks.ts
+++ b/packages/core/test/unit/resources/ExternalStatusChecks.ts
@@ -88,21 +88,6 @@ describe('ExternalStatusChecks.edit', () => {
   });
 });
 
-describe('ExternalStatusChecks.show', () => {
-  it('should request GET /projects/:id/merge_requests/:idd/status_check_responses', async () => {
-    await service.show(1, 2, 'sha', 3);
-
-    expect(RequestHelper.get()).toHaveBeenCalledWith(
-      service,
-      'projects/1/merge_requests/2/status_check_responses',
-      {
-        sha: 'sha',
-        externalCheckStatusId: 3,
-      },
-    );
-  });
-});
-
 describe('ExternalStatusChecks.set', () => {
   it('should request GET /projects/:id/merge_requests/:idd/status_check_responses', async () => {
     await service.set(1, 2, 'sha', 3);
@@ -112,7 +97,7 @@ describe('ExternalStatusChecks.set', () => {
       'projects/1/merge_requests/2/status_check_responses',
       {
         sha: 'sha',
-        externalCheckStatusId: 3,
+        external_status_check_id: 3,
       },
     );
   });


### PR DESCRIPTION
According API docs https://docs.gitlab.com/ee/api/status_checks.html 
externalCheckStatusId should be passed as "external_status_check_id". 

Additionally, I think show() method should be removed, because it does not do anything 