### PR TITLE
Request Retry Error Message Adjustment

### DIFF
--- a/packages/rest/src/Requester.ts
+++ b/packages/rest/src/Requester.ts
@@ -120,7 +120,7 @@ export async function defaultRequestHandler(endpoint: string, options?: RequestO
   /* eslint-enable */
 
   throw new GitbeakerRetryError(
-    `Could not successfully complete this request after ${maxRetries} retries, last status code: ${lastStatus}. ${lastStatus == 429 ? "Check the applicable rate limits for this endpoint" : "Verify the status of the endpoint"}.`
+    `Could not successfully complete this request after ${maxRetries} retries, last status code: ${lastStatus}. ${lastStatus == 429 ? "Check the applicable rate limits for this endpoint" : "Verify the status of the endpoint"}.`,
   );
 }
 

--- a/packages/rest/src/Requester.ts
+++ b/packages/rest/src/Requester.ts
@@ -81,6 +81,7 @@ export async function defaultRequestHandler(endpoint: string, options?: RequestO
   const maxRetries = 10;
   const { prefixUrl, asStream, searchParams, rateLimiters, method, ...opts } = options || {};
   const rateLimit = getMatchingRateLimiter(endpoint, rateLimiters, method);
+  let lastStatus: number | undefined;
   let baseUrl: string | undefined;
 
   if (prefixUrl) baseUrl = prefixUrl.endsWith('/') ? prefixUrl : `${prefixUrl}/`;
@@ -110,15 +111,16 @@ export async function defaultRequestHandler(endpoint: string, options?: RequestO
     if (!retryCodes.includes(response.status)) await throwFailedRequestError(request, response);
 
     // Retry
+    lastStatus = response.status;
     await delay(2 ** i * 0.25);
-
+    
     // eslint-disable-next-line
     continue;
   }
   /* eslint-enable */
 
   throw new GitbeakerRetryError(
-    `Could not successfully complete this request due to Error 429. Check the applicable rate limits for this endpoint.`,
+    `Could not successfully complete this request after ${maxRetries} retries, last status code: ${lastStatus}. ${lastStatus == 429 ? "Check the applicable rate limits for this endpoint" : "Verify the status of the endpoint"}.`
   );
 }
 

--- a/packages/rest/src/Requester.ts
+++ b/packages/rest/src/Requester.ts
@@ -120,7 +120,7 @@ export async function defaultRequestHandler(endpoint: string, options?: RequestO
   /* eslint-enable */
 
   throw new GitbeakerRetryError(
-    `Could not successfully complete this request after ${maxRetries} retries, last status code: ${lastStatus}. ${lastStatus == 429 ? 'Check the applicable rate limits for this endpoint' : 'Verify the status of the endpoint'}.`,
+    `Could not successfully complete this request after ${maxRetries} retries, last status code: ${lastStatus}. ${lastStatus === 429 ? 'Check the applicable rate limits for this endpoint' : 'Verify the status of the endpoint'}.`,
   );
 }
 

--- a/packages/rest/src/Requester.ts
+++ b/packages/rest/src/Requester.ts
@@ -113,14 +113,14 @@ export async function defaultRequestHandler(endpoint: string, options?: RequestO
     // Retry
     lastStatus = response.status;
     await delay(2 ** i * 0.25);
-    
+
     // eslint-disable-next-line
     continue;
   }
   /* eslint-enable */
 
   throw new GitbeakerRetryError(
-    `Could not successfully complete this request after ${maxRetries} retries, last status code: ${lastStatus}. ${lastStatus == 429 ? "Check the applicable rate limits for this endpoint" : "Verify the status of the endpoint"}.`,
+    `Could not successfully complete this request after ${maxRetries} retries, last status code: ${lastStatus}. ${lastStatus == 429 ? 'Check the applicable rate limits for this endpoint' : 'Verify the status of the endpoint'}.`,
   );
 }
 

--- a/packages/rest/test/unit/Requester.ts
+++ b/packages/rest/test/unit/Requester.ts
@@ -286,7 +286,7 @@ describe('defaultRequestHandler', () => {
 
     await expect(defaultRequestHandler('http://test.com', {} as RequestOptions)).rejects.toThrow({
       message:
-        'Could not successfully complete this request due to Error 429. Check the applicable rate limits for this endpoint.',
+        'Could not successfully complete this request after 10 retries, last status code: 429. Check the applicable rate limits for this endpoint.',
       name: 'GitbeakerRetryError',
     });
 


### PR DESCRIPTION
Improving retry failure error message to differentiate between a 429 and 502 to prevent confusion for users.  Recently had this come up where a gitlab endpoint was responding with a 502, yet GitBeaker was reporting failure due to 429 which was quite a rabbit hole 🐰 .  Hopefully this will help prevent confusion for any users in the future.