### PR TITLE
docs: Renamed Gitlab to GitLab

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -189,7 +189,7 @@ test:live:setup:
     - attempt=1
     - |
       while [[ "$(curl --fail --silent -X GET "$GITLAB_URL/-/readiness?all=1" --insecure | jq -r '.master_check[0].status')" != "ok" ]]; do
-        echo "Polling Attempt: $attempt - Gitlab service is not alive yet";
+        echo "Polling Attempt: $attempt - GitLab service is not alive yet";
         sleep 10;
         ((attempt++));
       done

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@
 
 ## Features
 
-- **Complete** - All features of Gitlab's exposed APIs are covered up to version [16.5](https://docs.gitlab.com/16.5/ee/api/api_resources.html). See [here](./packages/core/README.md#supported-apis) for the full list.
+- **Complete** - All features of GitLab's exposed APIs are covered up to version [16.5](https://docs.gitlab.com/16.5/ee/api/api_resources.html). See [here](./packages/core/README.md#supported-apis) for the full list.
 - **Universal** - Works in all modern browsers, [Node.js](https://nodejs.org/), and [Deno](https://deno.land/) and supports [CLI](https://www.npmjs.com/package/@gitbeaker/cli) usage.
 - **Tested** - All libraries have > 80% test coverage.
 - **Typed** - All libraries have extensive TypeScript declarations.
@@ -66,7 +66,7 @@
 ## Packages
 
 - :wrench: [**@gitbeaker/requester-utils**](https://www.npmjs.com/package/@gitbeaker/requester-utils) - Utilities for the underlying HTTP request functionality.
-- :scroll: [**@gitbeaker/core**](https://www.npmjs.com/package/@gitbeaker/core) - The core API detailing all the Gitlab resource support.
+- :scroll: [**@gitbeaker/core**](https://www.npmjs.com/package/@gitbeaker/core) - The core API detailing all the GitLab resource support.
 - :computer: [**@gitbeaker/rest**](https://www.npmjs.com/package/@gitbeaker/rest) - The Node.js, Deno and Modern Browser wrapper around the gitbeaker core API, using native fetch. This is the primary library for consumption.
 - :pager: [**@gitbeaker/cli**](https://www.npmjs.com/package/@gitbeaker/cli) - The CLI Wrapper around the @gitbeaker/rest distribution.
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -17,7 +17,7 @@ const api = new Gitlab({
 
 #### Handling HTTPS certificates
 
-If your Gitlab server is running via HTTPS, the proper way to pass in your certificates is via a `NODE_EXTRA_CA_CERTS` environment key, like this:
+If your GitLab server is running via HTTPS, the proper way to pass in your certificates is via a `NODE_EXTRA_CA_CERTS` environment key, like this:
 
 ```js
 "scripts": {

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -10,7 +10,7 @@ yarn test:unit
 
 **Integration Tests**
 
-1. First, run Gitlab in a docker container:
+1. First, run GitLab in a docker container:
 
 ```bash
 docker-compose -f scripts/docker-compose.yml up
@@ -36,4 +36,4 @@ You can also define them in front of the yarn script
 PERSONAL_ACCESS_TOKEN='abcdefg' GITLAB_URL='http://localhost:8080' yarn test
 ```
 
-> Note it may take about 3 minutes to get the variables while Gitlab is starting up in the container
+> Note it may take about 3 minutes to get the variables while GitLab is starting up in the container

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -135,25 +135,25 @@ export function getGlobalConfig(env = process.env): GlobalCLIConfig {
   return {
     'gb-token': {
       alias: 'gl-token',
-      desc: 'Your Gitlab Personal Token',
+      desc: 'Your GitLab Personal Token',
       type: 'string',
       defaultValue: normalEnv.GITBEAKER_TOKEN,
     },
     'gb-oauth-token': {
       alias: 'gl-oauth-token',
-      desc: 'Your Gitlab OAuth Token',
+      desc: 'Your GitLab OAuth Token',
       type: 'string',
       defaultValue: normalEnv.GITBEAKER_OAUTH_TOKEN,
     },
     'gb-job-token': {
       alias: 'gl-job-token',
-      desc: 'Your Gitlab Job Token',
+      desc: 'Your GitLab Job Token',
       type: 'string',
       defaultValue: normalEnv.GITBEAKER_JOB_TOKEN,
     },
     'gb-host': {
       alias: 'gl-host',
-      desc: 'Your Gitlab API host (Defaults to https://www.gitlab.com)',
+      desc: 'Your GitLab API host (Defaults to https://www.gitlab.com)',
       type: 'string',
       defaultValue: normalEnv.GITBEAKER_HOST,
     },
@@ -192,7 +192,7 @@ export function getGlobalConfig(env = process.env): GlobalCLIConfig {
 }
 
 export function getExposedAPIs(map: Record<string, MethodTemplate[]>) {
-  // Exclude Gitlab resource and constants from exposure
+  // Exclude GitLab resource and constants from exposure
   const { Gitlab, AccessLevel, ...exposed } = map;
 
   return exposed;

--- a/packages/core/src/resources/MergeRequests.ts
+++ b/packages/core/src/resources/MergeRequests.ts
@@ -612,7 +612,7 @@ export class MergeRequests<C extends boolean = false> extends BaseResource<C> {
     options?: { accessRawDiffs?: boolean } & Sudo & ShowExpanded<E>,
   ): Promise<GitlabAPIResponse<MergeRequestChangesSchema, C, E, void>> {
     process.emitWarning(
-      'This endpoint was deprecated in Gitlab API 15.7 and will be removed in API v5. Please use the "allDiffs" function instead.',
+      'This endpoint was deprecated in GitLab API 15.7 and will be removed in API v5. Please use the "allDiffs" function instead.',
       'DeprecationWarning',
     );
     return RequestHelper.get<MergeRequestChangesSchema>()(

--- a/packages/rest/README.md
+++ b/packages/rest/README.md
@@ -67,7 +67,7 @@
 
 ## Features
 
-- **Complete** - All features of Gitlab's exposed APIs are covered up to version [16.5](https://docs.gitlab.com/16.5/ee/api/api_resources.html). See [here](./packages/core/README.md#supported-apis) for the full list.
+- **Complete** - All features of GitLab's exposed APIs are covered up to version [16.5](https://docs.gitlab.com/16.5/ee/api/api_resources.html). See [here](./packages/core/README.md#supported-apis) for the full list.
 - **Universal** - Works in all modern browsers, [Node.js](https://nodejs.org/), and [Deno](https://deno.land/).
 - **Tested** - All libraries have > 80% test coverage.
 - **Typed** - All libraries have extensive TypeScript declarations.
@@ -114,7 +114,7 @@ import { Gitlab } from '@gitbeaker/rest';
 
 ## API Client
 
-Instantiate the library using a basic token created in your [Gitlab Profile](https://docs.gitlab.com/ce/user/profile/personal_access_tokens.html)
+Instantiate the library using a basic token created in your [GitLab Profile](https://docs.gitlab.com/ce/user/profile/personal_access_tokens.html)
 
 ```javascript
 const api = new Gitlab({
@@ -184,7 +184,7 @@ Available pagination options:
 
 #### Offset Pagination
 
-For any .all() function on a resource, it will return **all** the items from Gitlab. This can be troublesome if there are many items, as the request itself can take a while to be fulfilled. As such, a maxPages option can be passed to limit the scope of the all function.
+For any .all() function on a resource, it will return **all** the items from GitLab. This can be troublesome if there are many items, as the request itself can take a while to be fulfilled. As such, a maxPages option can be passed to limit the scope of the all function.
 
 ```javascript
 import { Gitlab } from '@gitbeaker/rest';
@@ -236,7 +236,7 @@ paginationInfo: {
 }
 ```
 
-> Note: Supplying any pagination restrictions is call intensive. Some resources will require many requests which can put a significant load on the Gitlab Server. The general best practice would be setting the page request option to only return the first page if all results are not required.
+> Note: Supplying any pagination restrictions is call intensive. Some resources will require many requests which can put a significant load on the GitLab Server. The general best practice would be setting the page request option to only return the first page if all results are not required.
 
 #### Keyset Pagination
 
@@ -252,7 +252,7 @@ const { data } = await api.Projects.all({
 
 ### Rate Limits
 
-Rate limits are completely customizable, and are used to limit the request rate between consecutive API requests within the library. By default, all non-specified endpoints use a 3000 rps rate limit, while some endpoints have much smaller rates as dictated by the [Gitlab Docs](https://docs.gitlab.com/ee/security/rate_limits.html). See below for the default values:
+Rate limits are completely customizable, and are used to limit the request rate between consecutive API requests within the library. By default, all non-specified endpoints use a 3000 rps rate limit, while some endpoints have much smaller rates as dictated by the [GitLab Docs](https://docs.gitlab.com/ee/security/rate_limits.html). See below for the default values:
 
 ```js
 const DEFAULT_RATE_LIMITS = Object.freeze({
@@ -379,7 +379,7 @@ const projectsAPI = new Projects({
 });
 
 projectsAPI.create({
-  //options defined in the Gitlab API documentation
+  //options defined in the GitLab API documentation
 });
 ```
 


### PR DESCRIPTION
The spelling of `GitLab` in this project is a mixture of `GitLab` and `Gitlab` and I thought it would be good to spell it correctly at least in the docs. I specifically didn't rename any variables to not break any functionality.