### PR TITLE
Add discussion_id to WebhookBaseNoteEventSchema

### DIFF
--- a/packages/core/src/resources/Webhooks.ts
+++ b/packages/core/src/resources/Webhooks.ts
@@ -87,6 +87,7 @@ export interface WebhookBaseNoteEventSchema extends BaseWebhookEventSchema {
     id: number;
     note: string;
     noteable_type: string;
+    discussion_id: string;
     author_id: number;
     created_at: string;
     updated_at: string;


### PR DESCRIPTION
i'm seeing the `discussion_id` at least on `note` events when commenting MRs, even when just adding a top-level comment (and not yet a thread).

i need this id for the `MergeRequestDiscussions.addNote` request since i'd like to directly respond to MR comments.