### PR TITLE
Add "reviewers" sub-resource for MergeRequests resource

### DIFF
--- a/packages/core/src/resources/MergeRequests.ts
+++ b/packages/core/src/resources/MergeRequests.ts
@@ -189,6 +189,12 @@ export interface MergeRequestChangesSchema
   overflow: boolean;
 }
 
+export interface MergeRequestReviewerSchema extends Record<string, unknown> {
+  user: MappedOmit<SimpleUserSchema, 'created_at'>;
+  state: 'unreviewed' | 'requested_changes' | 'reviewed' | 'approved' | 'review_started';
+  created_at: string;
+}
+
 // Select method options
 export type AllMergeRequestsOptions = {
   approvedByIds?: number[];
@@ -665,6 +671,18 @@ export class MergeRequests<C extends boolean = false> extends BaseResource<C> {
     return RequestHelper.post<ExpandedMergeRequestSchema>()(
       this,
       endpoint`projects/${projectId}/merge_requests/${mergerequestIId}/unsubscribe`,
+      options,
+    );
+  }
+
+  showReviewers<E extends boolean = false>(
+    projectId: string | number,
+    mergerequestIId: number,
+    options?: Sudo & ShowExpanded<E>,
+  ): Promise<GitlabAPIResponse<MergeRequestReviewerSchema[], C, E, void>> {
+    return RequestHelper.get<MergeRequestReviewerSchema[]>()(
+      this,
+      endpoint`projects/${projectId}/merge_requests/${mergerequestIId}/reviewers`,
       options,
     );
   }

--- a/packages/core/test/unit/resources/MergeRequests.ts
+++ b/packages/core/test/unit/resources/MergeRequests.ts
@@ -313,3 +313,15 @@ describe('MergeRequests.unsubscribe', () => {
     );
   });
 });
+
+describe('MergeRequests.showReviewers', () => {
+  it('should request GET projects/:id/merge_requests/:iid/reviewers', async () => {
+    await service.showReviewers(2, 3);
+
+    expect(RequestHelper.get()).toHaveBeenCalledWith(
+      service,
+      'projects/2/merge_requests/3/reviewers',
+      undefined,
+    );
+  });
+});


### PR DESCRIPTION
MergeRequests resource was missing "reviewers" API method which is the only place to get merge request review state

API Docs: https://archives.docs.gitlab.com/17.3/ee/api/merge_requests/#get-single-merge-request-reviewers