### PR TITLE
fix(core): Rename projectId to groupId in types

### DIFF
--- a/packages/core/src/resources/GroupLabels.ts
+++ b/packages/core/src/resources/GroupLabels.ts
@@ -73,7 +73,7 @@ export interface GroupLabels<C extends boolean = false> extends ResourceLabels<C
   ): Promise<GitlabAPIResponse<void, C, E, void>>;
 
   show<E extends boolean = false>(
-    projectId: string | number,
+    groupId: string | number,
     labelId: number | string,
     options?: { includeAncestorGroups?: boolean } & Sudo & ShowExpanded<E>,
   ): Promise<GitlabAPIResponse<LabelSchema, C, E, void>>;


### PR DESCRIPTION
I noticed that `GroupLabels.show` has `projectId` as first parameter (instead of `groupId`, like all other functions of `GroupLabels`.

This does not change any functionality, it is just confusing when using TypeScript 🙂 