### PR TITLE
Mark some MR nullable types as nullable

### DIFF
--- a/packages/core/src/resources/Issues.ts
+++ b/packages/core/src/resources/Issues.ts
@@ -19,8 +19,8 @@ import type { MetricImageSchema } from './AlertManagement';
 export interface TimeStatsSchema extends Record<string, unknown> {
   time_estimate: number;
   total_time_spent: number;
-  human_time_estimate: string;
-  human_total_time_spent: string;
+  human_time_estimate: string | null;
+  human_total_time_spent: string | null;
 }
 
 export interface IssueSchema extends Record<string, unknown> {

--- a/packages/core/src/resources/MergeRequests.ts
+++ b/packages/core/src/resources/MergeRequests.ts
@@ -89,10 +89,10 @@ export interface CondensedMergeRequestSchema extends Record<string, unknown> {
 }
 
 export interface MergeRequestSchema extends CondensedMergeRequestSchema {
-  merged_by: Omit<UserSchema, 'created_at'>;
-  merged_at: string;
-  closed_by?: Omit<UserSchema, 'created_at'>;
-  closed_at?: Omit<UserSchema, 'created_at'>;
+  merged_by: Omit<UserSchema, 'created_at'> | null;
+  merged_at: string | null;
+  closed_by: Omit<UserSchema, 'created_at'> | null;
+  closed_at: Omit<UserSchema, 'created_at'> | null;
   target_branch: string;
   source_branch: string;
   user_notes_count: number;
@@ -107,7 +107,7 @@ export interface MergeRequestSchema extends CondensedMergeRequestSchema {
   labels?: string[];
   draft: boolean;
   work_in_progress: boolean;
-  milestone?: MilestoneSchema;
+  milestone: MilestoneSchema | null;
   merge_when_pipeline_succeeds: boolean;
   merge_status:
     | 'unchecked'
@@ -116,10 +116,10 @@ export interface MergeRequestSchema extends CondensedMergeRequestSchema {
     | 'cannot_be_merged'
     | 'cannot_be_merged_recheck';
   sha: string;
-  merge_commit_sha: string;
-  squash_commit_sha?: string;
-  discussion_locked?: boolean;
-  should_remove_source_branch?: boolean;
+  merge_commit_sha: string | null;
+  squash_commit_sha: string | null;
+  discussion_locked: boolean | null;
+  should_remove_source_branch: boolean | null;
   force_remove_source_branch: boolean;
   reference: string;
   references: ReferenceSchema;
@@ -134,13 +134,13 @@ export interface MergeRequestSchema extends CondensedMergeRequestSchema {
 export interface ExpandedMergeRequestSchema extends MergeRequestSchema {
   subscribed: boolean;
   changes_count: string;
-  latest_build_started_at: string;
-  latest_build_finished_at: string;
-  first_deployed_to_production_at?: null;
-  pipeline: PipelineSchema;
-  head_pipeline: ExpandedPipelineSchema;
+  latest_build_started_at:  string | null;
+  latest_build_finished_at: string | null;
+  first_deployed_to_production_at: null;
+  pipeline: PipelineSchema | null
+  head_pipeline: ExpandedPipelineSchema | null;
   diff_refs: DiffRefsSchema;
-  merge_error?: null;
+  merge_error: string | null;
   first_contribution: boolean;
   user: {
     can_merge: boolean;

--- a/packages/core/src/resources/MergeRequests.ts
+++ b/packages/core/src/resources/MergeRequests.ts
@@ -134,10 +134,10 @@ export interface MergeRequestSchema extends CondensedMergeRequestSchema {
 export interface ExpandedMergeRequestSchema extends MergeRequestSchema {
   subscribed: boolean;
   changes_count: string;
-  latest_build_started_at:  string | null;
+  latest_build_started_at: string | null;
   latest_build_finished_at: string | null;
   first_deployed_to_production_at: null;
-  pipeline: PipelineSchema | null
+  pipeline: PipelineSchema | null;
   head_pipeline: ExpandedPipelineSchema | null;
   diff_refs: DiffRefsSchema;
   merge_error: string | null;


### PR DESCRIPTION
I encountered a null reference error today when using this library. The head_pipeline property on an object implementing
ExpandedMergeRequestSchema was null, and Typescript hadn't hinted that it could be null. Unfortunately GitLab's API docs don't tell you what values could be null, so I did a GET request to the REST endpoint of my self-hosted GitLab server (15.11.3) and updated these type definitions based on null JSON values I got back.

Let me know if this PR is in the right format, or if I need to add anything else! :smile: 