### PR TITLE
Implement MergeRequests.allIssuesRelated()

### DIFF
--- a/packages/core/src/resources/MergeRequests.ts
+++ b/packages/core/src/resources/MergeRequests.ts
@@ -391,6 +391,18 @@ export class MergeRequests<C extends boolean = false> extends BaseResource<C> {
     );
   }
 
+  allIssuesRelated<E extends boolean = false>(
+    projectId: string | number,
+    mergerequestIId: number,
+    options?: Sudo & ShowExpanded<E>,
+  ): Promise<GitlabAPIResponse<IssueSchema[], C, E, void>> {
+    return RequestHelper.get<IssueSchema[]>()(
+      this,
+      endpoint`projects/${projectId}/merge_requests/${mergerequestIId}/related_issues`,
+      options,
+    );
+  }
+
   allParticipants<E extends boolean = false>(
     projectId: string | number,
     mergerequestIId: number,

--- a/packages/core/test/unit/resources/MergeRequests.ts
+++ b/packages/core/test/unit/resources/MergeRequests.ts
@@ -301,3 +301,27 @@ describe('MergeRequests.unsubscribe', () => {
     );
   });
 });
+
+describe('MergeRequests.allIssuesClosed', () => {
+  it('should request GET projects/:id/merge_requests/:iid/closes_issues', async () => {
+    await service.allIssuesClosed(2, 3);
+
+    expect(RequestHelper.del()).toHaveBeenCalledWith(
+      service,
+      'projects/2/merge_requests/3/closes_issues',
+      undefined,
+    );
+  });
+});
+
+describe('MergeRequests.allIssuesRelated', () => {
+  it('should request GET projects/:id/merge_requests/:iid/related_issues', async () => {
+    await service.allIssuesRelated(2, 3);
+
+    expect(RequestHelper.del()).toHaveBeenCalledWith(
+      service,
+      'projects/2/merge_requests/3/related_issues',
+      undefined,
+    );
+  });
+});

--- a/packages/core/test/unit/resources/MergeRequests.ts
+++ b/packages/core/test/unit/resources/MergeRequests.ts
@@ -123,6 +123,18 @@ describe('MergeRequests.allIssuesClosed', () => {
   });
 });
 
+describe('MergeRequests.allIssuesRelated', () => {
+  it('should request GET projects/:id/merge_requests/:iid/related_issues', async () => {
+    await service.allIssuesRelated(2, 3);
+
+    expect(RequestHelper.del()).toHaveBeenCalledWith(
+      service,
+      'projects/2/merge_requests/3/related_issues',
+      undefined,
+    );
+  });
+});
+
 describe('MergeRequests.allCommits', () => {
   it('should request GET projects/:id/merge_requests/:id/commits', async () => {
     await service.allCommits(2, 3);
@@ -297,30 +309,6 @@ describe('MergeRequests.unsubscribe', () => {
     expect(RequestHelper.del()).toHaveBeenCalledWith(
       service,
       'projects/2/merge_requests/3/unsubscribe',
-      undefined,
-    );
-  });
-});
-
-describe('MergeRequests.allIssuesClosed', () => {
-  it('should request GET projects/:id/merge_requests/:iid/closes_issues', async () => {
-    await service.allIssuesClosed(2, 3);
-
-    expect(RequestHelper.del()).toHaveBeenCalledWith(
-      service,
-      'projects/2/merge_requests/3/closes_issues',
-      undefined,
-    );
-  });
-});
-
-describe('MergeRequests.allIssuesRelated', () => {
-  it('should request GET projects/:id/merge_requests/:iid/related_issues', async () => {
-    await service.allIssuesRelated(2, 3);
-
-    expect(RequestHelper.del()).toHaveBeenCalledWith(
-      service,
-      'projects/2/merge_requests/3/related_issues',
       undefined,
     );
   });


### PR DESCRIPTION
Gitlab documentation : https://docs.gitlab.com/ee/api/merge_requests.html#list-issues-related-to-the-merge-request

Copy / pasted from `MergeRequests.allIssuesClosed()`