### PR TITLE
Remove --treeshake option to work with node 22

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -31,7 +31,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsup src/index.ts --format esm --treeshake --target esnext",
+    "build": "tsup src/index.ts --format esm --target esnext",
     "test:unit": "jest --maxWorkers=50% test/unit",
     "test:e2e": "jest --maxWorkers=50% test/e2e",
     "lint": "eslint '**/{src,test,scripts}/**/*.ts'",


### PR DESCRIPTION
To work with Node.js 22, the `--treeshake` option has been removed from the build command.

https://github.com/jdalrymple/gitbeaker/issues/3591#issuecomment-2228760381


## Build Diff
Here are the build differences observed after making these changes:

```diff
--- packages/cli/dist/index.mjs
+++ packages/cli/dist/index.mjs
@@ -1,10 +1,13 @@
 #!/usr/bin/env node
-import Chalk from 'chalk';
-import Sywac from 'sywac';
-import * as Gitbeaker from '@gitbeaker/rest';
-import API_MAP from '@gitbeaker/core/map.json' assert { type: 'json' };
-import { decamelize, depascalize, camelize } from 'xcase';
 
+// src/cli.ts
+import Chalk from "chalk";
+import Sywac from "sywac";
+import * as Gitbeaker from "@gitbeaker/rest";
+import API_MAP from "@gitbeaker/core/map.json" with { type: "json" };
+
+// src/utils.ts
+import { camelize, decamelize, depascalize } from "xcase";
 function param(value) {
   let cleaned = value;
   const exceptions = [
```

refer to #3591