### PR TITLE
Add creation for service accounts on selfhosted instances

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1645,6 +1645,15 @@ import { Gitlab } from '@gitbeaker/core';
 </td>
 </tr>
 <tr>
+<th>ServiceAccounts</th>
+<td>
+<a href="https://docs.gitlab.com/ee/api/users.html#create-service-account-user">🦊</a>
+</td>
+<td>
+<a href="./src/resources/ServiceAccounts.ts">⌨️</a>
+</td>
+</tr>
+<tr>
 <th>ServiceData</th>
 <td>
 <a href="https://docs.gitlab.com/16.4/ee/api/usage_data.html">🦊</a>

--- a/packages/core/src/resources/Gitlab.ts
+++ b/packages/core/src/resources/Gitlab.ts
@@ -46,6 +46,7 @@ import { PyPI } from './PyPI';
 import { RubyGems } from './RubyGems';
 import { Search } from './Search';
 import { SearchAdmin } from './SearchAdmin';
+import { ServiceAccounts } from './ServiceAccounts';
 import { ServiceData } from './ServiceData';
 import { SidekiqMetrics } from './SidekiqMetrics';
 import { SidekiqQueues } from './SidekiqQueues';
@@ -237,6 +238,7 @@ export interface Gitlab<C extends boolean = false> extends BaseResource<C> {
   RubyGems: RubyGems<C>;
   Search: Search<C>;
   SearchAdmin: SearchAdmin<C>;
+  ServiceAccounts: ServiceAccounts<C>;
   ServiceData: ServiceData<C>;
   SidekiqMetrics: SidekiqMetrics<C>;
   SidekiqQueues: SidekiqQueues<C>;
@@ -426,6 +428,7 @@ const resources = {
   RubyGems,
   Search,
   SearchAdmin,
+  ServiceAccounts,
   ServiceData,
   SidekiqMetrics,
   SidekiqQueues,

--- a/packages/core/src/resources/GroupServiceAccounts.ts
+++ b/packages/core/src/resources/GroupServiceAccounts.ts
@@ -3,7 +3,7 @@ import type { AccessTokenSchema } from '../templates/ResourceAccessTokens';
 import { RequestHelper, endpoint } from '../infrastructure';
 import type { GitlabAPIResponse, MappedOmit, ShowExpanded, Sudo } from '../infrastructure';
 
-export interface ServiceAccountSchema extends Record<string, unknown> {
+export interface GroupServiceAccountSchema extends Record<string, unknown> {
   id: number;
   username: string;
   name: string;
@@ -15,8 +15,8 @@ export class GroupServiceAccounts<C extends boolean = false> extends BaseResourc
   create<E extends boolean = false>(
     groupId: string | number,
     options?: Sudo & ShowExpanded<E>,
-  ): Promise<GitlabAPIResponse<ServiceAccountSchema, C, E, void>> {
-    return RequestHelper.post<ServiceAccountSchema>()(
+  ): Promise<GitlabAPIResponse<GroupServiceAccountSchema, C, E, void>> {
+    return RequestHelper.post<GroupServiceAccountSchema>()(
       this,
       endpoint`groups/${groupId}/service_accounts`,
       options,

--- a/packages/core/src/resources/ServiceAccounts.ts
+++ b/packages/core/src/resources/ServiceAccounts.ts
@@ -1,0 +1,21 @@
+import { BaseResource } from '@gitbeaker/requester-utils';
+import { RequestHelper, endpoint } from '../infrastructure';
+import type { GitlabAPIResponse, ShowExpanded, Sudo } from '../infrastructure';
+
+export interface ServiceAccountSchema extends Record<string, unknown> {
+  id: number;
+  name: string;
+  username: string;
+  state: string;
+  locked: boolean;
+  avatar_url: string;
+  web_url: string;
+}
+
+export class ServiceAccounts<C extends boolean = false> extends BaseResource<C> {
+  create<E extends boolean = false>(
+    options?: Sudo & ShowExpanded<E>,
+  ): Promise<GitlabAPIResponse<ServiceAccountSchema, C, E, void>> {
+    return RequestHelper.post<ServiceAccountSchema>()(this, endpoint`service_accounts`, options);
+  }
+}

--- a/packages/core/src/resources/index.ts
+++ b/packages/core/src/resources/index.ts
@@ -43,6 +43,7 @@ export * from './PyPI';
 export * from './RubyGems';
 export * from './Search';
 export * from './SearchAdmin';
+export * from './ServiceAccounts';
 export * from './ServiceData';
 export * from './SidekiqMetrics';
 export * from './SidekiqQueues';

--- a/packages/rest/src/index.ts
+++ b/packages/rest/src/index.ts
@@ -53,6 +53,7 @@ export const {
   RubyGems,
   Search,
   SearchAdmin,
+  ServiceAccounts,
   ServiceData,
   SidekiqMetrics,
   SidekiqQueues,


### PR DESCRIPTION
Hi,

as an addition to https://github.com/jdalrymple/gitbeaker/issues/3437

**Description**

The already added service accounts creation for groups is mentioned in the [gitlab](https://docs.gitlab.com/ee/user/profile/service_accounts.html#create-a-service-account) documentation for creating service accounts on gitlab.com (also works for selfhosted). For self hosted instances there is also another endpoint available for adding [service accounts directly without a group needed](https://docs.gitlab.com/ee/user/profile/service_accounts.html#create-a-service-account). This would be my preferred way and therfore i created this pr.

This feature has also been added in GitLab 16.1.

**Proposal**

I created a new resource ServiceAccounts with a method for creating those accounts directly in self hosted instances. 

**Checklist**

- [x] I have checked that this is not a duplicate issue.
- [x] I have read the documentation.

<img width="672" alt="gitbeaker" src="https://github.com/jdalrymple/gitbeaker/assets/761764/b36e6720-417e-4417-b4fa-0ad5d45975ab">
