### PR TITLE
Add the `internal` option to `MergeRequestNotes.create`

### DIFF
--- a/packages/core/src/resources/MergeRequestNotes.ts
+++ b/packages/core/src/resources/MergeRequestNotes.ts
@@ -29,7 +29,8 @@ export interface MergeRequestNotes<C extends boolean = false> extends ResourceNo
     projectId: string | number,
     mergerequestIId: number,
     body: string,
-    options?: { mergeRequestDiffSha?: string; createdAt?: string } & Sudo & ShowExpanded<E>,
+    options?: { mergeRequestDiffSha?: string; createdAt?: string; internal?: boolean } & Sudo &
+      ShowExpanded<E>,
   ): Promise<GitlabAPIResponse<MergeRequestNoteSchema, C, E, void>>;
 
   edit<E extends boolean = false>(


### PR DESCRIPTION
fixes #3662 