### PR TITLE
Add support for passing custom agents

### DIFF
--- a/packages/core/test/unit/resources/General.ts
+++ b/packages/core/test/unit/resources/General.ts
@@ -10,7 +10,6 @@ describe('Instantiating services', () => {
 
       expect(service.constructor.name).toBe(k);
       expect(service.url).toBeDefined();
-      expect(service.rejectUnauthorized).toBeTruthy();
       expect(service.authHeaders).toMatchObject({
         'private-token': expect.any(Function),
       });

--- a/packages/core/test/unit/resources/GroupHooks.ts
+++ b/packages/core/test/unit/resources/GroupHooks.ts
@@ -19,7 +19,6 @@ describe('Instantiating GroupHooks service', () => {
   it('should create a valid service object', () => {
     expect(service).toBeInstanceOf(GroupHooks);
     expect(service.url).toBeDefined();
-    expect(service.rejectUnauthorized).toBeTruthy();
   });
 
   it('should call /groups prefix', () => {

--- a/packages/core/test/unit/resources/MergeRequestDiscussions.ts
+++ b/packages/core/test/unit/resources/MergeRequestDiscussions.ts
@@ -19,7 +19,6 @@ describe('Instantiating MergeRequestDiscussions service', () => {
   it('should create a valid service object', () => {
     expect(service).toBeInstanceOf(MergeRequestDiscussions);
     expect(service.url).toBeDefined();
-    expect(service.rejectUnauthorized).toBeTruthy();
   });
 });
 

--- a/packages/core/test/unit/templates/ResourceDiscussions.ts
+++ b/packages/core/test/unit/templates/ResourceDiscussions.ts
@@ -19,7 +19,6 @@ describe('Instantiating ResourceDiscussions service', () => {
   it('should create a valid service object', () => {
     expect(service).toBeInstanceOf(ResourceDiscussions);
     expect(service.url).toBeDefined();
-    expect(service.rejectUnauthorized).toBeTruthy();
   });
 });
 

--- a/packages/requester-utils/src/BaseResource.ts
+++ b/packages/requester-utils/src/BaseResource.ts
@@ -1,3 +1,4 @@
+import type { Agent } from 'http';
 import { RateLimitOptions, RequesterType, ResourceOptions } from './RequesterUtils';
 
 export interface RootResourceOptions<C> {
@@ -5,13 +6,13 @@ export interface RootResourceOptions<C> {
   requesterFn?: (resourceOptions: ResourceOptions) => RequesterType;
   host?: string;
   prefixUrl?: string;
-  rejectUnauthorized?: boolean;
   camelize?: C;
   queryTimeout?: number | null;
   sudo?: string | number;
   profileToken?: string;
   profileMode?: 'execution' | 'memory';
   rateLimits?: RateLimitOptions;
+  agent?: Agent;
 }
 
 export type GitlabToken = string | (() => Promise<string>);
@@ -95,17 +96,15 @@ export class BaseResource<C extends boolean = false> {
 
   public readonly camelize: C | undefined;
 
-  public readonly rejectUnauthorized: boolean;
-
   constructor({
     sudo,
     profileToken,
     camelize,
     requesterFn,
+    agent,
     profileMode = 'execution',
     host = 'https://gitlab.com',
     prefixUrl = '',
-    rejectUnauthorized = true,
     queryTimeout = 300000,
     rateLimits = DEFAULT_RATE_LIMITS,
     ...tokens
@@ -115,7 +114,6 @@ export class BaseResource<C extends boolean = false> {
     this.url = [host, 'api', 'v4', prefixUrl].join('/');
     this.headers = {};
     this.authHeaders = {};
-    this.rejectUnauthorized = rejectUnauthorized;
     this.camelize = camelize;
     this.queryTimeout = queryTimeout;
 
@@ -141,6 +139,6 @@ export class BaseResource<C extends boolean = false> {
     if (sudo) this.headers.Sudo = `${sudo}`;
 
     // Set requester instance using this information
-    this.requester = requesterFn({ ...this, rateLimits });
+    this.requester = requesterFn({ ...this, rateLimits, agent });
   }
 }

--- a/packages/requester-utils/src/RequesterUtils.ts
+++ b/packages/requester-utils/src/RequesterUtils.ts
@@ -2,6 +2,7 @@ import { stringify } from 'qs';
 import { decamelizeKeys } from 'xcase';
 import { RateLimiterMemory, RateLimiterQueue } from 'rate-limiter-flexible';
 import Picomatch from 'picomatch-browser';
+import type { Agent } from 'http';
 
 const { isMatch: isGlobMatch } = Picomatch;
 
@@ -35,8 +36,8 @@ export type ResourceOptions = {
   headers: { [header: string]: string };
   authHeaders: { [authHeader: string]: () => Promise<string> };
   url: string;
-  rejectUnauthorized: boolean;
   rateLimits?: RateLimitOptions;
+  agent?: Agent;
 };
 
 export type DefaultRequestOptions = {
@@ -58,6 +59,7 @@ export type RequestOptions = {
   asStream?: boolean;
   signal?: AbortSignal;
   rateLimiters?: Record<string, RateLimiterFn>;
+  agent?: Agent;
 };
 
 export interface RequesterType {
@@ -120,12 +122,13 @@ export async function defaultOptionsHandler(
     method = 'GET',
   }: DefaultRequestOptions = {},
 ): Promise<RequestOptions> {
-  const { headers: preconfiguredHeaders, authHeaders, url } = resourceOptions;
+  const { headers: preconfiguredHeaders, authHeaders, url, agent } = resourceOptions;
   const defaultOptions: RequestOptions = {
     method,
     asStream,
     signal,
     prefixUrl: url,
+    agent,
   };
 
   defaultOptions.headers = { ...preconfiguredHeaders };

--- a/packages/requester-utils/test/unit/BaseResource.ts
+++ b/packages/requester-utils/test/unit/BaseResource.ts
@@ -136,26 +136,6 @@ describe('Creation of BaseResource instance', () => {
     expect(service.headers['X-Profile-Mode']).toBe('memory');
   });
 
-  it('should default the https reject unauthorized option to true', () => {
-    const service = new BaseResource({
-      token: '123',
-      requesterFn: jest.fn(),
-      rejectUnauthorized: true,
-    });
-
-    expect(service.rejectUnauthorized).toBeTruthy();
-  });
-
-  it('should allow for the https reject unauthorized option to be set', () => {
-    const service = new BaseResource({
-      token: '123',
-      requesterFn: jest.fn(),
-      rejectUnauthorized: false,
-    });
-
-    expect(service.rejectUnauthorized).toBeFalsy();
-  });
-
   it('should default the queryTimeout to 300s', () => {
     const service = new BaseResource({ token: '123', requesterFn: jest.fn() });
 

--- a/packages/rest/src/Requester.ts
+++ b/packages/rest/src/Requester.ts
@@ -95,11 +95,7 @@ export async function defaultRequestHandler(endpoint: string, options?: RequestO
   // CHECKME: https://github.com/nodejs/undici/issues/1305
   const mode = getConditionalMode(endpoint);
 
-  const initOptions: Record<string, unknown> = {};
-
-  if (agent) {
-    initOptions.dispatcher = agent;
-  }
+  const initOptions: Record<string, unknown> | undefined = agent ? { dispatcher: agent } : undefined;
 
   /* eslint-disable no-await-in-loop */
   for (let i = 0; i < maxRetries; i += 1) {

--- a/packages/rest/test/unit/Requester.ts
+++ b/packages/rest/test/unit/Requester.ts
@@ -469,7 +469,7 @@ describe('defaultRequestHandler', () => {
 
     const request = new Request(new URL('http://test.com/testurl'), { mode: undefined });
 
-    expect(MockFetch).toHaveBeenCalledWith(request);
+    expect(MockFetch).toHaveBeenCalledWith(request, undefined);
   });
 
   it('should handle a searchParams correctly', async () => {
@@ -492,7 +492,7 @@ describe('defaultRequestHandler', () => {
 
     const request = new Request(new URL('http://test.com/testurl/123?test=4'), { mode: undefined });
 
-    expect(MockFetch).toHaveBeenCalledWith(request);
+    expect(MockFetch).toHaveBeenCalledWith(request, undefined);
   });
 
   it('should add same-origin mode for repository/archive endpoint', async () => {
@@ -514,7 +514,7 @@ describe('defaultRequestHandler', () => {
       mode: 'same-origin',
     });
 
-    expect(MockFetch).toHaveBeenCalledWith(request);
+    expect(MockFetch).toHaveBeenCalledWith(request, undefined);
   });
 
   it('should use default mode (cors) for non-repository/archive endpoints', async () => {
@@ -534,7 +534,7 @@ describe('defaultRequestHandler', () => {
 
     const request = new Request(new URL('http://test.com/test/something'), { mode: undefined });
 
-    expect(MockFetch).toHaveBeenCalledWith(request);
+    expect(MockFetch).toHaveBeenCalledWith(request, undefined);
   });
 
   it('should handle multipart prefixUrls correctly', async () => {
@@ -559,7 +559,7 @@ describe('defaultRequestHandler', () => {
       mode: undefined,
     });
 
-    expect(MockFetch).toHaveBeenCalledWith(request);
+    expect(MockFetch).toHaveBeenCalledWith(request, undefined);
 
     await defaultRequestHandler('123/testurl', {
       searchParams: 'test=4',
@@ -570,7 +570,7 @@ describe('defaultRequestHandler', () => {
       mode: undefined,
     });
 
-    expect(MockFetch).toHaveBeenCalledWith(request2);
+    expect(MockFetch).toHaveBeenCalledWith(request2, undefined);
 
     await defaultRequestHandler('123/testurl', {
       searchParams: 'test=4',
@@ -581,6 +581,6 @@ describe('defaultRequestHandler', () => {
       mode: undefined,
     });
 
-    expect(MockFetch).toHaveBeenCalledWith(request3);
+    expect(MockFetch).toHaveBeenCalledWith(request3, undefined);
   });
 });


### PR DESCRIPTION
This provides a way for consumers to apply the rejectUnauthorized configuration or certificants

Example:

```
import { Agent } from 'undici';

await fetch('https://example.com', {
  dispatcher: new Agent({
    connect: {
      rejectUnauthorized: false,
    },
  }),
});
```

fixes #3685 

TODO: Testing