### PR TITLE
Add `rebase_in_progress` to `ExpandedMergeRequestSchema`

### DIFF
--- a/packages/core/src/resources/MergeRequests.ts
+++ b/packages/core/src/resources/MergeRequests.ts
@@ -163,6 +163,7 @@ export interface ExpandedMergeRequestSchema extends MergeRequestSchema {
   user: {
     can_merge: boolean;
   };
+  rebase_in_progress?: boolean;
 }
 
 export interface MergeRequestSchemaWithExpandedLabels extends MergeRequestSchema {


### PR DESCRIPTION
When adding the `includeRebaseInProgress` flag to the `MergeRequests.show` function, the _gitbeaker_ response doesn't contain the `rebaseInProgress` property.

As stated in the [GitLab documentation](https://docs.gitlab.com/ee/api/merge_requests.html#rebase-a-merge-request):

> You can poll the [Get single MR](https://docs.gitlab.com/ee/api/merge_requests.html#get-single-mr) endpoint with the `include_rebase_in_progress` parameter to check the status of the asynchronous request.
> 
> If the rebase operation is ongoing, the response includes the following:
> ```
> {
>   "rebase_in_progress": true,
>   "merge_error": null
> }
> ```