### PR TITLE
Fixing typo in the `edit` function of Resource/Group/Project Milestones

### DIFF
--- a/packages/core/src/resources/GroupMilestones.ts
+++ b/packages/core/src/resources/GroupMilestones.ts
@@ -54,7 +54,7 @@ export interface GroupMilestones<C extends boolean = false> extends ResourceMile
       description?: string;
       dueDate?: string;
       startDate?: string;
-      startEvent?: 'close' | 'activate';
+      stateEvent?: 'close' | 'activate';
     } & Sudo &
       ShowExpanded<E>,
   ): Promise<GitlabAPIResponse<MilestoneSchema, C, E, void>>;

--- a/packages/core/src/resources/ProjectMilestones.ts
+++ b/packages/core/src/resources/ProjectMilestones.ts
@@ -55,7 +55,7 @@ export interface ProjectMilestones<C extends boolean = false> extends ResourceMi
       description?: string;
       dueDate?: string;
       startDate?: string;
-      startEvent?: 'close' | 'activate';
+      stateEvent?: 'close' | 'activate';
     } & Sudo &
       ShowExpanded<E>,
   ): Promise<GitlabAPIResponse<MilestoneSchema, C, E, void>>;

--- a/packages/core/src/templates/ResourceMilestones.ts
+++ b/packages/core/src/templates/ResourceMilestones.ts
@@ -114,7 +114,7 @@ export class ResourceMilestones<C extends boolean = false> extends BaseResource<
       description?: string;
       dueDate?: string;
       startDate?: string;
-      startEvent?: 'close' | 'activate';
+      stateEvent?: 'close' | 'activate';
     } & Sudo &
       ShowExpanded<E>,
   ): Promise<GitlabAPIResponse<MilestoneSchema, C, E, void>> {


### PR DESCRIPTION
fixes #3307 