### PR TITLE
Enhance error messaging in GitbeakerRequestError to clearly display only the description context

### DIFF
--- a/packages/rest/src/Requester.ts
+++ b/packages/rest/src/Requester.ts
@@ -64,7 +64,7 @@ async function throwFailedRequestError(
     description = content;
   }
 
-  throw new GitbeakerRequestError(response.statusText, {
+  throw new GitbeakerRequestError(description, {
     cause: {
       description,
       request,

--- a/packages/rest/test/unit/Requester.ts
+++ b/packages/rest/test/unit/Requester.ts
@@ -127,7 +127,7 @@ describe('defaultRequestHandler', () => {
       defaultRequestHandler('http://test.com', {} as RequestOptions),
     );
 
-    expect(error.message).toBe('Really Bad Error');
+    expect(error.message).toBe('msg');
     expect(error).toBeInstanceOf(GitbeakerRequestError);
   });
 
@@ -150,7 +150,7 @@ describe('defaultRequestHandler', () => {
       defaultRequestHandler('http://test.com', {} as RequestOptions),
     );
 
-    expect(error.message).toBe('Really Bad Error');
+    expect(error.message).toBe('msg');
     expect(error?.cause?.response).toBeInstanceOf(Response);
   });
 
@@ -173,7 +173,7 @@ describe('defaultRequestHandler', () => {
       defaultRequestHandler('http://test.com', {} as RequestOptions),
     );
 
-    expect(error.message).toBe('Really Bad Error');
+    expect(error.message).toBe('msg');
     expect(error?.cause?.request).toBeInstanceOf(Request);
   });
 


### PR DESCRIPTION
Close #3727
