### PR TITLE
Add missing `detailed_status` field to WebhookPipelineEventSchema

### DIFF
--- a/packages/core/src/resources/Webhooks.ts
+++ b/packages/core/src/resources/Webhooks.ts
@@ -429,6 +429,7 @@ export interface WebhookPipelineEventSchema
     before_sha: string;
     source: string;
     status: string;
+    detailed_status: string;
     stages: string[] | null;
     created_at: string;
     finished_at: string;
@@ -441,7 +442,7 @@ export interface WebhookPipelineEventSchema
       | null;
     url: string;
   };
-  merge_request: {
+  merge_request: null | {
     id: number;
     iid: number;
     title: string;


### PR DESCRIPTION
## Description
This PR enhances the `WebhookPipelineEventSchema` interface by adding the missing `detailed_status` field and improving type safety for the `merge_request` field.

## Changes
Add `detailed_status` field - Includes the missing detailed status information for pipeline events

Improve `merge_request` field typing - Updated from `object` to `null | object` union type for better type safety

The field is `null` for most pipeline sources
Only populated when pipeline source is `merge_request_event`

## Webhook event payload

```json
{
  "object_kind": "pipeline",
  "object_attributes": {
    "id": 123456,
    "iid": 351,
    "name": null,
    "ref": "feature/test",
    "tag": false,
    "sha": "xxx",
    "before_sha": "xxx",
    "source": "push",
    "status": "success",
    "detailed_status": "passed with warnings",
    "stages": [
      "test"
    ],
    "created_at": "2025-06-05 13:16:35 +0800",
    "finished_at": "2025-06-05 13:16:43 +0800",
    "duration": 7,
    "queued_duration": null,
    "variables": [],
    "url": "https://test"
  },
  "merge_request": null
	...
}
```

Reference: [GitLab CI Pipeline Source Documentation](https://docs.gitlab.com/ci/jobs/job_rules/#ci_pipeline_source-predefined-variable)

