### PR TITLE
feat: JobArtifacts.downloadArchive: Add support for search_recent_successful_pipelines with an artifact path

### DIFF
--- a/packages/core/src/infrastructure/Utils.ts
+++ b/packages/core/src/infrastructure/Utils.ts
@@ -141,7 +141,7 @@ export function getPrefixedUrl(
 
   const combinedPath = pathSegments.join('/');
 
-  return `${combinedPath}/${suffix}`;
+  return suffix ? `${combinedPath}/${suffix}` : combinedPath;
 }
 
 export function ensureRequiredParams(

--- a/packages/core/src/resources/JobArtifacts.ts
+++ b/packages/core/src/resources/JobArtifacts.ts
@@ -20,13 +20,19 @@ export class JobArtifacts<C extends boolean = false> extends BaseResource<C> {
         | { jobId: number; artifactPath?: undefined; job?: undefined; ref?: undefined }
         | { jobId: number; artifactPath: string; job?: undefined; ref?: undefined }
         | {
-            ref: string;
-            job: string;
             jobId?: undefined;
             artifactPath?: undefined;
+            job: string;
+            ref: string;
             searchRecentSuccessfulPipelines?: boolean;
           }
-        | { ref: string; job: string; artifactPath: string; jobId?: undefined }
+        | {
+            jobId?: undefined;
+            artifactPath: string;
+            job: string;
+            ref: string;
+            searchRecentSuccessfulPipelines?: boolean;
+          }
       ) = {} as any,
   ): Promise<GitlabAPIResponse<Blob, void, E, void>> {
     let url = '';

--- a/packages/core/test/unit/resources/Issues.ts
+++ b/packages/core/test/unit/resources/Issues.ts
@@ -181,7 +181,7 @@ describe('Issues.show', () => {
   it('should request GET /projects/:id/issues/:id', async () => {
     await service.show(1, { projectId: 2 });
 
-    expect(RequestHelper.get()).toHaveBeenLastCalledWith(service, 'projects/2/issues/1/', {
+    expect(RequestHelper.get()).toHaveBeenLastCalledWith(service, 'projects/2/issues/1', {
       searchParams: {},
       showExpanded: undefined,
       sudo: undefined,

--- a/packages/core/test/unit/resources/JobArtifacts.ts
+++ b/packages/core/test/unit/resources/JobArtifacts.ts
@@ -25,7 +25,7 @@ describe('JobArtifacts.downloadArchive', () => {
   it('should request GET /projects/:id/jobs/:job_id/artifacts, getting the job’s artifacts zipped archive of a project via private token', async () => {
     await service.downloadArchive(1, { jobId: 43 });
 
-    expect(RequestHelper.get()).toHaveBeenCalledWith(service, `projects/1/jobs/43/artifacts/`, {
+    expect(RequestHelper.get()).toHaveBeenCalledWith(service, `projects/1/jobs/43/artifacts`, {
       searchParams: {},
       showExpanded: undefined,
       sudo: undefined,
@@ -35,7 +35,7 @@ describe('JobArtifacts.downloadArchive', () => {
   it('should request GET /projects/:id/jobs/:job_id/artifacts, getting the job’s artifacts zipped archive of a project via jobToken parameter', async () => {
     await service.downloadArchive(1, { jobId: 43, jobToken: 'token' });
 
-    expect(RequestHelper.get()).toHaveBeenCalledWith(service, `projects/1/jobs/43/artifacts/`, {
+    expect(RequestHelper.get()).toHaveBeenCalledWith(service, `projects/1/jobs/43/artifacts`, {
       searchParams: {
         jobToken: 'token',
       },
@@ -49,7 +49,7 @@ describe('JobArtifacts.downloadArchive', () => {
 
     expect(RequestHelper.get()).toHaveBeenLastCalledWith(
       service,
-      `projects/1/jobs/artifacts/ref1/download/`,
+      `projects/1/jobs/artifacts/ref1/download`,
       {
         searchParams: {},
         showExpanded: undefined,
@@ -63,7 +63,7 @@ describe('JobArtifacts.downloadArchive', () => {
 
     expect(RequestHelper.get()).toHaveBeenLastCalledWith(
       service,
-      `projects/1/jobs/artifacts/ref1/download/`,
+      `projects/1/jobs/artifacts/ref1/download`,
       {
         searchParams: {
           jobToken: 'token',
@@ -79,7 +79,7 @@ describe('JobArtifacts.downloadArchive', () => {
 
     expect(RequestHelper.get()).toHaveBeenLastCalledWith(
       service,
-      `projects/1/jobs/43/artifacts/path/`,
+      `projects/1/jobs/43/artifacts/path`,
       {
         searchParams: {},
         showExpanded: undefined,
@@ -93,7 +93,7 @@ describe('JobArtifacts.downloadArchive', () => {
 
     expect(RequestHelper.get()).toHaveBeenLastCalledWith(
       service,
-      `projects/1/jobs/43/artifacts/path/`,
+      `projects/1/jobs/43/artifacts/path`,
       {
         searchParams: {
           jobToken: 'token',
@@ -109,7 +109,7 @@ describe('JobArtifacts.downloadArchive', () => {
 
     expect(RequestHelper.get()).toHaveBeenLastCalledWith(
       service,
-      `projects/1/jobs/artifacts/ref1/raw/path/`,
+      `projects/1/jobs/artifacts/ref1/raw/path`,
       {
         searchParams: {},
         showExpanded: undefined,
@@ -128,7 +128,7 @@ describe('JobArtifacts.downloadArchive', () => {
 
     expect(RequestHelper.get()).toHaveBeenLastCalledWith(
       service,
-      `projects/1/jobs/artifacts/ref1/raw/path/`,
+      `projects/1/jobs/artifacts/ref1/raw/path`,
       {
         searchParams: {
           jobToken: 'token',
@@ -148,7 +148,7 @@ describe('JobArtifacts.downloadArchive', () => {
 
     expect(RequestHelper.get()).toHaveBeenLastCalledWith(
       service,
-      `projects/1/jobs/artifacts/ref1/download/`,
+      `projects/1/jobs/artifacts/ref1/download`,
       {
         searchParams: {
           searchRecentSuccessfulPipelines: true,
@@ -171,8 +171,11 @@ describe('JobArtifacts.downloadArchive', () => {
       service,
       `projects/1/jobs/artifacts/ref1/raw/path`,
       {
-        job: 'job1',
-        searchRecentSuccessfulPipelines: true,
+        searchParams: {
+          searchRecentSuccessfulPipelines: true,
+        },
+        showExpanded: undefined,
+        sudo: undefined,
       },
     );
   });
@@ -190,9 +193,12 @@ describe('JobArtifacts.downloadArchive', () => {
       service,
       `projects/1/jobs/artifacts/ref1/raw/path`,
       {
-        job: 'job1',
-        jobToken: 'token',
-        searchRecentSuccessfulPipelines: true,
+        searchParams: {
+          jobToken: 'token',
+          searchRecentSuccessfulPipelines: true,
+        },
+        showExpanded: undefined,
+        sudo: undefined,
       },
     );
   });

--- a/packages/core/test/unit/resources/JobArtifacts.ts
+++ b/packages/core/test/unit/resources/JobArtifacts.ts
@@ -158,6 +158,44 @@ describe('JobArtifacts.downloadArchive', () => {
       },
     );
   });
+
+  it('should request GET /projects/:id/jobs/artifacts/:ref/raw/:artifact_path?job=:name&search_recent_successful_pipelines=true when searchRecentSuccessfulPipelines is true with artifactPath', async () => {
+    await service.downloadArchive(1, {
+      job: 'job1',
+      ref: 'ref1',
+      artifactPath: 'path',
+      searchRecentSuccessfulPipelines: true,
+    });
+
+    expect(RequestHelper.get()).toHaveBeenCalledWith(
+      service,
+      `projects/1/jobs/artifacts/ref1/raw/path`,
+      {
+        job: 'job1',
+        searchRecentSuccessfulPipelines: true,
+      },
+    );
+  });
+
+  it('should request GET /projects/:id/jobs/artifacts/:ref/raw/:artifact_path?job=:name&search_recent_successful_pipelines=true with artifactPath via job token', async () => {
+    await service.downloadArchive(1, {
+      job: 'job1',
+      ref: 'ref1',
+      artifactPath: 'path',
+      jobToken: 'token',
+      searchRecentSuccessfulPipelines: true,
+    });
+
+    expect(RequestHelper.get()).toHaveBeenCalledWith(
+      service,
+      `projects/1/jobs/artifacts/ref1/raw/path`,
+      {
+        job: 'job1',
+        jobToken: 'token',
+        searchRecentSuccessfulPipelines: true,
+      },
+    );
+  });
 });
 
 describe('JobArtifacts.keep', () => {

--- a/packages/core/test/unit/resources/Projects.ts
+++ b/packages/core/test/unit/resources/Projects.ts
@@ -154,7 +154,7 @@ describe('Projects.create', () => {
   it('should request POST /projects when userId undefined', async () => {
     await service.create({ name: 'test proj' });
 
-    expect(RequestHelper.post()).toHaveBeenLastCalledWith(service, 'projects/', {
+    expect(RequestHelper.post()).toHaveBeenLastCalledWith(service, 'projects', {
       body: {
         name: 'test proj',
       },
@@ -166,7 +166,7 @@ describe('Projects.create', () => {
   it('should request POST /projects/user/:id when userId defined', async () => {
     await service.create({ userId: 2, name: 'test proj' });
 
-    expect(RequestHelper.post()).toHaveBeenLastCalledWith(service, 'projects/user/2/', {
+    expect(RequestHelper.post()).toHaveBeenLastCalledWith(service, 'projects/user/2', {
       body: {
         name: 'test proj',
       },
@@ -184,7 +184,7 @@ describe('Projects.create', () => {
     expectedFormData.append('name', 'test proj');
     expectedFormData.append('avatar', content, 'image.jpeg');
 
-    expect(RequestHelper.post()).toHaveBeenLastCalledWith(service, 'projects/', {
+    expect(RequestHelper.post()).toHaveBeenLastCalledWith(service, 'projects', {
       body: expectedFormData,
       showExpanded: undefined,
       sudo: undefined,

--- a/packages/core/test/unit/resources/Runners.ts
+++ b/packages/core/test/unit/resources/Runners.ts
@@ -115,7 +115,7 @@ describe('Runners.remove', () => {
   it('should request DEL /runners/:id', async () => {
     await service.remove({ runnerId: 2 });
 
-    expect(RequestHelper.del()).toHaveBeenLastCalledWith(service, 'runners/2/', {
+    expect(RequestHelper.del()).toHaveBeenLastCalledWith(service, 'runners/2', {
       searchParams: {},
       showExpanded: undefined,
       sudo: undefined,
@@ -125,7 +125,7 @@ describe('Runners.remove', () => {
   it('should request DEL /runners with token', async () => {
     await service.remove({ token: 'token' });
 
-    expect(RequestHelper.del()).toHaveBeenLastCalledWith(service, 'runners/', {
+    expect(RequestHelper.del()).toHaveBeenLastCalledWith(service, 'runners', {
       searchParams: { token: 'token' },
       showExpanded: undefined,
       sudo: undefined,

--- a/packages/core/test/unit/resources/Snippets.ts
+++ b/packages/core/test/unit/resources/Snippets.ts
@@ -19,7 +19,7 @@ describe('Snippets.all', () => {
   it('should request GET /snippets', async () => {
     await service.all();
 
-    expect(RequestHelper.get()).toHaveBeenLastCalledWith(service, 'snippets/', {
+    expect(RequestHelper.get()).toHaveBeenLastCalledWith(service, 'snippets', {
       maxPages: undefined,
       searchParams: {},
       showExpanded: undefined,
@@ -30,7 +30,7 @@ describe('Snippets.all', () => {
   it('should request GET /snippets/public', async () => {
     await service.all({ public: true });
 
-    expect(RequestHelper.get()).toHaveBeenLastCalledWith(service, 'snippets/public/', {
+    expect(RequestHelper.get()).toHaveBeenLastCalledWith(service, 'snippets/public', {
       maxPages: undefined,
       searchParams: {},
       showExpanded: undefined,


### PR DESCRIPTION
Support for `search_recent_successful_pipelines` has now been added to the [download-a-single-artifact-file-by-reference-name](https://docs.gitlab.com/api/job_artifacts/#download-a-single-artifact-file-by-reference-name) endpoint in GitLab 18.9.

This PR adds support for this.

Related to: https://github.com/jdalrymple/gitbeaker/pull/3812
