### PR TITLE
Update AcceptMergeRequestOptions type definition

### DIFF
--- a/packages/core/src/resources/MergeRequests.ts
+++ b/packages/core/src/resources/MergeRequests.ts
@@ -244,9 +244,6 @@ export type AcceptMergeRequestOptions = {
    */
   mergeWhenPipelineSucceeds?: boolean;
   sha?: string;
-  /**
-   * If true, the merge request merges when the pipeline succeeds.
-   */
   autoMerge?: boolean;
 };
 


### PR DESCRIPTION
- Add `autoMerge` field to replace deprecated `mergeWhenPipelineSucceeds`
- Mark `mergeWhenPipelineSucceeds` as deprecated (GitLab 17.11)

[Reference](https://docs.gitlab.com/api/merge_requests/#merge-a-merge-request)

fixes #3726