### PR TITLE
docs: fix broken README link to Supported APIs

### DIFF
--- a/packages/rest/README.md
+++ b/packages/rest/README.md
@@ -67,7 +67,7 @@
 
 ## Features
 
-- **Complete** - All features of GitLab's exposed APIs are covered up to version [16.5](https://docs.gitlab.com/16.5/ee/api/api_resources.html). See [here](./packages/core/README.md#supported-apis) for the full list.
+- **Complete** - All features of GitLab's exposed APIs are covered up to version [16.5](https://docs.gitlab.com/16.5/ee/api/api_resources.html). See [here](/packages/core/README.md#supported-apis) for the full list.
 - **Universal** - Works in all modern browsers, [Node.js](https://nodejs.org/), and [Deno](https://deno.land/).
 - **Tested** - All libraries have > 80% test coverage.
 - **Typed** - All libraries have extensive TypeScript declarations.


### PR DESCRIPTION
Fixes https://github.com/jdalrymple/gitbeaker/issues/3760 by using a path from root rather than relative to packages/rest