### PR TITLE
Limit pipeline usage to MRs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -44,12 +44,13 @@ variables:
     - .nx/cache
 
 #Link and Install all required dependencies
+default:
+  rules:
+    - if: '$CI_MERGE_REQUEST_ID'
 
 install:
   image: node:20-alpine
   stage: install
-  rules:
-    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
   variables:
     NX_REJECT_UNKNOWN_LOCAL_CACHE: 0
   before_script:
@@ -149,10 +150,10 @@ test:live:setup:
   needs: []
   timeout: 15m
   rules:
-    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && '$CI_MERGE_REQUEST_ID'
       when: on_success
       allow_failure: false
-    - if: $CI_COMMIT_BRANCH == "next" || $CI_COMMIT_BRANCH =~ /^pr-[0-9]+$/
+    - if: ($CI_COMMIT_BRANCH == "next" || $CI_COMMIT_BRANCH =~ /^pr-[0-9]+$/) && '$CI_MERGE_REQUEST_ID'
       when: manual
       allow_failure: true
   variables:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -46,10 +46,8 @@ variables:
 #Link and Install all required dependencies
 workflow:
   rules:
-    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
-    - if: '$CI_COMMIT_BRANCH && $CI_OPEN_MERGE_REQUESTS'
-      when: never
     - if: '$CI_COMMIT_BRANCH == "main"'
+    - if: '$CI_COMMIT_BRANCH =~ /^pr-[0-9]+$/'
 
 install:
   image: node:20-alpine
@@ -153,10 +151,10 @@ test:live:setup:
   needs: []
   timeout: 15m
   rules:
-    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && '$CI_MERGE_REQUEST_ID'
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
       when: on_success
       allow_failure: false
-    - if: ($CI_COMMIT_BRANCH == "next" || $CI_COMMIT_BRANCH =~ /^pr-[0-9]+$/) && '$CI_MERGE_REQUEST_ID'
+    - if: ($CI_COMMIT_BRANCH == "next" || $CI_COMMIT_BRANCH =~ /^pr-[0-9]+$/)
       when: manual
       allow_failure: true
   variables:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -44,9 +44,10 @@ variables:
     - .nx/cache
 
 #Link and Install all required dependencies
-default:
+workflow:
   rules:
     - if: '$CI_MERGE_REQUEST_ID'
+    - if: '$CI_COMMIT_BRANCH == "main"'
 
 install:
   image: node:20-alpine

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -46,8 +46,8 @@ variables:
 #Link and Install all required dependencies
 workflow:
   rules:
-    - if: '$CI_MERGE_REQUEST_ID'
-    - if: '$CI_COMMIT_BRANCH == "main"'
+    - if: $CI_PIPELINE_SOURCE == 'merge_request_event'
+    - if: $CI_COMMIT_BRANCH == "main"
 
 install:
   image: node:20-alpine

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -46,8 +46,10 @@ variables:
 #Link and Install all required dependencies
 workflow:
   rules:
-    - if: $CI_PIPELINE_SOURCE == 'merge_request_event'
-    - if: $CI_COMMIT_BRANCH == "main"
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+    - if: '$CI_COMMIT_BRANCH && $CI_OPEN_MERGE_REQUESTS'
+      when: never
+    - if: '$CI_COMMIT_BRANCH == "main"'
 
 install:
   image: node:20-alpine

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -43,11 +43,13 @@ variables:
   paths:
     - .nx/cache
 
-#Link and Install all required dependancies
+#Link and Install all required dependencies
 
 install:
   image: node:20-alpine
   stage: install
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
   variables:
     NX_REJECT_UNKNOWN_LOCAL_CACHE: 0
   before_script:


### PR DESCRIPTION
Due to the limited free tier compute minutes available on Gitlab, im restricting pipelines to just PRs. A better long term solution should be implemented though.