### PR TITLE
Update error JSON handling

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -1,1 +1,22 @@
 import 'jest-extended'
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace jest {
+    interface AsymmetricMatchers {
+      toThrowWith(cb: (error: Error) => void): void;
+    }
+    interface Matchers<R> {
+      toThrowWith(cb: (error: Error) => void): R;
+    }
+  }
+}
+
+declare module "expect" {
+  interface AsymmetricMatchers {
+    toThrowWith(cb: (error: Error) => void): void;
+  }
+  interface Matchers<R> {
+    toThrowWith(cb: (error: Error) => void): R;
+  }
+}

--- a/jest.config.base.mjs
+++ b/jest.config.base.mjs
@@ -1,4 +1,5 @@
 export default {
+  rootDir: '../../',
   testEnvironment: 'node',
   testRegex: 'test\\/.*\\.ts$',
   coverageDirectory: 'coverage',
@@ -9,10 +10,11 @@ export default {
     ['jest-junit', { outputDirectory: 'reports', outputName: 'nodejs_junit.xml' }],
   ],
   moduleNameMapper: {
-    '^@gitbeaker/(.*)$': '<rootDir>/../$1/src',
+    '^@gitbeaker/core/map.json': '<rootDir>/packages/core/dist/map.json',
+    '^@gitbeaker/(.*)$': '<rootDir>/packages/$1/src',
   },
   transform: {
     '^.+\\.(t|j)sx?$': '@swc/jest',
   },
-  setupFilesAfterEnv: ['jest-extended/all'],
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
 };

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,2 +1,77 @@
 import 'jest-extended';
 import 'jest-extended/all';
+
+import { expect } from '@jest/globals';
+import type {MatcherFunction} from 'expect';
+
+const toThrowWith: MatcherFunction<[cb:unknown]> = async function (expectCallbackOrPromiseReturn, matcherCallback) {
+  const isFromReject = this && this.promise === 'rejects'; // See https://github.com/facebook/jest/pull/7621#issue-244312550
+  if ((!expectCallbackOrPromiseReturn || typeof expectCallbackOrPromiseReturn !== 'function') && !isFromReject) {
+    return {
+      pass: false,
+      message: () =>
+        `Received value must be a function but instead "${expectCallbackOrPromiseReturn}" was found`,
+    };
+  }
+
+  if ((!matcherCallback || typeof matcherCallback !== 'function')) {
+    return {
+      pass: false,
+      message: () =>
+        `matcherCallback value must be a function but instead "${matcherCallback}" was found`,
+    };
+  }
+
+
+  let error;
+  if (isFromReject) {
+    error = expectCallbackOrPromiseReturn;
+  } else {
+    try {
+      if (typeof expectCallbackOrPromiseReturn === 'function') {
+        await expectCallbackOrPromiseReturn();
+      }
+    } catch (e) {
+      error = e;
+    }
+  }
+
+  await matcherCallback(error)
+
+  if (!error) {
+    return {
+      pass: false,
+      message: () => 'Expected the function to throw an error.\n' + "But it didn't throw anything.",
+    };
+  } else {
+    return {
+      pass: true,
+      message: () => 'Expected the function not to throw an error"
+    };
+  }
+}
+
+expect.extend({
+  toThrowWith,
+});
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace jest {
+    interface AsymmetricMatchers {
+      toThrowWith(cb: (error: Error) => void): void;
+    }
+    interface Matchers<R> {
+      toThrowWith(cb: (error: Error) => void): R;
+    }
+  }
+}
+
+declare module "expect" {
+  interface AsymmetricMatchers {
+    toThrowWith(cb: (error: Error) => void): void;
+  }
+  interface Matchers<R> {
+    toThrowWith(cb: (error: Error) => void): R;
+  }
+}

--- a/packages/rest/src/Requester.ts
+++ b/packages/rest/src/Requester.ts
@@ -57,7 +57,7 @@ async function throwFailedRequestError(
   if (contentType?.includes('application/json')) {
     const output = JSON.parse(content);
 
-    description = output.message;
+    description = typeof output.message === 'string' ? output.message : JSON.stringify(output);
   } else {
     description = content;
   }

--- a/packages/rest/src/Requester.ts
+++ b/packages/rest/src/Requester.ts
@@ -56,8 +56,10 @@ async function throwFailedRequestError(
 
   if (contentType?.includes('application/json')) {
     const output = JSON.parse(content);
+    const contentProperty = output.error || output.message;
 
-    description = typeof output.message === 'string' ? output.message : JSON.stringify(output);
+    description =
+      typeof contentProperty === 'string' ? contentProperty : JSON.stringify(contentProperty);
   } else {
     description = content;
   }

--- a/packages/rest/test/unit/Requester.ts
+++ b/packages/rest/test/unit/Requester.ts
@@ -454,7 +454,7 @@ describe('defaultRequestHandler', () => {
     });
   });
 
-  it.only('should return correct properties as stream if request is valid', async () => {
+  it('should return correct properties as stream if request is valid', async () => {
     MockFetch.mockReturnValueOnce(
       Promise.resolve(
         new Response('text', {

--- a/packages/rest/test/unit/Requester.ts
+++ b/packages/rest/test/unit/Requester.ts
@@ -98,7 +98,54 @@ describe('processBody', () => {
 });
 
 describe('defaultRequestHandler', () => {
-  it('should return an error with the statusText as the primary message and a description derived from a error property when response has an error property', async () => {
+  it.only('should return an error with the statusText as the primary message', async () => {
+    const responseContent = { error: 'msg' };
+
+    MockFetch.mockReturnValueOnce(
+      Promise.resolve({
+        ok: false,
+        status: 501,
+        statusText: 'Really Bad Error',
+        headers: new Headers({
+          'content-type': 'application/json',
+        }),
+        json: () => Promise.resolve(responseContent),
+        text: () => Promise.resolve(JSON.stringify(responseContent)),
+      }),
+    );
+
+    await expect(defaultRequestHandler('http://test.com', {} as RequestOptions)).rejects.toThrow({
+      message: 'Really Bad Error',
+      name: 'GitbeakerRequestError',
+    });
+  });
+
+  it('should return an error with a description property derived from the error property when response has an error property', async () => {
+    const stringBody = { error: 'msg' };
+
+    MockFetch.mockReturnValueOnce(
+      Promise.resolve({
+        ok: false,
+        status: 501,
+        statusText: 'Really Bad Error',
+        headers: new Headers({
+          'content-type': 'application/json',
+        }),
+        json: () => Promise.resolve(stringBody),
+        text: () => Promise.resolve(JSON.stringify(stringBody)),
+      }),
+    );
+
+    await expect(defaultRequestHandler('http://test.com', {} as RequestOptions)).rejects.toThrow({
+      message: 'Really Bad Error',
+      name: 'GitbeakerRequestError',
+      cause: {
+        description: 'msg',
+      },
+    });
+  });
+
+  it('should return an error with a description property derived from the error property when response has an error property', async () => {
     const stringBody = { error: 'msg' };
 
     MockFetch.mockReturnValueOnce(

--- a/packages/rest/test/unit/Requester.ts
+++ b/packages/rest/test/unit/Requester.ts
@@ -1,3 +1,4 @@
+import { expect } from '@jest/globals';
 import type { RequestOptions } from '@gitbeaker/requester-utils';
 import {
   GitbeakerRequestError,
@@ -129,7 +130,7 @@ describe('defaultRequestHandler', () => {
     }
   });
 
-  it('should return an error with the response included in the cause', async () => {
+  it.only('should return an error with the response included in the cause', async () => {
     const responseContent = { error: 'msg' };
 
     MockFetch.mockReturnValueOnce(
@@ -145,14 +146,28 @@ describe('defaultRequestHandler', () => {
     );
 
     // Ensure an assertion is made (the error is thrown)
-    expect.assertions(2);
 
-    try {
-      await defaultRequestHandler('http://test.com', {} as RequestOptions);
-    } catch (e) {
-      expect(e.message).toBe('Really Bad Error');
-      expect(e.cause.response).toBeInstanceOf(Response);
-    }
+    // await expect(() => defaultRequestHandler('http://test.com', {} as RequestOptions)).rejects.toThrow(
+    //   expect.objectContaining({
+    //     name: "GitbeakerRequestError",
+    //     message: 'Really Bad Error',
+    //     cause: {
+    //       response: expect.any(Response),
+    //     },
+    //   }),
+    // );
+
+    await expect(() => Promise.reject(new Error(''))).rejects.toThrowWithMessage(Error, 'test');
+
+    // await expect(() => Promise.reject(new Error(''))).rejects.toThrowWith((e: GitbeakerRequestError) => {
+    //   expect(e.message).toBe('Really Bad Error');
+    //   expect(e?.cause?.response).toBeInstanceOf(Response);
+    // });
+
+    // await expect(() => defaultRequestHandler('http://test.com')).rejects.toThrowWith((e: GitbeakerRequestError) => {
+    //   expect(e.message).toBe('Really Bad Error');
+    //   expect(e?.cause?.response).toBeInstanceOf(Response);
+    // });
   });
 
   it('should return an error with the request included in the cause', async () => {


### PR DESCRIPTION
Ensure the both `error` and `message` key terms are used to populate and raise a more targeted error.

fixes #3646 