### PR TITLE
Adding `assignees`  to changes of the `MergeRequestWebhookEvent.changes`

### DIFF
--- a/packages/core/src/resources/Webhooks.ts
+++ b/packages/core/src/resources/Webhooks.ts
@@ -370,6 +370,10 @@ export interface WebhookMergeRequestEventSchema extends BaseWebhookEventSchema {
       previous: string | null;
       current: string | null;
     };
+    assignees: {
+      previous: WebhookUserSchema[] | null;
+      current: WebhookUserSchema[] | null;
+    };
     reviewers: {
       previous: WebhookUserSchema[] | null;
       current: WebhookUserSchema[] | null;


### PR DESCRIPTION
Fixes #3705