### PR TITLE
Improve webhook reviewer type definitions

### DIFF
--- a/packages/core/src/resources/MergeRequests.ts
+++ b/packages/core/src/resources/MergeRequests.ts
@@ -13,6 +13,7 @@ import type {
 import type { CommitDiffSchema, CommitSchema } from './Commits';
 import type { IssueSchema, TimeStatsSchema } from './Issues';
 import type { ExpandedPipelineSchema, PipelineSchema } from './Pipelines';
+import type { ReviewerState } from './Webhooks';
 import type { SimpleProjectSchema } from './Projects';
 import type { TodoSchema } from './TodoLists';
 import type { SimpleUserSchema } from './Users';
@@ -191,7 +192,7 @@ export interface MergeRequestChangesSchema
 
 export interface MergeRequestReviewerSchema extends Record<string, unknown> {
   user: MappedOmit<SimpleUserSchema, 'created_at'>;
-  state: 'unreviewed' | 'requested_changes' | 'reviewed' | 'approved' | 'review_started';
+  state: ReviewerState;
   created_at: string;
 }
 

--- a/packages/core/src/resources/Webhooks.ts
+++ b/packages/core/src/resources/Webhooks.ts
@@ -64,7 +64,16 @@ export interface WebhookDiffSchema {
   deleted_file: boolean;
 }
 
-export type WebhookUserSchema = Pick<SimpleUserSchema, 'id' | 'name' | 'username' | 'avatar_url'>;
+export type ReviewerState = 'unreviewed' | 'requested_changes' | 'reviewed' | 'approved' | 'review_started' | 'unapproved';
+
+export type WebhookUserSchema = Pick<SimpleUserSchema, 'id' | 'name' | 'username' | 'avatar_url'> & {
+  email: string;
+};
+
+export interface WebhookReviewerSchema extends WebhookUserSchema {
+  state: ReviewerState;
+  re_requested: boolean;
+}
 
 export interface BaseWebhookEventSchema {
   object_kind: string;
@@ -376,8 +385,8 @@ export interface WebhookMergeRequestEventSchema extends BaseWebhookEventSchema {
       current: WebhookUserSchema[] | null;
     };
     reviewers: {
-      previous: WebhookUserSchema[] | null;
-      current: WebhookUserSchema[] | null;
+      previous: WebhookReviewerSchema[] | null;
+      current: WebhookReviewerSchema[] | null;
     };
     labels: {
       previous: WebhookLabelSchema[] | null;
@@ -393,7 +402,7 @@ export interface WebhookMergeRequestEventSchema extends BaseWebhookEventSchema {
     };
   };
   assignees: WebhookUserSchema[] | null;
-  reviewers: WebhookUserSchema[] | null;
+  reviewers: WebhookReviewerSchema[] | null;
 }
 
 export interface WebhookWikiEventSchema extends MappedOmit<BaseWebhookEventSchema, 'event_name'> {


### PR DESCRIPTION
- Extract `ReviewerState` type to avoid duplication between `Webhooks` and `MergeRequests`
- Add `WebhookReviewerSchema` with proper `state` and `re_requested` fields
- Add `email` field to `WebhookUserSchema` based on actual webhook payloads
- Add missing `'unapproved'` state found in production webhooks
- Update `changes.reviewers` to use `WebhookReviewerSchema`

References:
- https://docs.gitlab.com/user/project/integrations/webhook_events/#reviewer-state-tracking
- https://docs.gitlab.com/user/project/integrations/webhook_events/#re-request-review-events