### PR TITLE
Fix missing ProjectReleaseSchema._links property

### DIFF
--- a/packages/core/src/resources/ProjectReleases.ts
+++ b/packages/core/src/resources/ProjectReleases.ts
@@ -51,6 +51,15 @@ export interface ReleaseSchema extends Record<string, unknown> {
     evidence_file_path: string;
   };
   evidences: ReleaseEvidence[] | null;
+  _links: {
+    closed_issues_url: string;
+    closed_merge_requests_url: string;
+    edit_url: string;
+    merged_merge_requests_url: string;
+    opened_issues_url: string;
+    opened_merge_requests_url: string;
+    self: string;
+  };
 }
 
 export class ProjectReleases<C extends boolean = false> extends BaseResource<C> {


### PR DESCRIPTION
This property started to be documented in 15.8, and expanded in 15.9.

* https://archives.docs.gitlab.com/15.8/ee/api/releases/
* https://archives.docs.gitlab.com/15.9/ee/api/releases/
