### PR TITLE
Fix MergeRequestSchema.closed_at property type

### DIFF
--- a/packages/core/src/resources/MergeRequests.ts
+++ b/packages/core/src/resources/MergeRequests.ts
@@ -93,7 +93,7 @@ export interface MergeRequestSchema extends CondensedMergeRequestSchema {
   merged_by: MappedOmit<UserSchema, 'created_at'> | null;
   merged_at: string | null;
   closed_by: MappedOmit<UserSchema, 'created_at'> | null;
-  closed_at: MappedOmit<UserSchema, 'created_at'> | null;
+  closed_at: string | null;
   target_branch: string;
   source_branch: string;
   user_notes_count: number;


### PR DESCRIPTION
This PR fixes `MergeRequestSchema.closed_at` property type which was wrongly typed as a `UserSchema`.

This should be `string | null`, with the timestamp of when the MR was closed.