### PR TITLE
Add missing scopes and token attribute

### DIFF
--- a/packages/core/src/resources/PersonalAccessTokens.ts
+++ b/packages/core/src/resources/PersonalAccessTokens.ts
@@ -18,14 +18,20 @@ export interface PersonalAccessTokenSchema extends Record<string, unknown> {
   last_used_at: string;
   active: boolean;
   expires_at?: string;
+  token?: string;
 }
 
 export type PersonalAccessTokenScopes =
   | 'api'
-  | 'read_user'
   | 'read_api'
+  | 'read_user'
+  | 'create_runner'
   | 'read_repository'
-  | 'write_repository';
+  | 'write_repository'
+  | 'read_registry'
+  | 'write_registry'
+  | 'sudo'
+  | 'admin_mode';
 
 export type AllPersonalAccessTokenOptions = {
   userId?: string | number;

--- a/packages/core/src/resources/UserImpersonationTokens.ts
+++ b/packages/core/src/resources/UserImpersonationTokens.ts
@@ -8,7 +8,18 @@ import type {
   Sudo,
 } from '../infrastructure';
 
-export type ImpersonationTokenScope = 'api' | 'read_user';
+export type ImpersonationTokenScope =
+  | 'api'
+  | 'read_api'
+  | 'read_user'
+  | 'create_runner'
+  | 'read_repository'
+  | 'write_repository'
+  | 'read_registry'
+  | 'write_registry'
+  | 'sudo'
+  | 'admin_mode';
+
 export type ImpersonationTokenState = 'all' | 'active' | 'inactive';
 
 export interface UserImpersonationTokenSchema extends Record<string, unknown> {
@@ -21,6 +32,7 @@ export interface UserImpersonationTokenSchema extends Record<string, unknown> {
   created_at: string;
   impersonation: boolean;
   expires_at: string;
+  token?: string;
 }
 
 export class UserImpersonationTokens<C extends boolean = false> extends BaseResource<C> {

--- a/packages/core/src/templates/ResourceAccessTokens.ts
+++ b/packages/core/src/templates/ResourceAccessTokens.ts
@@ -13,6 +13,7 @@ import type { AccessLevel } from './ResourceAccessRequests';
 export type AccessTokenScopes =
   | 'api'
   | 'read_api'
+  | 'create_runner'
   | 'read_registry'
   | 'write_registry'
   | 'read_repository'
@@ -28,6 +29,7 @@ export interface AccessTokenSchema extends Record<string, unknown> {
   created_at: string;
   revoked: boolean;
   access_level: AccessLevel;
+  token?: string;
 }
 
 export class ResourceAccessTokens<C extends boolean = false> extends BaseResource<C> {


### PR DESCRIPTION
Hi,

i saw that some of the scopes i need for the creation of a user impersonation token are missing. So i added those and also checked the other token types and added the missing scopes accordingly.

I also added the 'token' attribute to every token schema because at creation level the token attribute is available (and my ide drives me crazy ;) ), see here:

https://docs.gitlab.com/ee/api/project_access_tokens.html#create-a-project-access-token
https://docs.gitlab.com/ee/api/group_access_tokens.html#create-a-group-access-token
https://docs.gitlab.com/ee/api/users.html#create-an-impersonation-token
https://docs.gitlab.com/ee/api/users.html#create-a-personal-access-token