### PR TITLE
Add sync to ProjectRemoteMirrors (#3616)

### DIFF
--- a/packages/core/src/resources/ProjectRemoteMirrors.ts
+++ b/packages/core/src/resources/ProjectRemoteMirrors.ts
@@ -113,4 +113,16 @@ export class ProjectRemoteMirrors<C extends boolean = false> extends BaseResourc
       options,
     );
   }
+
+  sync<E extends boolean = false>(
+    projectId: string | number,
+    mirrorId: number,
+    options?: Sudo & ShowExpanded<E>,
+  ): Promise<GitlabAPIResponse<void, C, E, void>> {
+    return RequestHelper.post<void>()(
+      this,
+      endpoint`projects/${projectId}/remote_mirrors/${mirrorId}/sync`,
+      options,
+    );
+  }
 }


### PR DESCRIPTION
This adds a sync() call to force push updates to a mirror - https://docs.gitlab.com/ee/api/remote_mirrors.html#force-push-mirror-update

Fixes #3616 