### PR TITLE
RequestHelper: move maxPages from OffsetPaginationRequestOptions to BasePaginationRequestOptions

### DIFF
--- a/packages/core/src/infrastructure/RequestHelper.ts
+++ b/packages/core/src/infrastructure/RequestHelper.ts
@@ -41,12 +41,12 @@ export interface KeysetPaginationRequestOptions {
 
 export interface OffsetPaginationRequestOptions {
   page?: number | string;
-  maxPages?: number;
 }
 
 export interface BasePaginationRequestOptions<P extends PaginationTypes | void> {
   pagination?: P;
   perPage?: number | string;
+  maxPages?: number;
 }
 
 export type PaginationRequestSubOptions<P extends PaginationTypes | void> = P extends 'keyset'


### PR DESCRIPTION
maxPages is accounted for in keyset pagination as well as offset pagination, and passing it is useful when one wants to fetch all items of a given type incrementally.