### PR TITLE
 Add missing `merge_request` field to WebhookEmojiEventSchema

### DIFF
--- a/packages/core/src/resources/Webhooks.ts
+++ b/packages/core/src/resources/Webhooks.ts
@@ -656,6 +656,7 @@ export interface WebhookReleaseEventSchema {
 export interface WebhookEmojiEventSchema extends BaseWebhookEventSchema {
   object_kind: 'emoji';
   event_type: 'award';
+  merge_request?: WebhookMergeRequestEventSchema['object_attributes'];
   project_id: number;
   object_attributes: {
     user_id: number;


### PR DESCRIPTION
## Description

This PR adds the missing `merge_request` field to the `WebhookEmojiEventSchema` interface. When emoji reactions are added to merge request comments, GitLab webhook events include a `merge_request` object, but this was not properly reflected in our Type definitions.

## Changes

- Added the optional `merge_request` field to `WebhookEmojiEventSchema`

<img width="741" alt="Xnip2025-05-20_13-38-17" src="https://github.com/user-attachments/assets/edf61f56-844f-47d7-bce7-4b528f2f7c3f" />

## Related issues

N/A