### PR TITLE
Add missing administrator-only Users.all search params

### DIFF
--- a/packages/core/src/resources/Users.ts
+++ b/packages/core/src/resources/Users.ts
@@ -1,6 +1,7 @@
 import { BaseResource } from '@gitbeaker/requester-utils';
 import { RequestHelper, endpoint } from '../infrastructure';
 import type {
+  AllOrNone,
   GitlabAPIResponse,
   PaginationRequestOptions,
   PaginationTypes,
@@ -119,11 +120,13 @@ export interface UserRunnerSchema extends Record<string, unknown> {
 
 export type AllUsersOptions = {
   orderBy?: 'name' | 'username' | 'created_at' | 'updated_at';
+  createdBy?: string;
   sort?: 'asc' | 'desc';
   twoFactor?: string;
   withoutProjects?: boolean;
   admins?: boolean;
   samlProviderId?: number;
+  skipLdap?: boolean;
   search?: string;
   username?: string;
   active?: boolean;
@@ -132,9 +135,11 @@ export type AllUsersOptions = {
   excludeInternal?: boolean;
   excludeExternal?: boolean;
   withoutProjectBots?: boolean;
-  provider?: string;
-  extern_uid?: string;
-};
+  createdBefore?: string;
+  createdAfter?: string;
+  withCustomAttributes?: boolean;
+  customAttributes?: Record<string, string>;
+} & AllOrNone<{ provider: string; externUid: string }>;
 
 export type CreateUserOptions = {
   admin?: boolean;

--- a/packages/core/src/resources/Users.ts
+++ b/packages/core/src/resources/Users.ts
@@ -132,6 +132,8 @@ export type AllUsersOptions = {
   excludeInternal?: boolean;
   excludeExternal?: boolean;
   withoutProjectBots?: boolean;
+  provider?: string;
+  extern_uid?: string;
 };
 
 export type CreateUserOptions = {


### PR DESCRIPTION
extern_uid and provider are very powerful params to get a User

These needs to be sent together or Gitlab reply with an error, Idk if typescript have a way to declare it 