### PR TITLE
Allow 'self' for personal access token rotation

### DIFF
--- a/packages/core/src/resources/PersonalAccessTokens.ts
+++ b/packages/core/src/resources/PersonalAccessTokens.ts
@@ -87,7 +87,7 @@ export class PersonalAccessTokens<C extends boolean = false> extends BaseResourc
   }
 
   rotate<E extends boolean = false>(
-    tokenId: number,
+    tokenId: number | "self",
     options?: { expiresAt?: string } & Sudo & ShowExpanded<E>,
   ): Promise<GitlabAPIResponse<PersonalAccessTokenSchema, C, E, void>> {
     return RequestHelper.post<PersonalAccessTokenSchema>()(

--- a/packages/core/src/resources/PersonalAccessTokens.ts
+++ b/packages/core/src/resources/PersonalAccessTokens.ts
@@ -87,7 +87,7 @@ export class PersonalAccessTokens<C extends boolean = false> extends BaseResourc
   }
 
   rotate<E extends boolean = false>(
-    tokenId: number | "self",
+    tokenId: number | 'self',
     options?: { expiresAt?: string } & Sudo & ShowExpanded<E>,
   ): Promise<GitlabAPIResponse<PersonalAccessTokenSchema, C, E, void>> {
     return RequestHelper.post<PersonalAccessTokenSchema>()(


### PR DESCRIPTION
Since GitLab 16.10[^1] a personal access token with the `api` scope can refresh itself by making a call to `/personal_access_tokens/:id/rotate` with an `:id` of `self`[^2].

Tested with the following script:
```ts
import { Gitlab } from "@gitbeaker/rest"
const gl = new Gitlab({token: "glpat-..."});
gl.PersonalAccessTokens.rotate("self").then((rotated) => {
    console.log(`New token is ${rotated.token}, expires at ${rotated.expires_at}`);
});
```

[^1]: This feature is available but undocumented from 16.9.
[^2]: https://docs.gitlab.com/ee/api/personal_access_tokens.html#use-a-request-header