### PR TITLE
feat: Support inputs on pipeline creation

### DIFF
--- a/packages/core/src/resources/Pipelines.ts
+++ b/packages/core/src/resources/Pipelines.ts
@@ -155,7 +155,11 @@ export class Pipelines<C extends boolean = false> extends BaseResource<C> {
   create<E extends boolean = false>(
     projectId: string | number,
     ref: string,
-    options?: { variables?: PipelineVariableSchema[] } & Sudo & ShowExpanded<E>,
+    options?: {
+      variables?: PipelineVariableSchema[];
+      inputs?: Record<string, string>;
+    } & Sudo &
+      ShowExpanded<E>,
   ): Promise<GitlabAPIResponse<ExpandedPipelineSchema, C, E, void>> {
     return RequestHelper.post<ExpandedPipelineSchema>()(
       this,

--- a/packages/core/test/unit/resources/Pipelines.ts
+++ b/packages/core/test/unit/resources/Pipelines.ts
@@ -68,6 +68,10 @@ describe('Pipelines', () => {
             value: 'TEST',
           },
         ],
+        inputs: {
+          INPUT_1: 'value1',
+          INPUT_2: 'value2',
+        },
       };
 
       await service.create(projectId, ref, options);


### PR DESCRIPTION
Besides variables pipelines also have the option to use inputs. I needed this to work with my sub pipelines but since I changed this my automation broke that was triggering pipelines as I had to switch to using inputs instead of variables.