### PR TITLE
Allow using falsey values in isForm requests

### DIFF
--- a/packages/core/src/infrastructure/Utils.ts
+++ b/packages/core/src/infrastructure/Utils.ts
@@ -32,7 +32,7 @@ export function appendFormFromObject(object: Record<string, OptionValueType>): F
   const form = new FormData();
 
   Object.entries(object).forEach(([k, v]) => {
-    if (v === undefined || v === null) return;
+    if (v == null) return;
     if (Array.isArray(v)) form.append(k, v[0] as Blob, v[1] as string);
     else form.append(k, v as unknown as string | Blob);
   });

--- a/packages/core/src/infrastructure/Utils.ts
+++ b/packages/core/src/infrastructure/Utils.ts
@@ -32,7 +32,7 @@ export function appendFormFromObject(object: Record<string, OptionValueType>): F
   const form = new FormData();
 
   Object.entries(object).forEach(([k, v]) => {
-    if (!v) return;
+    if (v === undefined || v === null) return;
     if (Array.isArray(v)) form.append(k, v[0] as Blob, v[1] as string);
     else form.append(k, v as unknown as string | Blob);
   });


### PR DESCRIPTION
I was trying to edit a user and only set `admin: false`. GitLab returned with 400 Bad Request. After some digging, I found out that falsey form values (including `0`, `false`) get removed from the request.

Let's specifically check for undefined and null here.
