### PR TITLE
Add back isForm when setting position within the create Discussions API

### DIFF
--- a/packages/core/src/templates/ResourceDiscussions.ts
+++ b/packages/core/src/templates/ResourceDiscussions.ts
@@ -112,6 +112,8 @@ export class ResourceDiscussions<C extends boolean = false> extends BaseResource
 
     if (position) {
       Object.assign(opts, reformatObjectOptions(position, 'position', true));
+
+      opts.isForm = true;
     }
 
     return RequestHelper.post<DiscussionSchema>()(

--- a/packages/core/test/unit/templates/ResourceDiscussions.ts
+++ b/packages/core/test/unit/templates/ResourceDiscussions.ts
@@ -79,6 +79,7 @@ describe('ResourceDiscussions.create', () => {
 
     expect(RequestHelper.post()).toHaveBeenCalledWith(service, '1/resource2/2/discussions', {
       body: 'test',
+      isForm: true,
       'position[base_sha]': 'sha1',
       'position[start_sha]': 'sha2',
       'position[head_sha]': 'sha3',


### PR DESCRIPTION
fixes #3494 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>39.28.0--canary.3497.1119579763.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @gitbeaker/cli@39.28.0--canary.3497.1119579763.0
  npm install @gitbeaker/core@39.28.0--canary.3497.1119579763.0
  npm install @gitbeaker/requester-utils@39.28.0--canary.3497.1119579763.0
  npm install @gitbeaker/rest@39.28.0--canary.3497.1119579763.0
  # or 
  yarn add @gitbeaker/cli@39.28.0--canary.3497.1119579763.0
  yarn add @gitbeaker/core@39.28.0--canary.3497.1119579763.0
  yarn add @gitbeaker/requester-utils@39.28.0--canary.3497.1119579763.0
  yarn add @gitbeaker/rest@39.28.0--canary.3497.1119579763.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
