### PR TITLE
feat: Support pagination on runner jobs

### DIFF
--- a/packages/core/src/resources/Runners.ts
+++ b/packages/core/src/resources/Runners.ts
@@ -105,10 +105,12 @@ export class Runners<C extends boolean = false> extends BaseResource<C> {
     return RequestHelper.get<RunnerSchema[]>()(this, url, options);
   }
 
-  allJobs<E extends boolean = false>(
+  allJobs<E extends boolean = false, P extends PaginationTypes = 'offset'>(
     runnerId: number,
-    options?: Sudo & ShowExpanded<E> & { status?: string; orderBy?: string; sort?: string },
-  ): Promise<GitlabAPIResponse<JobSchema[], C, E, void>> {
+    options?: Sudo &
+      PaginationRequestOptions<P> &
+      ShowExpanded<E> & { status?: string; orderBy?: string; sort?: string },
+  ): Promise<GitlabAPIResponse<JobSchema[], C, E, P>> {
     return RequestHelper.get<JobSchema[]>()(this, `runners/${runnerId}/jobs`, options);
   }
 

--- a/packages/core/test/unit/resources/Pipelines.ts
+++ b/packages/core/test/unit/resources/Pipelines.ts
@@ -19,7 +19,7 @@ describe('Pipelines', () => {
   describe('all', () => {
     it('should request GET /projects/:id/pipelines', async () => {
       const projectId = 1;
-      const options = { scope: 'running' };
+      const options = { scope: 'running' as const };
 
       await service.all(projectId, options);
 


### PR DESCRIPTION
Getting timeouts on retrieving jobs for runners that have a long list of jobs

[GitLab API docs for runners](https://docs.gitlab.com/api/runners/) mentions at the top that pagination is supported for this route
