### PR TITLE
Fix search params in JobArtifact.downloadArchive endpoints

### DIFF
--- a/packages/core/src/resources/JobArtifacts.ts
+++ b/packages/core/src/resources/JobArtifacts.ts
@@ -15,18 +15,13 @@ function generateDownloadPathForJob(
   return url;
 }
 
-function generateDownloadPath(
-  projectId: string | number,
-  ref: string,
-  job: string,
-  artifactPath?: string,
-) {
+function generateDownloadPath(projectId: string | number, ref: string, artifactPath?: string) {
   let url = endpoint`projects/${projectId}/jobs/artifacts/${ref}`;
 
   if (artifactPath) {
-    url += endpoint`/raw/${artifactPath}?job=${job}`;
+    url += endpoint`/raw/${artifactPath}`;
   } else {
-    url += endpoint`/download?job=${job}`;
+    url += endpoint`/download`;
   }
 
   return url;
@@ -53,16 +48,15 @@ export class JobArtifacts<C extends boolean = false> extends BaseResource<C> {
     let url: string;
 
     if (jobId) url = generateDownloadPathForJob(projectId, jobId, artifactPath);
-    else if (job && ref) url = generateDownloadPath(projectId, ref, job, artifactPath);
+    else if (job && ref) url = generateDownloadPath(projectId, ref, artifactPath);
     else
       throw new Error(
         'Missing one of the required parameters. See typing documentation for available arguments.',
       );
 
     return RequestHelper.get<Blob>()(this, url, {
-      searchParams: {
-        jobToken,
-      },
+      jobToken,
+      job,
       ...options,
     });
   }

--- a/packages/core/src/resources/JobArtifacts.ts
+++ b/packages/core/src/resources/JobArtifacts.ts
@@ -32,10 +32,8 @@ export class JobArtifacts<C extends boolean = false> extends BaseResource<C> {
     projectId: string | number,
     {
       jobId,
-      jobToken,
       artifactPath,
       ref,
-      job,
       ...options
     }: (
       | { jobId: number; artifactPath?: undefined; job?: undefined; ref?: undefined }
@@ -48,17 +46,13 @@ export class JobArtifacts<C extends boolean = false> extends BaseResource<C> {
     let url: string;
 
     if (jobId) url = generateDownloadPathForJob(projectId, jobId, artifactPath);
-    else if (job && ref) url = generateDownloadPath(projectId, ref, artifactPath);
+    else if (options?.job && ref) url = generateDownloadPath(projectId, ref, artifactPath);
     else
       throw new Error(
         'Missing one of the required parameters. See typing documentation for available arguments.',
       );
 
-    return RequestHelper.get<Blob>()(this, url, {
-      jobToken,
-      job,
-      ...options,
-    });
+    return RequestHelper.get<Blob>()(this, url, options);
   }
 
   keep<E extends boolean = false>(

--- a/packages/core/test/unit/resources/JobArtifacts.ts
+++ b/packages/core/test/unit/resources/JobArtifacts.ts
@@ -25,20 +25,14 @@ describe('JobArtifacts.downloadArchive', () => {
   it('should request GET /projects/:id/jobs/:job_id/artifacts, getting the job’s artifacts zipped archive of a project via private token', async () => {
     await service.downloadArchive(1, { jobId: 43 });
 
-    expect(RequestHelper.get()).toHaveBeenCalledWith(service, `projects/1/jobs/43/artifacts`, {
-      searchParams: {
-        jobToken: undefined,
-      },
-    });
+    expect(RequestHelper.get()).toHaveBeenCalledWith(service, `projects/1/jobs/43/artifacts`, {});
   });
 
   it('should request GET /projects/:id/jobs/:job_id/artifacts, getting the job’s artifacts zipped archive of a project via jobToken parameter', async () => {
     await service.downloadArchive(1, { jobId: 43, jobToken: 'token' });
 
     expect(RequestHelper.get()).toHaveBeenCalledWith(service, `projects/1/jobs/43/artifacts`, {
-      searchParams: {
-        jobToken: 'token',
-      },
+      jobToken: 'token',
     });
   });
 
@@ -47,11 +41,9 @@ describe('JobArtifacts.downloadArchive', () => {
 
     expect(RequestHelper.get()).toHaveBeenCalledWith(
       service,
-      `projects/1/jobs/artifacts/ref1/download?job=job1`,
+      `projects/1/jobs/artifacts/ref1/download`,
       {
-        searchParams: {
-          jobToken: undefined,
-        },
+        job: 'job1',
       },
     );
   });
@@ -61,11 +53,10 @@ describe('JobArtifacts.downloadArchive', () => {
 
     expect(RequestHelper.get()).toHaveBeenCalledWith(
       service,
-      `projects/1/jobs/artifacts/ref1/download?job=job1`,
+      `projects/1/jobs/artifacts/ref1/download`,
       {
-        searchParams: {
-          jobToken: 'token',
-        },
+        job: 'job1',
+        jobToken: 'token',
       },
     );
   });
@@ -73,20 +64,18 @@ describe('JobArtifacts.downloadArchive', () => {
   it('should request GET /projects/:id/jobs/:job_id/artifacts/:artifact_path, getting a single artifact file from a job with a specified ID from inside the job’s artifacts zipped archive via private token', async () => {
     await service.downloadArchive(1, { jobId: 43, artifactPath: 'path' });
 
-    expect(RequestHelper.get()).toHaveBeenCalledWith(service, `projects/1/jobs/43/artifacts/path`, {
-      searchParams: {
-        jobToken: undefined,
-      },
-    });
+    expect(RequestHelper.get()).toHaveBeenCalledWith(
+      service,
+      `projects/1/jobs/43/artifacts/path`,
+      {},
+    );
   });
 
   it('should request GET /projects/:id/jobs/:job_id/artifacts, getting a single artifact file from a job with a specified ID from inside the job’s artifacts zipped archive via jobToken parameter', async () => {
     await service.downloadArchive(1, { jobId: 43, jobToken: 'token', artifactPath: 'path' });
 
     expect(RequestHelper.get()).toHaveBeenCalledWith(service, `projects/1/jobs/43/artifacts/path`, {
-      searchParams: {
-        jobToken: 'token',
-      },
+      jobToken: 'token',
     });
   });
 
@@ -95,11 +84,9 @@ describe('JobArtifacts.downloadArchive', () => {
 
     expect(RequestHelper.get()).toHaveBeenCalledWith(
       service,
-      `projects/1/jobs/artifacts/ref1/raw/path?job=job1`,
+      `projects/1/jobs/artifacts/ref1/raw/path`,
       {
-        searchParams: {
-          jobToken: undefined,
-        },
+        job: 'job1',
       },
     );
   });
@@ -114,11 +101,10 @@ describe('JobArtifacts.downloadArchive', () => {
 
     expect(RequestHelper.get()).toHaveBeenCalledWith(
       service,
-      `projects/1/jobs/artifacts/ref1/raw/path?job=job1`,
+      `projects/1/jobs/artifacts/ref1/raw/path`,
       {
-        searchParams: {
-          jobToken: 'token',
-        },
+        job: 'job1',
+        jobToken: 'token',
       },
     );
   });


### PR DESCRIPTION
fixes #3345 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>39.6.0--canary.3346.928099133.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @gitbeaker/cli@39.6.0--canary.3346.928099133.0
  npm install @gitbeaker/core@39.6.0--canary.3346.928099133.0
  npm install @gitbeaker/requester-utils@39.6.0--canary.3346.928099133.0
  npm install @gitbeaker/rest@39.6.0--canary.3346.928099133.0
  # or 
  yarn add @gitbeaker/cli@39.6.0--canary.3346.928099133.0
  yarn add @gitbeaker/core@39.6.0--canary.3346.928099133.0
  yarn add @gitbeaker/requester-utils@39.6.0--canary.3346.928099133.0
  yarn add @gitbeaker/rest@39.6.0--canary.3346.928099133.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
