### PR TITLE
Use correct HTTP method on AccessRequest approve

### DIFF
--- a/packages/core/src/templates/ResourceAccessRequests.ts
+++ b/packages/core/src/templates/ResourceAccessRequests.ts
@@ -51,7 +51,7 @@ export class ResourceAccessRequests<C extends boolean = false> extends BaseResou
     userId: number,
     options?: { accessLevel?: Exclude<AccessLevel, AccessLevel.ADMIN> } & Sudo & ShowExpanded<E>,
   ): Promise<GitlabAPIResponse<AccessRequestSchema, C, E, void>> {
-    return RequestHelper.post<AccessRequestSchema>()(
+    return RequestHelper.put<AccessRequestSchema>()(
       this,
       endpoint`${resourceId}/access_requests/${userId}/approve`,
       options,


### PR DESCRIPTION
Use `PUT` instead of `POST` in the approve method of Access Requests.
Fixes: #3659 

Related documentation: [Here](https://docs.gitlab.com/17.6/ee/api/access_requests.html#approve-an-access-request)