### PR TITLE
feat: Add 'branches' field to ForkProjectOptions type

### DIFF
--- a/packages/core/src/resources/Projects.ts
+++ b/packages/core/src/resources/Projects.ts
@@ -377,6 +377,7 @@ export type EditProjectOptions = {
 };
 
 export type ForkProjectOptions = {
+  branches?: string; 
   description?: string;
   mrDefaultTargetSelf?: boolean;
   name?: string;

--- a/packages/core/src/resources/Projects.ts
+++ b/packages/core/src/resources/Projects.ts
@@ -377,7 +377,7 @@ export type EditProjectOptions = {
 };
 
 export type ForkProjectOptions = {
-  branches?: string; 
+  branches?: string;
   description?: string;
   mrDefaultTargetSelf?: boolean;
   name?: string;


### PR DESCRIPTION
👋🏻 Hi team,

Added definition of the `branches` field in `ForkProjectOptions`

The `branches` field has been added to the `ForkProjectOptions` type to allow specifying branches when forking a project. This field is optional and enables indicating the branches to fork; leaving it empty will fork all available branches.

##

| Attribute  | Type                 | Required | Description                              |
|------------|----------------------|----------|------------------------------------------|
| branches   | string               | No       | Branches to fork (empty for all branches).|

##