### PR TITLE
Move maxPages under BasePaginationRequestOptions

### DIFF
--- a/packages/core/src/infrastructure/RequestHelper.ts
+++ b/packages/core/src/infrastructure/RequestHelper.ts
@@ -41,12 +41,12 @@ export interface KeysetPaginationRequestOptions {
 
 export interface OffsetPaginationRequestOptions {
   page?: number | string;
-  maxPages?: number;
 }
 
 export interface BasePaginationRequestOptions<P extends PaginationTypes | void> {
   pagination?: P;
   perPage?: number | string;
+  maxPages?: number;
 }
 
 export type PaginationRequestSubOptions<P extends PaginationTypes | void> = P extends 'keyset'
@@ -165,7 +165,7 @@ function getManyMore<
   getFn: RequestHandlerFn<T>,
   endpoint: string,
   response: FormattedResponse<T>,
-  requestOptions: { maxPages?: number } & PaginationRequestOptions<P> & BaseRequestOptions<E>,
+  requestOptions: PaginationRequestOptions<P> & BaseRequestOptions<E>,
   acc?: T,
 ): Promise<E extends true ? PaginatedResponse<T, P> : T>;
 
@@ -178,7 +178,7 @@ async function getManyMore<
   getFn: RequestHandlerFn<T>,
   endpoint: string,
   response: FormattedResponse<T>,
-  requestOptions: { maxPages?: number } & PaginationRequestOptions<P> & BaseRequestOptions<E>,
+  requestOptions: PaginationRequestOptions<P> & BaseRequestOptions<E>,
   acc?: T,
 ): Promise<PaginatedResponse<T, P> | T> {
   const { sudo, showExpanded, maxPages, pagination, page, perPage, idAfter, orderBy, sort } =
@@ -201,7 +201,7 @@ async function getManyMore<
       maxPages,
       sudo,
       showExpanded,
-    } as unknown as { maxPages?: number } & PaginationRequestOptions<P> & BaseRequestOptions<E>;
+    } as unknown as PaginationRequestOptions<P> & BaseRequestOptions<E>;
 
     const nextResponse: FormattedResponse<T> = await getFn(endpoint, {
       searchParams: qs,


### PR DESCRIPTION
In the current version, `maxPages` is not declared as a valid pagination option for the `keyset` pagination. However it's implemented and it works well, it's just hidden by the typing.

![Capture d’écran 2025-06-27 à 20 10 41](https://github.com/user-attachments/assets/3812d6de-6453-4677-b02e-2949cff73009)

It should be exposed as a valid field for both pagination modes `offset` and `keyset` just like the `perPage` field, which is what this PR does.