### PR TITLE
Adding merge_commit_sha to WebhookMergeRequestEventSchema

### DIFF
--- a/packages/core/src/resources/Webhooks.ts
+++ b/packages/core/src/resources/Webhooks.ts
@@ -325,6 +325,7 @@ export interface WebhookMergeRequestEventSchema extends BaseWebhookEventSchema {
     draft: boolean;
     first_contribution: boolean;
     merge_status: string;
+    merge_commit_sha: string;
     target_project_id: number;
     description: string;
     total_time_spent: number;


### PR DESCRIPTION
Adding `merge_commit_sha` attribute to the WebhookMergeRequestEventSchema interface to match the actual payload that is being sent.

<img width="1152" alt="image" src="https://github.com/jdalrymple/gitbeaker/assets/148767664/b7d45aaf-18ab-4788-a0ab-231c8505208e">
