### PR TITLE
Export error classes in rest package

### DIFF
--- a/packages/rest/src/index.ts
+++ b/packages/rest/src/index.ts
@@ -11,6 +11,12 @@ const API = presetResourceArguments(Resources, { requesterFn });
 
 export const AccessLevel = AL;
 
+export {
+  GitbeakerRequestError,
+  GitbeakerTimeoutError,
+  GitbeakerRetryError,
+} from '@gitbeaker/requester-utils';
+
 export const {
   Agents,
   AlertManagement,

--- a/packages/rest/test/integration/browser/General.ts
+++ b/packages/rest/test/integration/browser/General.ts
@@ -6,6 +6,9 @@ const { describe } = it;
 describe('Browser Import', () => {
   const keys = [
     'AccessLevel',
+    'GitbeakerRequestError',
+    'GitbeakerTimeoutError',
+    'GitbeakerRetryError',
     'Agents',
     'AlertManagement',
     'ApplicationAppearance',


### PR DESCRIPTION
Adds exports for error classes to the `rest` package, so `instanceof` checks don't fail because of different sub-package versions.

Fixes https://github.com/jdalrymple/gitbeaker/issues/3689