### PR TITLE
Update `Users.edit` to use FormData when submitting `avatar` updates

### DIFF
--- a/packages/core/src/resources/Users.ts
+++ b/packages/core/src/resources/Users.ts
@@ -156,7 +156,7 @@ export type AllUsersOptions = {
 export type CreateUserOptions = {
   admin?: boolean;
   auditor?: boolean;
-  avatar?: { content: Blob; filepath?: string };
+  avatar?: { content: Blob; filename?: string };
   bio?: string;
   canCreateGroup?: boolean;
   colorSchemeId?: number;
@@ -487,9 +487,16 @@ export class Users<C extends boolean = false> extends BaseResource<C> {
 
   edit<E extends boolean = false>(
     userId: number,
-    options?: EditUserOptions & Sudo & ShowExpanded<E>,
+    { avatar, ...options }: EditUserOptions & Sudo & ShowExpanded<E> = {},
   ) {
-    return RequestHelper.put<ExpandedUserSchema>()(this, endpoint`users/${userId}`, options);
+    const opts: Record<string, unknown> = {
+      ...options,
+      isForm: true,
+    };
+
+    if (avatar) opts.avatar = [avatar.content, avatar.filename];
+
+    return RequestHelper.put<ExpandedUserSchema>()(this, endpoint`users/${userId}`, opts);
   }
 
   editStatus<E extends boolean = false>(

--- a/packages/core/test/unit/resources/Users.ts
+++ b/packages/core/test/unit/resources/Users.ts
@@ -181,7 +181,10 @@ describe('Users.edit', () => {
   it('should request PUT users/:id', async () => {
     await service.edit(1, { name: 'Okoye' });
 
-    expect(RequestHelper.put()).toHaveBeenCalledWith(service, 'users/1', { name: 'Okoye' });
+    expect(RequestHelper.put()).toHaveBeenCalledWith(service, 'users/1', {
+      isForm: true,
+      name: 'Okoye'
+    });
   });
 });
 

--- a/packages/core/test/unit/resources/Users.ts
+++ b/packages/core/test/unit/resources/Users.ts
@@ -183,7 +183,7 @@ describe('Users.edit', () => {
 
     expect(RequestHelper.put()).toHaveBeenCalledWith(service, 'users/1', {
       isForm: true,
-      name: 'Okoye'
+      name: 'Okoye',
     });
   });
 });


### PR DESCRIPTION
This should allow the payload to accept the correct Blob types needed for updating the avatar.

fixes #3611 