### PR TITLE
Fix includeDivergedCommitsCount Type Definition

### DIFF
--- a/packages/core/src/resources/MergeRequests.ts
+++ b/packages/core/src/resources/MergeRequests.ts
@@ -594,7 +594,7 @@ export class MergeRequests<C extends boolean = false> extends BaseResource<C> {
     mergerequestIId: number,
     options?: {
       renderHtml?: boolean;
-      includeDivergedCommitsCount?: true;
+      includeDivergedCommitsCount?: boolean;
       includeRebaseInProgress?: boolean;
     } & Sudo &
       ShowExpanded<E>,


### PR DESCRIPTION
The `includeDivergedCommitsCount` parameter in the `MergeRequests.show()` method was incorrectly typed as the literal type `true` instead of `boolean`.

## Reference
According to the [GitLab API documentation](https://docs.gitlab.com/api/merge_requests/#get-single-mr), the `include_diverged_commits_count` parameter is defined as a boolean type.