### PR TITLE
fix: add changes.target_branch to WebhookMergeRequestEventSchema 

### DIFF
--- a/packages/core/src/resources/Webhooks.ts
+++ b/packages/core/src/resources/Webhooks.ts
@@ -357,7 +357,7 @@ export interface WebhookMergeRequestEventSchema extends BaseWebhookEventSchema {
     target_branch: {
       previous: string | null;
       current: string | null;
-    },
+    };
     updated_by_id: {
       previous: number | null;
       current: number | null;

--- a/packages/core/src/resources/Webhooks.ts
+++ b/packages/core/src/resources/Webhooks.ts
@@ -354,6 +354,10 @@ export interface WebhookMergeRequestEventSchema extends BaseWebhookEventSchema {
   };
   labels: WebhookLabelSchema[] | null;
   changes: {
+    target_branch: {
+      previous: string | null;
+      current: string | null;
+    },
     updated_by_id: {
       previous: number | null;
       current: number | null;


### PR DESCRIPTION
adds `changes.target_branch` to `WebhookMergeRequestEventSchema` interface