### PR TITLE
Add rotate to PersonalAccessTokens resource

### DIFF
--- a/packages/core/src/resources/PersonalAccessTokens.ts
+++ b/packages/core/src/resources/PersonalAccessTokens.ts
@@ -86,6 +86,17 @@ export class PersonalAccessTokens<C extends boolean = false> extends BaseResourc
     return RequestHelper.del()(this, url, options);
   }
 
+  rotate<E extends boolean = false>(
+    tokenId: number,
+    options?: { expiresAt?: string } & Sudo & ShowExpanded<E>,
+  ): Promise<GitlabAPIResponse<PersonalAccessTokenSchema, C, E, void>> {
+    return RequestHelper.post<PersonalAccessTokenSchema>()(
+      this,
+      endpoint`personal_access_tokens/${tokenId}/rotate`,
+      options,
+    );
+  }
+
   show<E extends boolean = false>({
     tokenId,
     ...options


### PR DESCRIPTION
**Description**

An endpoint for [rotating personal access points ](https://docs.gitlab.com/ee/api/personal_access_tokens.html#rotate-a-personal-access-token) was introduced in gitlab 16.0. 

**Proposal**

I added the rotate function to the PersonalAccessToken resource.

This commit also includes the expiresAt option which was introduced to the rotate endpoint with gitlab 16.6.

**Checklist**

- [x] I have checked that this is not a duplicate issue.
- [x] I have read the documentation.