### PR TITLE
Adding Mergerequest "changes" endpoint for backwards compatibility until full deprecation

### DIFF
--- a/packages/core/src/resources/MergeRequests.ts
+++ b/packages/core/src/resources/MergeRequests.ts
@@ -131,15 +131,6 @@ export interface MergeRequestSchema extends CondensedMergeRequestSchema {
   approvals_before_merge: unknown | null;
 }
 
-export interface MergeRequestChangesSchema
-  extends Omit<
-    MergeRequestSchema,
-    'has_conflicts' | 'blocking_discussions_resolved' | 'approvals_before_merge'
-  > {
-  changes: CommitDiffSchema[];
-  overflow: boolean;
-}
-
 export interface ExpandedMergeRequestSchema extends MergeRequestSchema {
   subscribed: boolean;
   changes_count: string;
@@ -160,6 +151,15 @@ export interface MergeRequestTodoSchema extends TodoSchema {
   project: SimpleProjectSchema;
   target_type: 'MergeRequest';
   target: ExpandedMergeRequestSchema;
+}
+
+export interface MergeRequestChangesSchema
+  extends Omit<
+    MergeRequestSchema,
+    'has_conflicts' | 'blocking_discussions_resolved' | 'approvals_before_merge'
+  > {
+  changes: CommitDiffSchema[];
+  overflow: boolean;
 }
 
 // Select method options
@@ -247,10 +247,6 @@ export type EditMergeRequestOptions = {
   allowMaintainerToPush?: boolean;
 };
 
-export type GetMergeRequestChangesOptions = {
-  access_raw_diffs?: boolean;
-};
-
 // Export API
 export class MergeRequests<C extends boolean = false> extends BaseResource<C> {
   // convenience method
@@ -311,18 +307,6 @@ export class MergeRequests<C extends boolean = false> extends BaseResource<C> {
     );
   }
 
-  allIssuesClosed<E extends boolean = false>(
-    projectId: string | number,
-    mergerequestIId: number,
-    options?: Sudo & ShowExpanded<E>,
-  ): Promise<GitlabAPIResponse<IssueSchema[], C, E, void>> {
-    return RequestHelper.get<IssueSchema[]>()(
-      this,
-      endpoint`projects/${projectId}/merge_requests/${mergerequestIId}/closes_issues`,
-      options,
-    );
-  }
-
   allCommits<E extends boolean = false>(
     projectId: string | number,
     mergerequestIId: number,
@@ -347,14 +331,14 @@ export class MergeRequests<C extends boolean = false> extends BaseResource<C> {
     );
   }
 
-  changes<E extends boolean = false>(
+  allIssuesClosed<E extends boolean = false>(
     projectId: string | number,
     mergerequestIId: number,
-    options?: GetMergeRequestChangesOptions & Sudo & ShowExpanded<E>,
-  ): Promise<GitlabAPIResponse<MergeRequestChangesSchema, C, E, void>> {
-    return RequestHelper.get<MergeRequestChangesSchema>()(
+    options?: Sudo & ShowExpanded<E>,
+  ): Promise<GitlabAPIResponse<IssueSchema[], C, E, void>> {
+    return RequestHelper.get<IssueSchema[]>()(
       this,
-      endpoint`projects/${projectId}/merge_requests/${mergerequestIId}/changes`,
+      endpoint`projects/${projectId}/merge_requests/${mergerequestIId}/closes_issues`,
       options,
     );
   }
@@ -553,6 +537,22 @@ export class MergeRequests<C extends boolean = false> extends BaseResource<C> {
     return RequestHelper.get<ExpandedMergeRequestSchema>()(
       this,
       endpoint`projects/${projectId}/merge_requests/${mergerequestIId}`,
+      options,
+    );
+  }
+
+  showChanges<E extends boolean = false>(
+    projectId: string | number,
+    mergerequestIId: number,
+    options?: { accessRawDiffs?: boolean } & Sudo & ShowExpanded<E>,
+  ): Promise<GitlabAPIResponse<MergeRequestChangesSchema, C, E, void>> {
+    process.emitWarning(
+      'This endpoint was deprecated in Gitlab API 15.7 and will be removed in API v5. Please use the "allDiffs" function instead.',
+      'DeprecationWarning',
+    );
+    return RequestHelper.get<MergeRequestChangesSchema>()(
+      this,
+      endpoint`projects/${projectId}/merge_requests/${mergerequestIId}/changes`,
       options,
     );
   }

--- a/packages/core/src/resources/MergeRequests.ts
+++ b/packages/core/src/resources/MergeRequests.ts
@@ -131,6 +131,15 @@ export interface MergeRequestSchema extends CondensedMergeRequestSchema {
   approvals_before_merge: unknown | null;
 }
 
+export interface MergeRequestChangesSchema
+  extends Omit<
+    MergeRequestSchema,
+    'has_conflicts' | 'blocking_discussions_resolved' | 'approvals_before_merge'
+  > {
+  changes: CommitDiffSchema[];
+  overflow: boolean;
+}
+
 export interface ExpandedMergeRequestSchema extends MergeRequestSchema {
   subscribed: boolean;
   changes_count: string;
@@ -238,6 +247,10 @@ export type EditMergeRequestOptions = {
   allowMaintainerToPush?: boolean;
 };
 
+export type GetMergeRequestChangesOptions = {
+  access_raw_diffs?: boolean;
+};
+
 // Export API
 export class MergeRequests<C extends boolean = false> extends BaseResource<C> {
   // convenience method
@@ -330,6 +343,18 @@ export class MergeRequests<C extends boolean = false> extends BaseResource<C> {
     return RequestHelper.get<MergeRequestDiffVersionsSchema[]>()(
       this,
       endpoint`projects/${projectId}/merge_requests/${mergerequestIId}/versions`,
+      options,
+    );
+  }
+
+  changes<E extends boolean = false>(
+    projectId: string | number,
+    mergerequestIId: number,
+    options?: GetMergeRequestChangesOptions & Sudo & ShowExpanded<E>,
+  ): Promise<GitlabAPIResponse<MergeRequestChangesSchema, C, E, void>> {
+    return RequestHelper.get<MergeRequestChangesSchema>()(
+      this,
+      endpoint`projects/${projectId}/merge_requests/${mergerequestIId}/changes`,
       options,
     );
   }

--- a/packages/core/test/unit/resources/MergeRequests.ts
+++ b/packages/core/test/unit/resources/MergeRequests.ts
@@ -87,13 +87,25 @@ describe('MergeRequests.cancelOnPipelineSuccess', () => {
   });
 });
 
-describe('MergeRequests.allChanges', () => {
-  it('should request GET projects/:id/merge_requests/:id/changes', async () => {
+describe('MergeRequests.allDiffs', () => {
+  it('should request GET projects/:id/merge_requests/:id/diffs', async () => {
     await service.allDiffs(2, 3);
 
     expect(RequestHelper.get()).toHaveBeenCalledWith(
       service,
       'projects/2/merge_requests/3/diffs',
+      undefined,
+    );
+  });
+});
+
+describe('MergeRequests.changes', () => {
+  it('should request GET projects/:id/merge_requests/:id/changes', async () => {
+    await service.allDiffs(2, 3);
+
+    expect(RequestHelper.get()).toHaveBeenCalledWith(
+      service,
+      'projects/2/merge_requests/3/changes',
       undefined,
     );
   });

--- a/packages/core/test/unit/resources/MergeRequests.ts
+++ b/packages/core/test/unit/resources/MergeRequests.ts
@@ -99,9 +99,9 @@ describe('MergeRequests.allDiffs', () => {
   });
 });
 
-describe('MergeRequests.changes', () => {
+describe('MergeRequests.showChanges', () => {
   it('should request GET projects/:id/merge_requests/:id/changes', async () => {
-    await service.changes(2, 3);
+    await service.showChanges(2, 3);
 
     expect(RequestHelper.get()).toHaveBeenCalledWith(
       service,

--- a/packages/core/test/unit/resources/MergeRequests.ts
+++ b/packages/core/test/unit/resources/MergeRequests.ts
@@ -101,7 +101,7 @@ describe('MergeRequests.allDiffs', () => {
 
 describe('MergeRequests.changes', () => {
   it('should request GET projects/:id/merge_requests/:id/changes', async () => {
-    await service.allDiffs(2, 3);
+    await service.changes(2, 3);
 
     expect(RequestHelper.get()).toHaveBeenCalledWith(
       service,


### PR DESCRIPTION
Implemented the `GET /projects/:id/merge_requests/:merge_request_iid/changes` endpoint. 

It is deprecated but isn't removed yet. The `/diffs` endpoint, created to replace it, is unavailable in some legacy GitLab versions(for example, 15.4).

[GitLab API Doc](https://docs.gitlab.com/ee/api/merge_requests.html#get-single-merge-request-changes)