### PR TITLE
Add Blob to RepositoryFiles.showRaw response type

### DIFF
--- a/packages/core/src/resources/RepositoryFiles.ts
+++ b/packages/core/src/resources/RepositoryFiles.ts
@@ -142,8 +142,8 @@ export class RepositoryFiles<C extends boolean = false> extends BaseResource<C> 
     filePath: string,
     ref: string,
     options?: { lfs?: boolean } & Sudo & ShowExpanded<E>,
-  ): Promise<GitlabAPIResponse<string, C, E, void>> {
-    return RequestHelper.get<string>()(
+  ): Promise<GitlabAPIResponse<string | Blob, C, E, void>> {
+    return RequestHelper.get<string | Blob>()(
       this,
       endpoint`projects/${projectId}/repository/files/${filePath}/raw`,
       {


### PR DESCRIPTION
When downloading an image, the response type is actually Blob for this endpoint. The current type hint suggests that it will always return a string.

Example test case:

```typescript
import { Gitlab } from "@gitbeaker/rest";

describe("GitLab", () => {
  const api = new Gitlab({ token });

  it("loads an image as a Blob", async () => {
    const response = (await api.RepositoryFiles.showRaw(
      "gitlab-org/gitlab-runner",
      "docs/configuration/img/autoscale-example.png",
      "f8917ca0d5be65b2eb8af5522c20e8e1e2f62e45"
    )) as any;
    assert(response instanceof Blob);
  });
});
```