### PR TITLE
Fix codeql-analysis branch reference from `master` to `main`

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,10 +13,10 @@ name: 'CodeQL'
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [master]
+    branches: [main]
   schedule:
     - cron: '16 0 * * 4'
 


### PR DESCRIPTION
The CodeQL Analysis config is configured to run on the non-existent `master` branch, not `main`, so is not running on PRs.