### PR TITLE
feat(jobs): job scope waiting_for_resource

### DIFF
--- a/packages/core/src/resources/Jobs.ts
+++ b/packages/core/src/resources/Jobs.ts
@@ -23,7 +23,8 @@ export type JobScope =
   | 'success'
   | 'canceled'
   | 'skipped'
-  | 'manual';
+  | 'manual'
+  | 'waiting_for_resource';
 
 export interface ArtifactSchema extends Record<string, unknown> {
   file_type: string;


### PR DESCRIPTION
It looks like the jobs scope is missing `waiting_for_resource` if I'm not mistaken.

<img width="724" alt="image" src="https://github.com/user-attachments/assets/67f692e7-3d74-4ed6-a3ff-c303bb2d4510">


https://docs.gitlab.com/ee/api/jobs.html#list-project-jobs