### PR TITLE
Export defaultRequestHandler from Requester

### DIFF
--- a/packages/rest/src/index.ts
+++ b/packages/rest/src/index.ts
@@ -19,6 +19,8 @@ const API = presetResourceArguments(Resources, { requesterFn });
 // Export AccessLevel separately (not a class)
 export { AccessLevel };
 
+export { defaultRequestHandler } from './Requester';
+
 // Dual Export Pattern: Each class exported as both constructor and instance type
 
 export const { Agents } = API;


### PR DESCRIPTION
This pull request introduces a minor update to the `packages/rest/src/index.ts` file, focusing on improving the module's exports.

* Added a named export for `defaultRequestHandler` from the `Requester` module, making it available for consumers of this package.