### PR TITLE
Adding expires_at to the rotate method of the AccessToken resources

### DIFF
--- a/packages/core/src/resources/GroupAccessTokens.ts
+++ b/packages/core/src/resources/GroupAccessTokens.ts
@@ -43,7 +43,7 @@ export interface GroupAccessTokens<C extends boolean = false> extends ResourceAc
   rotate<E extends boolean = false>(
     groupId: string | number,
     tokenId: string | number,
-    options?: Sudo & ShowExpanded<E>,
+    options?: { expiresAt?: string } & Sudo & ShowExpanded<E>,
   ): Promise<GitlabAPIResponse<AccessTokenExposedSchema, C, E, void>>;
 
   show<E extends boolean = false>(

--- a/packages/core/src/resources/ProjectAccessTokens.ts
+++ b/packages/core/src/resources/ProjectAccessTokens.ts
@@ -43,7 +43,7 @@ export interface ProjectAccessTokens<C extends boolean = false> extends Resource
   rotate<E extends boolean = false>(
     projectId: string | number,
     tokenId: string | number,
-    options?: Sudo & ShowExpanded<E>,
+    options?: { expiresAt?: string } & Sudo & ShowExpanded<E>,
   ): Promise<GitlabAPIResponse<AccessTokenExposedSchema, C, E, void>>;
 
   show<E extends boolean = false>(


### PR DESCRIPTION
fixes #3709 