### PR TITLE
Add rate limit duration

### DIFF
--- a/packages/requester-utils/src/BaseResource.ts
+++ b/packages/requester-utils/src/BaseResource.ts
@@ -8,6 +8,7 @@ export interface RootResourceOptions<C> {
   rejectUnauthorized?: boolean;
   camelize?: C;
   queryTimeout?: number | null;
+  rateLimitDuration?: number;
   sudo?: string | number;
   profileToken?: string;
   profileMode?: 'execution' | 'memory';
@@ -107,6 +108,7 @@ export class BaseResource<C extends boolean = false> {
     prefixUrl = '',
     rejectUnauthorized = true,
     queryTimeout = 300000,
+    rateLimitDuration = 60,
     rateLimits = DEFAULT_RATE_LIMITS,
     ...tokens
   }: BaseResourceOptions<C>) {
@@ -141,6 +143,6 @@ export class BaseResource<C extends boolean = false> {
     if (sudo) this.headers.Sudo = `${sudo}`;
 
     // Set requester instance using this information
-    this.requester = requesterFn({ ...this, rateLimits });
+    this.requester = requesterFn({ ...this, rateLimits, rateLimitDuration });
   }
 }

--- a/packages/requester-utils/src/RequesterUtils.ts
+++ b/packages/requester-utils/src/RequesterUtils.ts
@@ -158,11 +158,15 @@ export async function defaultOptionsHandler(
   return Promise.resolve(defaultOptions);
 }
 
-export function createRateLimiters(rateLimitOptions: RateLimitOptions = {}, rateLimitDuration: number = 60) {
+export function createRateLimiters(
+  rateLimitOptions: RateLimitOptions = {},
+  rateLimitDuration: number = 60,
+) {
   const rateLimiters: RateLimiters = {};
 
   Object.entries(rateLimitOptions).forEach(([key, config]) => {
-    if (typeof config === 'number') rateLimiters[key] = generateRateLimiterFn(config, rateLimitDuration);
+    if (typeof config === 'number')
+      rateLimiters[key] = generateRateLimiterFn(config, rateLimitDuration);
     else
       rateLimiters[key] = {
         method: config.method.toUpperCase(),
@@ -181,7 +185,10 @@ export function createRequesterFn(
 
   return (serviceOptions) => {
     const requester: RequesterType = {} as RequesterType;
-    const rateLimiters = createRateLimiters(serviceOptions.rateLimits, serviceOptions.rateLimitDuration);
+    const rateLimiters = createRateLimiters(
+      serviceOptions.rateLimits,
+      serviceOptions.rateLimitDuration,
+    );
 
     methods.forEach((m) => {
       requester[m] = async (endpoint: string, options: Record<string, unknown>) => {

--- a/packages/requester-utils/src/RequesterUtils.ts
+++ b/packages/requester-utils/src/RequesterUtils.ts
@@ -37,6 +37,7 @@ export type ResourceOptions = {
   url: string;
   rejectUnauthorized: boolean;
   rateLimits?: RateLimitOptions;
+  rateLimitDuration?: number;
 };
 
 export type DefaultRequestOptions = {
@@ -157,15 +158,15 @@ export async function defaultOptionsHandler(
   return Promise.resolve(defaultOptions);
 }
 
-export function createRateLimiters(rateLimitOptions: RateLimitOptions = {}) {
+export function createRateLimiters(rateLimitOptions: RateLimitOptions = {}, rateLimitDuration: number = 60) {
   const rateLimiters: RateLimiters = {};
 
   Object.entries(rateLimitOptions).forEach(([key, config]) => {
-    if (typeof config === 'number') rateLimiters[key] = generateRateLimiterFn(config, 60);
+    if (typeof config === 'number') rateLimiters[key] = generateRateLimiterFn(config, rateLimitDuration);
     else
       rateLimiters[key] = {
         method: config.method.toUpperCase(),
-        limit: generateRateLimiterFn(config.limit, 60),
+        limit: generateRateLimiterFn(config.limit, rateLimitDuration),
       };
   });
 
@@ -180,7 +181,7 @@ export function createRequesterFn(
 
   return (serviceOptions) => {
     const requester: RequesterType = {} as RequesterType;
-    const rateLimiters = createRateLimiters(serviceOptions.rateLimits);
+    const rateLimiters = createRateLimiters(serviceOptions.rateLimits, serviceOptions.rateLimitDuration);
 
     methods.forEach((m) => {
       requester[m] = async (endpoint: string, options: Record<string, unknown>) => {

--- a/packages/requester-utils/test/unit/RequesterUtils.ts
+++ b/packages/requester-utils/test/unit/RequesterUtils.ts
@@ -225,7 +225,7 @@ describe('createInstance', () => {
 });
 
 describe('createRateLimiters', () => {
-  it('should create rate limiter functions when configured', () => {
+  it('should create rate limiter functions when configured, with a default timeout duration of 60', () => {
     const limiters = createRateLimiters({
       '*': 40,
       'projects/*/test': {
@@ -236,6 +236,30 @@ describe('createRateLimiters', () => {
 
     expect(RateLimiterMemory).toHaveBeenCalledWith({ points: 10, duration: 60 });
     expect(RateLimiterMemory).toHaveBeenCalledWith({ points: 40, duration: 60 });
+
+    expect(limiters).toStrictEqual({
+      '*': expect.toBeFunction(),
+      'projects/*/test': {
+        method: 'GET',
+        limit: expect.toBeFunction(),
+      },
+    });
+  });
+
+  it('should respect a custom timeout duration when passed to createRateLimiters', () => {
+    const limiters = createRateLimiters(
+      {
+        '*': 40,
+        'projects/*/test': {
+          method: 'GET',
+          limit: 10,
+        },
+      },
+      30,
+    );
+
+    expect(RateLimiterMemory).toHaveBeenCalledWith({ points: 10, duration: 30 });
+    expect(RateLimiterMemory).toHaveBeenCalledWith({ points: 40, duration: 30 });
 
     expect(limiters).toStrictEqual({
       '*': expect.toBeFunction(),

--- a/packages/rest/README.md
+++ b/packages/rest/README.md
@@ -131,13 +131,14 @@ Available instantiating options:
 | `oauthToken`         | Yes\*    | N/A                                                                                                                                     | OAuth Token. Recommended (one of the three tokens are recommended)                                                 |
 | `jobToken`           | Yes\*    | N/A                                                                                                                                     | CI Job Token. Recommended (one of the three tokens are recommended)                                                |
 | `rejectUnauthorized` | Yes      | `true`                                                                                                                                  | Http Certificate setting, Only applies to non-browser releases and HTTPS hosts urls                                |
-| `sudo`               | Yes      | `false`                                                                                                                                 | [Sudo](https://docs.gitlab.com/api/#sudo) query parameter                                                       |
+| `sudo`               | Yes      | `false`                                                                                                                                 | [Sudo](https://docs.gitlab.com/api/#sudo) query parameter                                                          |
 | `camelize`           | Yes      | `false`                                                                                                                                 | Camelizes all response body keys                                                                                   |
 | `requesterFn`        | No       | @gitbeaker/rest & @gitbeaker/cli : fetch-based, The @gitbeaker/core package **does not** have a default and thus must be set explicitly | Request Library Wrapper                                                                                            |
 | `queryTimeout`       | Yes      | `300000`                                                                                                                                | Query Timeout in ms                                                                                                |
-| `profileToken`       | Yes      | N/A                                                                                                                                     | [Requests Profiles Token](https://docs.gitlab.com/administration/monitoring/performance/request_profiling.html) |
-| `profileMode`        | Yes      | `execution`                                                                                                                             | [Requests Profiles Token](https://docs.gitlab.com/administration/monitoring/performance/request_profiling.html) |
+| `profileToken`       | Yes      | N/A                                                                                                                                     | [Requests Profiles Token](https://docs.gitlab.com/administration/monitoring/performance/request_profiling.html)    |
+| `profileMode`        | Yes      | `execution`                                                                                                                             | [Requests Profiles Token](https://docs.gitlab.com/administration/monitoring/performance/request_profiling.html)    |
 | `rateLimits`         | No       | [DEFAULT_RATE_LIMITS](#rate-limits)                                                                                                     | Global and endpoint specific adjustable rate limits                                                                |
+| `rateLimitDuration`  | No       | `60`                                                                                                                                    | Timeout duration when rate limit is reached                                                                        |
 
 > \*One of these options should be supplied, as most API requests require authentication.
 
@@ -302,6 +303,8 @@ Rate limits can be overridden when instantiating a API wrapper. For ease of use,
 1. The glob for the endpoint with the corresponding rate per second
 2. The glob for the endpoint, with an object specifying the specific method for the endpoint and the corresponding rate limit
 
+You can also override the `rateLimitDuration` default value of 60 seconds. This is how long a specific endpoint will be timed out for when its rate limit is reached.
+
 ```js
 const api = new Gitlab({
   token: 'token',
@@ -313,6 +316,7 @@ const api = new Gitlab({
       limit: 300,
     },
   },
+  rateLimitDuration: 30
 });
 ```
 

--- a/packages/rest/README.md
+++ b/packages/rest/README.md
@@ -124,22 +124,21 @@ const api = new Gitlab({
 
 Available instantiating options:
 
-| Name                 | Optional | Default                                                                                                                                 | Description                                                                                                        |
-| -------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
-| `host`               | Yes      | `https://gitlab.com`                                                                                                                    | Gitlab Instance Host URL                                                                                           |
-| `token`              | Yes\*    | N/A                                                                                                                                     | Personal Token. Recommended (one of the three tokens are recommended)                                              |
-| `oauthToken`         | Yes\*    | N/A                                                                                                                                     | OAuth Token. Recommended (one of the three tokens are recommended)                                                 |
-| `jobToken`           | Yes\*    | N/A                                                                                                                                     | CI Job Token. Recommended (one of the three tokens are recommended)                                                |
-| `rejectUnauthorized` | Yes      | `true`                                                                                                                                  | Http Certificate setting, Only applies to non-browser releases and HTTPS hosts urls                                |
-| `sudo`               | Yes      | `false`                                                                                                                                 | [Sudo](https://docs.gitlab.com/api/#sudo) query parameter                                                          |
-| `camelize`           | Yes      | `false`                                                                                                                                 | Camelizes all response body keys                                                                                   |
-| `requesterFn`        | No       | @gitbeaker/rest & @gitbeaker/cli : fetch-based, The @gitbeaker/core package **does not** have a default and thus must be set explicitly | Request Library Wrapper                                                                                            |
-| `queryTimeout`       | Yes      | `300000`                                                                                                                                | Query Timeout in ms                                                                                                |
-| `profileToken`       | Yes      | N/A                                                                                                                                     | [Requests Profiles Token](https://docs.gitlab.com/administration/monitoring/performance/request_profiling.html)    |
-| `profileMode`        | Yes      | `execution`                                                                                                                             | [Requests Profiles Token](https://docs.gitlab.com/administration/monitoring/performance/request_profiling.html)    |
-| `rateLimits`         | No       | [DEFAULT_RATE_LIMITS](#rate-limits)                                                                                                     | Global and endpoint specific adjustable rate limits                                                                |
-| `rateLimitDuration`  | No       | `60`                                                                                                                                    | Timeout duration when rate limit is reached                                                                        |
-
+| Name                 | Optional | Default                                                                                                                                 | Description                                                                                                     |
+| -------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| `host`               | Yes      | `https://gitlab.com`                                                                                                                    | Gitlab Instance Host URL                                                                                        |
+| `token`              | Yes\*    | N/A                                                                                                                                     | Personal Token. Recommended (one of the three tokens are recommended)                                           |
+| `oauthToken`         | Yes\*    | N/A                                                                                                                                     | OAuth Token. Recommended (one of the three tokens are recommended)                                              |
+| `jobToken`           | Yes\*    | N/A                                                                                                                                     | CI Job Token. Recommended (one of the three tokens are recommended)                                             |
+| `rejectUnauthorized` | Yes      | `true`                                                                                                                                  | Http Certificate setting, Only applies to non-browser releases and HTTPS hosts urls                             |
+| `sudo`               | Yes      | `false`                                                                                                                                 | [Sudo](https://docs.gitlab.com/api/#sudo) query parameter                                                       |
+| `camelize`           | Yes      | `false`                                                                                                                                 | Camelizes all response body keys                                                                                |
+| `requesterFn`        | No       | @gitbeaker/rest & @gitbeaker/cli : fetch-based, The @gitbeaker/core package **does not** have a default and thus must be set explicitly | Request Library Wrapper                                                                                         |
+| `queryTimeout`       | Yes      | `300000`                                                                                                                                | Query Timeout in ms                                                                                             |
+| `profileToken`       | Yes      | N/A                                                                                                                                     | [Requests Profiles Token](https://docs.gitlab.com/administration/monitoring/performance/request_profiling.html) |
+| `profileMode`        | Yes      | `execution`                                                                                                                             | [Requests Profiles Token](https://docs.gitlab.com/administration/monitoring/performance/request_profiling.html) |
+| `rateLimits`         | No       | [DEFAULT_RATE_LIMITS](#rate-limits)                                                                                                     | Global and endpoint specific adjustable rate limits                                                             |
+| `rateLimitDuration`  | No       | `60`                                                                                                                                    | Timeout duration when rate limit is reached                                                                     |
 
 > \*One of these options should be supplied, as most API requests require authentication.
 
@@ -317,7 +316,7 @@ const api = new Gitlab({
       limit: 300,
     },
   },
-  rateLimitDuration: 30
+  rateLimitDuration: 30,
 });
 ```
 


### PR DESCRIPTION
This exposes a `rateLimitDuration` property to the BaseResource class. This new property ends up passed to the `createRateLimiters` function in RequesterUtils.js, and controls the duration of the timeout when the rate limit defined in the `rateLimits` is hit for an endpoint.

I also modified an existing example and updated the README.md in the gitbeaker/rest directory to show usage of this new property, added a simple unit test for this new property, and just realigned some characters in the gitbeaker/rest README.md

fixes #3741