### PR TITLE
fix: Parsing param names from functions with destructured params was not working correctly

### DIFF
--- a/packages/core/scripts/getParamNames.ts
+++ b/packages/core/scripts/getParamNames.ts
@@ -1,5 +1,5 @@
 function isValidParam(param: string): boolean {
-  return Boolean(param) && !param.startsWith('{') && !param.startsWith('...');
+  return Boolean(param) && !param.startsWith('...');
 }
 
 function removeDefaultValues(param: string): string {
@@ -12,6 +12,7 @@ export const getParamNames = (func: () => unknown): string[] => {
   const paramString = paramPattern.exec(funcString)?.[1] || '';
 
   return paramString
+    .replace(/(\{[^}]*\}|\s*=\s*{[^}]*})/g, '') // Remove destructured params
     .replace(/\/\*.*?\*\//g, '') // Remove comments
     .replace(/ /g, '') // Remove spaces
     .split(',') // Split into array


### PR DESCRIPTION
fixes #3743 