### PR TITLE
Fix a couple of types in Users and PersonalAccessTokens resources

### DIFF
--- a/packages/core/src/resources/PersonalAccessTokens.ts
+++ b/packages/core/src/resources/PersonalAccessTokens.ts
@@ -18,7 +18,7 @@ export interface PersonalAccessTokenSchema extends Record<string, unknown> {
   last_used_at: string;
   active: boolean;
   expires_at?: string;
-  token?: string;
+  token: string;
 }
 
 export type PersonalAccessTokenScopes =

--- a/packages/core/src/resources/Users.ts
+++ b/packages/core/src/resources/Users.ts
@@ -151,7 +151,7 @@ export type CreateUserOptions = {
   externUid?: number;
   external?: boolean;
   extraSharedRunnersMinutesLimit?: number;
-  forceRandomPassword?: string;
+  forceRandomPassword?: boolean;
   groupIdForSaml?: number;
   linkedin?: string;
   location?: string;


### PR DESCRIPTION
- `CreateUserOptions.forceRandomPassword` should be a boolean and not a string
- `PersonalAccessTokenSchema.token` should be required

Fixes: https://github.com/jdalrymple/gitbeaker/issues/3481