### PR TITLE
refactor: :label: declare default type first

### DIFF
--- a/packages/core/src/resources/Groups.ts
+++ b/packages/core/src/resources/Groups.ts
@@ -234,16 +234,16 @@ export class Groups<C extends boolean = false> extends BaseResource<C> {
 
   allProjects<E extends boolean = false, P extends PaginationTypes = 'offset'>(
     groupId: string | number,
+    options?: AllGroupProjectsOptions & PaginationRequestOptions<P> & Sudo & ShowExpanded<E>,
+  ): Promise<GitlabAPIResponse<ProjectSchema[], C, E, P>>;
+
+  allProjects<E extends boolean = false, P extends PaginationTypes = 'offset'>(
+    groupId: string | number,
     options?: { simple: true } & AllGroupProjectsOptions &
       PaginationRequestOptions<P> &
       Sudo &
       ShowExpanded<E>,
   ): Promise<GitlabAPIResponse<CondensedProjectSchema[], C, E, P>>;
-
-  allProjects<E extends boolean = false, P extends PaginationTypes = 'offset'>(
-    groupId: string | number,
-    options?: AllGroupProjectsOptions & PaginationRequestOptions<P> & Sudo & ShowExpanded<E>,
-  ): Promise<GitlabAPIResponse<ProjectSchema[], C, E, P>>;
 
   allProjects<E extends boolean = false, P extends PaginationTypes = 'offset'>(
     groupId: string | number,


### PR DESCRIPTION
Hello in you code the return of `allProjects` is `CondensedProjectSchema[]`.
Apparently for ts if no options are provided it matches the first signature.
So I just interved the two signatures to be closer to the api default behavior

ps: topics can be `null` in your schema but i don't see anything on it in the documentation. Feel free to edit my pr to remove it if you think it is a good idea.