### PR TITLE
Set merge request `description` type to nullable

### DIFF
--- a/packages/core/src/resources/MergeRequests.ts
+++ b/packages/core/src/resources/MergeRequests.ts
@@ -83,7 +83,7 @@ export interface CondensedMergeRequestSchema extends Record<string, unknown> {
   iid: number;
   project_id: number;
   title: string;
-  description: string;
+  description: string | null;
   state: string;
   created_at: string;
   updated_at: string;


### PR DESCRIPTION
When creating a merge request via the GitLab API, the `description` field could be omitted, resulting in a `null` value.

This fix updates the type definition to correctly reflect that the description is nullable.

## Verification

The merge request created via GitLab API (without filling the *optional* description field): https://gitlab.com/frantic1048/test-gitlab-mr-description-typing/-/merge_requests/2

**API Results**

- REST API: https://gitlab.com/api/v4/projects/frantic1048%2Ftest-gitlab-mr-description-typing/merge_requests/2
  There will be `"description": null` in the result.

- GraphQL API (the `description` field is already noted as nullable in GraphQL schema):
    Visit https://gitlab.com/-/graphql-explorer, enter following query and execute it.

    ```graphql
    {
	  mergeRequest(id: "gid://gitlab/MergeRequest/392227168") {
	    id
	    title
	    description
	  }
	}
   ```
   There will be `"description": null` in the result, same as the REST API.
