### PR TITLE
Fixing typo in CreateAndEditPushRuleOptions

### DIFF
--- a/packages/core/src/templates/ResourcePushRules.ts
+++ b/packages/core/src/templates/ResourcePushRules.ts
@@ -24,7 +24,7 @@ export interface CreateAndEditPushRuleOptions {
   memberCheck?: boolean;
   preventSecrets?: boolean;
   commitMessageRegex?: string;
-  commitMessagNegativeRegex?: string;
+  commitMessageNegativeRegex?: string;
   branchNameRegex?: string;
   authorEmailRegex?: string;
   fileNameRegex?: string;


### PR DESCRIPTION
fixes #3679 