### PR TITLE
Add memberEvents option to AddResourceHookOptions

### DIFF
--- a/packages/core/src/templates/ResourceHooks.ts
+++ b/packages/core/src/templates/ResourceHooks.ts
@@ -37,6 +37,7 @@ export interface ExpandedHookSchema extends HookSchema {
 }
 
 export interface AddResourceHookOptions {
+  memberEvents?: boolean;
   pushEvents?: boolean;
   pushEventsBranchFilter?: string;
   issuesEvents?: boolean;


### PR DESCRIPTION
Adding the `memberEvents` option to group hooks
https://docs.gitlab.com/api/group_webhooks/#add-a-group-hook

If this isn't the correct place, would be happy to fix!