### PR TITLE
Updating typing for `MergeRequests.all()` to properly support not passing `groupId` or `projectId`

### DIFF
--- a/packages/core/src/resources/MergeRequests.ts
+++ b/packages/core/src/resources/MergeRequests.ts
@@ -285,7 +285,7 @@ export class MergeRequests<C extends boolean = false> extends BaseResource<C> {
       PaginationRequestOptions<P> &
       BaseRequestOptions<E> = {} as any,
   ): Promise<GitlabAPIResponse<MergeRequestSchema[], C, E, P>> {
-    let prefix = endpoint``;
+    let prefix = '';
 
     if (projectId) {
       prefix = endpoint`projects/${projectId}/`;

--- a/packages/core/src/resources/MergeRequests.ts
+++ b/packages/core/src/resources/MergeRequests.ts
@@ -2,7 +2,7 @@ import { BaseResource } from '@gitbeaker/requester-utils';
 import { RequestHelper, endpoint } from '../infrastructure';
 import type {
   BaseRequestOptions,
-  Either,
+  EitherOrNone,
   GitlabAPIResponse,
   MappedOmit,
   PaginationRequestOptions,
@@ -281,11 +281,11 @@ export class MergeRequests<C extends boolean = false> extends BaseResource<C> {
       groupId,
       ...options
     }: AllMergeRequestsOptions &
-      Either<{ projectId: string | number }, { groupId: string | number }> &
+      EitherOrNone<{ projectId: string | number }, { groupId: string | number }> &
       PaginationRequestOptions<P> &
       BaseRequestOptions<E> = {} as any,
   ): Promise<GitlabAPIResponse<MergeRequestSchema[], C, E, P>> {
-    let prefix = '';
+    let prefix = endpoint``;
 
     if (projectId) {
       prefix = endpoint`projects/${projectId}/`;


### PR DESCRIPTION
Fix when need `MergeRequests.all()` without `groupId` or `projectId`.

Before this fix, when you call the `MergeRequests.all()`  with some options, the type-check requires the `groupId` or `projectId`.