### PR TITLE
Added masked_and_hidden option to the ProjectVariables

### DIFF
--- a/packages/core/src/resources/ProjectVariables.ts
+++ b/packages/core/src/resources/ProjectVariables.ts
@@ -27,6 +27,7 @@ export interface ProjectVariables<C extends boolean = false> extends ResourceVar
       variableType?: VariableType;
       protected?: boolean;
       masked?: boolean;
+      masked_and_hidden?: boolean;
       environmentScope?: string;
       description?: string;
       raw?: boolean;
@@ -42,6 +43,7 @@ export interface ProjectVariables<C extends boolean = false> extends ResourceVar
       variableType?: VariableType;
       protected?: boolean;
       masked?: boolean;
+      masked_and_hidden?: boolean;
       environmentScope?: string;
       raw?: boolean;
       filter: VariableFilter;


### PR DESCRIPTION
I have the added the masked_and_hidden option for projects variables. The feature was introduced in Gitlab 17.4