### PR TITLE
Missing build files

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -454,7 +454,7 @@ release:special:
         labels=$(yarn auto label --pr $pr_id)
 
         if [[ "$labels" =~ "release:canary" ]]; then
-          yarn release:canary --dry-run
+          yarn release:canary
         fi
       fi
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -425,7 +425,6 @@ test:live:teardown:
     - ls -A packages/rest/dist
     - ls -A packages/cli/dist
 
-
 ## Canary or RC Special Releases
 
 release:special:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -433,6 +433,9 @@ test:live:teardown:
     - git branch $CI_COMMIT_BRANCH HEAD
     - git checkout $CI_COMMIT_BRANCH
     - echo 'Ensure build files are present'
+
+    - rm -r packages/requester-utils/dist # Testing to make sure this fails
+
     - ls -A packages/requester-utils/dist
     - ls -A packages/core/dist
     - ls -A packages/rest/dist

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -196,15 +196,15 @@ test:live:setup:
     - echo "GITLAB_PERSONAL_ACCESS_TOKEN=${GITLAB_PERSONAL_ACCESS_TOKEN}" >> intergration.env
     - echo "Waiting for service to start"
     - sleep 180
+    - attempt=1
     - |
-      attempt=1;
-      while [[ "$(curl --fail --silent -X GET "$GITLAB_URL/-/readiness?all=1" --insecure | jq -r '.master_check[0].status')" != "ok" ]];
-      do
-        echo -ne "Polling Attempt: $attempt - Gitlab service still not alive yet!";
+      while [[ "$(curl --fail --silent -X GET "$GITLAB_URL/-/readiness?all=1" --insecure | jq -r '.master_check[0].status')" != "ok" ]]; do
+        echo -ne "Polling Attempt: $attempt - Gitlab service is not alive yet\033[0K\r";
         sleep 10;
         ((attempt++));
-      done;
-    - echo "Service is up and running!"
+      done
+    - printf "\n"
+    - echo "Service is up and running"
   artifacts:
     reports:
       dotenv: intergration.env

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -429,20 +429,20 @@ release:special:
     - test:unit:core
     - test:unit:cli
     - test:unit:rest
-    - test:types:utils
-    - test:types:core
-    - test:types:rest
-    - test:integration:rest
-    - test:integration:core
-    - test:e2e:cli
-    - test:e2e:rest
+    # - test:types:utils
+    # - test:types:core
+    # - test:types:rest
+    # - test:integration:rest
+    # - test:integration:core
+    # - test:e2e:cli
+    # - test:e2e:rest
   only:
     refs:
       - /^pr-[0-9]+$/
 
   script:
-    - echo 'release'
     - echo "Checking for special release..."
+    - ls -al packages/core/dist
     - |
       if [[ $CI_COMMIT_BRANCH =~ ^pr-[0-9]*$ ]]; then
         pr_id="${CI_COMMIT_BRANCH//[!0-9]/}"
@@ -453,7 +453,7 @@ release:special:
         labels=$(yarn auto label --pr $pr_id)
 
         if [[ "$labels" =~ "release:canary" ]]; then
-          yarn release:canary
+          yarn release:canary --dryRun
         fi
       fi
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -443,21 +443,20 @@ release:special:
 
   script:
     - echo "Checking for special release..."
-    - ls -al packages/core
     - ls -al ./packages/core/dist
-    # - |
-    #   if [[ $CI_COMMIT_BRANCH =~ ^pr-[0-9]*$ ]]; then
-    #     pr_id="${CI_COMMIT_BRANCH//[!0-9]/}"
+    - |
+      if [[ $CI_COMMIT_BRANCH =~ ^pr-[0-9]*$ ]]; then
+        pr_id="${CI_COMMIT_BRANCH//[!0-9]/}"
 
-    #     export CI_MERGE_REQUEST_ID=$pr_id
-    #     export CI_MERGE_REQUEST_SOURCE_BRANCH_NAME=$CI_COMMIT_BRANCH
+        export CI_MERGE_REQUEST_ID=$pr_id
+        export CI_MERGE_REQUEST_SOURCE_BRANCH_NAME=$CI_COMMIT_BRANCH
 
-    #     labels=$(yarn auto label --pr $pr_id)
+        labels=$(yarn auto label --pr $pr_id)
 
-    #     if [[ "$labels" =~ "release:canary" ]]; then
-    #       yarn release:canary --dryRun
-    #     fi
-    #   fi
+        if [[ "$labels" =~ "release:canary" ]]; then
+          yarn release:canary --dryRun
+        fi
+      fi
 
 ## Production
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -406,6 +406,19 @@ test:live:teardown:
     GIT_STRATEGY: clone
     GIT_DEPTH: 0
     NX_REJECT_UNKNOWN_LOCAL_CACHE: 0
+  needs:
+    - build # CHECKME: Needed for the artifacts
+    - test:unit:utils
+    - test:unit:core
+    - test:unit:cli
+    - test:unit:rest
+    - test:types:utils
+    - test:types:core
+    - test:types:rest
+    - test:integration:rest
+    - test:integration:core
+    - test:e2e:cli
+    - test:e2e:rest
   cache:
     - <<: *cacheinstallmodules
       policy: pull
@@ -429,59 +442,31 @@ test:live:teardown:
 
 release:special:
   extends: .release:base
-  needs:
-    - build # CHECKME: Needed for the artifacts
-    - test:unit:utils
-    - test:unit:core
-    - test:unit:cli
-    - test:unit:rest
-    - test:types:utils
-    - test:types:core
-    - test:types:rest
-    - test:integration:rest
-    - test:integration:core
-    - test:e2e:cli
-    - test:e2e:rest
   only:
     refs:
       - /^pr-[0-9]+$/
-
   script:
     - echo "Checking for special release..."
-    # - |
-    #   if [[ $CI_COMMIT_BRANCH =~ ^pr-[0-9]*$ ]]; then
-    #     pr_id="${CI_COMMIT_BRANCH//[!0-9]/}"
+    - |
+      if [[ $CI_COMMIT_BRANCH =~ ^pr-[0-9]*$ ]]; then
+        pr_id="${CI_COMMIT_BRANCH//[!0-9]/}"
 
-    #     export CI_MERGE_REQUEST_ID=$pr_id
-    #     export CI_MERGE_REQUEST_SOURCE_BRANCH_NAME=$CI_COMMIT_BRANCH
+        export CI_MERGE_REQUEST_ID=$pr_id
+        export CI_MERGE_REQUEST_SOURCE_BRANCH_NAME=$CI_COMMIT_BRANCH
 
-    #     labels=$(yarn auto label --pr $pr_id)
+        labels=$(yarn auto label --pr $pr_id)
 
-    #     if [[ "$labels" =~ "release:canary" ]]; then
-    #       yarn release:canary
-    #     fi
-    #   fi
+        if [[ "$labels" =~ "release:canary" ]]; then
+          yarn release:canary
+        fi
+      fi
 
 ## Production
 
 release:
   extends: .release:base
-  needs:
-    - build # CHECKME: Needed for the artifacts
-    - test:unit:utils
-    - test:unit:core
-    - test:unit:cli
-    - test:unit:rest
-    - test:types:utils
-    - test:types:core
-    - test:types:rest
-    - test:integration:rest
-    - test:integration:core
-    - test:e2e:cli
-    - test:e2e:rest
   only:
     refs:
       - main
       - next
-
   script: yarn release

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -419,50 +419,56 @@ test:live:teardown:
     - git remote set-url origin https://jdalrymple:${GITHUB_TOKEN}@github.com/jdalrymple/gitbeaker.git
     - git branch $CI_COMMIT_BRANCH HEAD
     - git checkout $CI_COMMIT_BRANCH
+    - echo 'Ensure build files are present'
+    - ls -A packages/requester-utils/dist
+    - ls -A packages/core/dist
+    - ls -A packages/rest/dist
+    - ls -A packages/cli/dist
+
 
 ## Canary or RC Special Releases
 
 release:special:
   extends: .release:base
   needs:
-    # - build
+    - build # CHECKME: Needed for the artifacts
     - test:unit:utils
     - test:unit:core
     - test:unit:cli
     - test:unit:rest
-    # - test:types:utils
-    # - test:types:core
-    # - test:types:rest
-    # - test:integration:rest
-    # - test:integration:core
-    # - test:e2e:cli
-    # - test:e2e:rest
+    - test:types:utils
+    - test:types:core
+    - test:types:rest
+    - test:integration:rest
+    - test:integration:core
+    - test:e2e:cli
+    - test:e2e:rest
   only:
     refs:
       - /^pr-[0-9]+$/
 
   script:
     - echo "Checking for special release..."
-    - ls -al ./packages/core/dist
-    - |
-      if [[ $CI_COMMIT_BRANCH =~ ^pr-[0-9]*$ ]]; then
-        pr_id="${CI_COMMIT_BRANCH//[!0-9]/}"
+    # - |
+    #   if [[ $CI_COMMIT_BRANCH =~ ^pr-[0-9]*$ ]]; then
+    #     pr_id="${CI_COMMIT_BRANCH//[!0-9]/}"
 
-        export CI_MERGE_REQUEST_ID=$pr_id
-        export CI_MERGE_REQUEST_SOURCE_BRANCH_NAME=$CI_COMMIT_BRANCH
+    #     export CI_MERGE_REQUEST_ID=$pr_id
+    #     export CI_MERGE_REQUEST_SOURCE_BRANCH_NAME=$CI_COMMIT_BRANCH
 
-        labels=$(yarn auto label --pr $pr_id)
+    #     labels=$(yarn auto label --pr $pr_id)
 
-        if [[ "$labels" =~ "release:canary" ]]; then
-          yarn release:canary
-        fi
-      fi
+    #     if [[ "$labels" =~ "release:canary" ]]; then
+    #       yarn release:canary
+    #     fi
+    #   fi
 
 ## Production
 
 release:
   extends: .release:base
   needs:
+    - build # CHECKME: Needed for the artifacts
     - test:unit:utils
     - test:unit:core
     - test:unit:cli

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -454,7 +454,7 @@ release:special:
         labels=$(yarn auto label --pr $pr_id)
 
         if [[ "$labels" =~ "release:canary" ]]; then
-          yarn release:canary --dryRun
+          yarn release:canary --dry-run
         fi
       fi
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -425,6 +425,7 @@ test:live:teardown:
 release:special:
   extends: .release:base
   needs:
+    - build
     - test:unit:utils
     - test:unit:core
     - test:unit:cli
@@ -442,20 +443,21 @@ release:special:
 
   script:
     - echo "Checking for special release..."
-    - ls -al packages/core/dist
-    - |
-      if [[ $CI_COMMIT_BRANCH =~ ^pr-[0-9]*$ ]]; then
-        pr_id="${CI_COMMIT_BRANCH//[!0-9]/}"
+    - la -al packages/core
+    - ls -al ./packages/core/dist
+    # - |
+    #   if [[ $CI_COMMIT_BRANCH =~ ^pr-[0-9]*$ ]]; then
+    #     pr_id="${CI_COMMIT_BRANCH//[!0-9]/}"
 
-        export CI_MERGE_REQUEST_ID=$pr_id
-        export CI_MERGE_REQUEST_SOURCE_BRANCH_NAME=$CI_COMMIT_BRANCH
+    #     export CI_MERGE_REQUEST_ID=$pr_id
+    #     export CI_MERGE_REQUEST_SOURCE_BRANCH_NAME=$CI_COMMIT_BRANCH
 
-        labels=$(yarn auto label --pr $pr_id)
+    #     labels=$(yarn auto label --pr $pr_id)
 
-        if [[ "$labels" =~ "release:canary" ]]; then
-          yarn release:canary --dryRun
-        fi
-      fi
+    #     if [[ "$labels" =~ "release:canary" ]]; then
+    #       yarn release:canary --dryRun
+    #     fi
+    #   fi
 
 ## Production
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -425,7 +425,7 @@ test:live:teardown:
 release:special:
   extends: .release:base
   needs:
-    - build
+    # - build
     - test:unit:utils
     - test:unit:core
     - test:unit:cli

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -195,15 +195,14 @@ test:live:setup:
     - echo "GITLAB_URL=${GITLAB_URL}" >> intergration.env
     - echo "GITLAB_PERSONAL_ACCESS_TOKEN=${GITLAB_PERSONAL_ACCESS_TOKEN}" >> intergration.env
     - echo "Waiting for service to start"
-    - sleep 180
+    - sleep 210
     - attempt=1
     - |
       while [[ "$(curl --fail --silent -X GET "$GITLAB_URL/-/readiness?all=1" --insecure | jq -r '.master_check[0].status')" != "ok" ]]; do
-        echo -ne "Polling Attempt: $attempt - Gitlab service is not alive yet\033[0K\r";
+        echo "Polling Attempt: $attempt - Gitlab service is not alive yet";
         sleep 10;
         ((attempt++));
       done
-    - printf "\n"
     - echo "Service is up and running"
   artifacts:
     reports:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -443,7 +443,7 @@ release:special:
 
   script:
     - echo "Checking for special release..."
-    - la -al packages/core
+    - ls -al packages/core
     - ls -al ./packages/core/dist
     # - |
     #   if [[ $CI_COMMIT_BRANCH =~ ^pr-[0-9]*$ ]]; then

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -432,9 +432,6 @@ test:live:teardown:
     - git branch $CI_COMMIT_BRANCH HEAD
     - git checkout $CI_COMMIT_BRANCH
     - echo 'Ensure build files are present'
-
-    - rm -r packages/requester-utils/dist # Testing to make sure this fails
-
     - ls -A packages/requester-utils/dist
     - ls -A packages/core/dist
     - ls -A packages/rest/dist

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -38,8 +38,8 @@
     "lint:fix": "yarn lint --fix"
   },
   "dependencies": {
-    "@gitbeaker/core": "^39.33.2",
-    "@gitbeaker/rest": "^39.33.2",
+    "@gitbeaker/core": "39.33.2",
+    "@gitbeaker/rest": "39.33.2",
     "chalk": "4.1.2",
     "sywac": "^1.3.0",
     "xcase": "^2.0.1"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -51,7 +51,7 @@
     "lint:fix": "yarn lint --fix"
   },
   "dependencies": {
-    "@gitbeaker/requester-utils": "^39.33.2",
+    "@gitbeaker/requester-utils": "39.33.2",
     "qs": "^6.11.2",
     "xcase": "^2.0.1"
   },

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -53,8 +53,8 @@
     "lint:fix": "yarn lint --fix"
   },
   "dependencies": {
-    "@gitbeaker/core": "^39.33.2",
-    "@gitbeaker/requester-utils": "^39.33.2"
+    "@gitbeaker/core": "39.33.2",
+    "@gitbeaker/requester-utils": "39.33.2"
   },
   "devDependencies": {
     "@playwright/test": "^1.40.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -831,8 +831,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@gitbeaker/cli@workspace:packages/cli"
   dependencies:
-    "@gitbeaker/core": "npm:^39.33.2"
-    "@gitbeaker/rest": "npm:^39.33.2"
+    "@gitbeaker/core": "npm:39.33.2"
+    "@gitbeaker/rest": "npm:39.33.2"
     chalk: "npm:4.1.2"
     sywac: "npm:^1.3.0"
     tsup: "npm:^8.0.1"
@@ -844,11 +844,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@gitbeaker/core@npm:^39.33.2, @gitbeaker/core@workspace:packages/core":
+"@gitbeaker/core@npm:39.33.2, @gitbeaker/core@workspace:packages/core":
   version: 0.0.0-use.local
   resolution: "@gitbeaker/core@workspace:packages/core"
   dependencies:
-    "@gitbeaker/requester-utils": "npm:^39.33.2"
+    "@gitbeaker/requester-utils": "npm:39.33.2"
     "@types/node": "npm:^20.10.5"
     get-param-names: "github:jdalrymple/get-param-names#1-improve-functionality"
     qs: "npm:^6.11.2"
@@ -859,7 +859,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@gitbeaker/requester-utils@npm:^39.33.2, @gitbeaker/requester-utils@workspace:packages/requester-utils":
+"@gitbeaker/requester-utils@npm:39.33.2, @gitbeaker/requester-utils@workspace:packages/requester-utils":
   version: 0.0.0-use.local
   resolution: "@gitbeaker/requester-utils@workspace:packages/requester-utils"
   dependencies:
@@ -873,12 +873,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@gitbeaker/rest@npm:^39.33.2, @gitbeaker/rest@workspace:packages/rest":
+"@gitbeaker/rest@npm:39.33.2, @gitbeaker/rest@workspace:packages/rest":
   version: 0.0.0-use.local
   resolution: "@gitbeaker/rest@workspace:packages/rest"
   dependencies:
-    "@gitbeaker/core": "npm:^39.33.2"
-    "@gitbeaker/requester-utils": "npm:^39.33.2"
+    "@gitbeaker/core": "npm:39.33.2"
+    "@gitbeaker/requester-utils": "npm:39.33.2"
     "@playwright/test": "npm:^1.40.1"
     "@types/node": "npm:^20.10.5"
     tsup: "npm:^8.0.1"


### PR DESCRIPTION
## Summary
Gitlab CI artifacts don't automatically get included in upstream jobs unless the job explicitly needs the job where those artifacts are created. Even if you need a job that is upstream from the one that build the artifacts.

## Solution
- Adding check at release job to ensure dist files are present before releasing.
- Fixing monorepo package versions to avoid possible mismatch 

fixes #3521

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>39.33.3--canary.3522.1156475438.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @gitbeaker/cli@39.33.3--canary.3522.1156475438.0
  npm install @gitbeaker/core@39.33.3--canary.3522.1156475438.0
  npm install @gitbeaker/requester-utils@39.33.3--canary.3522.1156475438.0
  npm install @gitbeaker/rest@39.33.3--canary.3522.1156475438.0
  # or 
  yarn add @gitbeaker/cli@39.33.3--canary.3522.1156475438.0
  yarn add @gitbeaker/core@39.33.3--canary.3522.1156475438.0
  yarn add @gitbeaker/requester-utils@39.33.3--canary.3522.1156475438.0
  yarn add @gitbeaker/rest@39.33.3--canary.3522.1156475438.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
