### PR TITLE
Fix `upcoming jobs by resource group` endpoint

### DIFF
--- a/packages/core/src/resources/ResourceGroups.ts
+++ b/packages/core/src/resources/ResourceGroups.ts
@@ -55,11 +55,12 @@ export class ResourceGroups<C extends boolean = false> extends BaseResource<C> {
 
   allUpcomingJobs<E extends boolean = false>(
     projectId: string | number,
+    key: string,
     options?: Sudo & ShowExpanded<E>,
   ): Promise<GitlabAPIResponse<JobSchema[], C, E, void>> {
     return RequestHelper.get<JobSchema[]>()(
       this,
-      endpoint`projects/${projectId}/resource_groups/upcoming_jobs`,
+      endpoint`projects/${projectId}/resource_groups/${key}/upcoming_jobs`,
       options,
     );
   }


### PR DESCRIPTION
Gitlab API requires the resource group key for fetching the upcoming jobs. 
Gitlab Doc -> https://docs.gitlab.com/ee/api/resource_groups.html#list-upcoming-jobs-for-a-specific-resource-group

Current implementation results 404