### PR TITLE
fix: Ensure generated formdata properly decamelizes its properties where applicable

### DIFF
--- a/packages/core/src/infrastructure/Utils.ts
+++ b/packages/core/src/infrastructure/Utils.ts
@@ -1,5 +1,5 @@
 import { stringify } from 'picoquery';
-import { decamelizeKeys } from 'xcase';
+import { decamelizeKeys as decamelizeObjKeys } from 'xcase';
 
 export interface UserAgentDetailSchema extends Record<string, unknown> {
   user_agent: string;
@@ -96,22 +96,18 @@ export function parseLinkHeader(linkString: string): { next?: string; prev?: str
   return output;
 }
 
-export function reformatObjectOptions(
+export function normalizeFormData(
   obj: Record<string, unknown>,
-  prefixKey: string,
-  decamelizeValues = false,
+  { decamelizeKeys = true }: { decamelizeKeys?: boolean } = {},
 ): Record<string, string> {
-  const formatted = decamelizeValues ? decamelizeKeys(obj) : obj;
+  const source = decamelizeKeys ? decamelizeObjKeys(obj) : obj;
 
-  return stringify(
-    { [prefixKey]: formatted },
-    {
-      nesting: true,
-      nestingSyntax: 'index',
-      arrayRepeat: true,
-      arrayRepeatSyntax: 'bracket',
-    },
-  )
+  return stringify(source, {
+    nesting: true,
+    nestingSyntax: 'index',
+    arrayRepeat: true,
+    arrayRepeatSyntax: 'bracket',
+  })
     .split('&')
     .reduce((acc: Record<string, string>, cur: string) => {
       const [key, val] = cur.split(/=(.*)/);

--- a/packages/core/src/infrastructure/Utils.ts
+++ b/packages/core/src/infrastructure/Utils.ts
@@ -1,5 +1,5 @@
 import { stringify } from 'picoquery';
-import { decamelizeKeys as decamelizeObjKeys } from 'xcase';
+import { decamelizeKeys as decamelizeObjKeys, decamelize } from 'xcase';
 
 export interface UserAgentDetailSchema extends Record<string, unknown> {
   user_agent: string;
@@ -96,26 +96,50 @@ export function parseLinkHeader(linkString: string): { next?: string; prev?: str
   return output;
 }
 
+/*
+Since the formatting of formdata depends on the endpoint, a catch all solution within the requester utils would not work.
+*/
 export function normalizeFormData(
   obj: Record<string, unknown>,
   { decamelizeKeys = true }: { decamelizeKeys?: boolean } = {},
-): Record<string, string> {
-  const source = decamelizeKeys ? decamelizeObjKeys(obj) : obj;
+): Record<string, unknown> {
+  if (Object.keys(obj).length === 0) return {};
 
-  return stringify(source, {
-    nesting: true,
-    nestingSyntax: 'index',
-    arrayRepeat: true,
-    arrayRepeatSyntax: 'bracket',
-  })
-    .split('&')
-    .reduce((acc: Record<string, string>, cur: string) => {
+  const result: Record<string, unknown> = {};
+  const fileArrayEntries: [string, [Blob, string]][] = [];
+  const nonFileArrayObj: Record<string, unknown> = {};
+
+  // Split out Blob/File entries from main object
+  Object.entries(obj).forEach(([key, value]) => {
+    if (Array.isArray(value) && value.length === 2 && value[0] instanceof Blob) {
+      fileArrayEntries.push([key, value as [Blob, string]]);
+    } else {
+      nonFileArrayObj[key] = value;
+    }
+  });
+
+  // Process non-file-array values through decamelize and stringify
+  if (Object.keys(nonFileArrayObj).length > 0) {
+    const normObj = decamelizeKeys ? decamelizeObjKeys(nonFileArrayObj) : nonFileArrayObj;
+    const stringified = stringify(normObj, {
+      nesting: true,
+      nestingSyntax: 'index',
+    });
+
+    stringified.split('&').forEach((cur: string) => {
       const [key, val] = cur.split(/=(.*)/);
+      result[decodeURIComponent(key)] = decodeURIComponent(val);
+    });
+  }
 
-      acc[decodeURIComponent(key)] = decodeURIComponent(val);
+  // Add file arrays back with normalized keys
+  fileArrayEntries.forEach(([key, value]) => {
+    const normKey = decamelizeKeys ? decamelize(key) : key;
 
-      return acc;
-    }, {});
+    result[normKey] = value;
+  });
+
+  return result;
 }
 
 export function getPrefixedUrl(

--- a/packages/core/src/resources/AlertManagement.ts
+++ b/packages/core/src/resources/AlertManagement.ts
@@ -8,7 +8,7 @@ import type {
   Sudo,
 } from '../infrastructure';
 
-import { RequestHelper, createFormData, endpoint } from '../infrastructure';
+import { RequestHelper, createFormData, endpoint, normalizeFormData } from '../infrastructure';
 
 export interface MetricImageSchema extends Record<string, unknown> {
   id: number;
@@ -87,11 +87,13 @@ export class AlertManagement<C extends boolean = false> extends BaseResource<C> 
       {
         sudo,
         showExpanded,
-        body: createFormData({
-          file: [metricImage.content, metricImage.filename],
-          url: body?.url,
-          urlText: body?.urlText,
-        }),
+        body: createFormData(
+          normalizeFormData({
+            file: [metricImage.content, metricImage.filename],
+            url: body?.url,
+            urlText: body?.urlText,
+          }),
+        ),
       },
     );
   }

--- a/packages/core/src/resources/ApplicationAppearance.ts
+++ b/packages/core/src/resources/ApplicationAppearance.ts
@@ -7,7 +7,7 @@ import type {
   Sudo,
 } from '../infrastructure';
 
-import { RequestHelper, createFormData } from '../infrastructure';
+import { RequestHelper, createFormData, normalizeFormData } from '../infrastructure';
 
 export interface ApplicationAppearanceSchema extends Record<string, unknown> {
   title: string;
@@ -57,7 +57,7 @@ export class ApplicationAppearance<C extends boolean = false> extends BaseResour
       if (logo) formDataOpts.logo = [logo.content, logo.filename];
       if (pwaIcon) formDataOpts.pwaIcon = [pwaIcon.content, pwaIcon.filename];
 
-      body = createFormData(formDataOpts);
+      body = createFormData(normalizeFormData(formDataOpts));
     } else {
       body = remaining;
     }

--- a/packages/core/src/resources/GroupImportExports.ts
+++ b/packages/core/src/resources/GroupImportExports.ts
@@ -3,7 +3,7 @@ import { BaseResource } from '@gitbeaker/requester-utils';
 import type { AsStream, GitlabAPIResponse, ShowExpanded, Sudo } from '../infrastructure';
 import type { ImportStatusSchema } from './ProjectImportExports';
 
-import { RequestHelper, createFormData, endpoint } from '../infrastructure';
+import { RequestHelper, createFormData, endpoint, normalizeFormData } from '../infrastructure';
 
 export class GroupImportExports<C extends boolean = false> extends BaseResource<C> {
   download<E extends boolean = false>(
@@ -39,18 +39,19 @@ export class GroupImportExports<C extends boolean = false> extends BaseResource<
     path: string,
     { parentId, name, ...options }: { parentId?: number; name?: string } & ShowExpanded<E> & Sudo,
   ): Promise<GitlabAPIResponse<ImportStatusSchema, C, E, void>> {
-    const { sudo, showExpanded, ...body } = options || {};
+    const { sudo, showExpanded } = options || {};
 
     return RequestHelper.post<ImportStatusSchema>()(this, 'groups/import', {
       sudo,
       showExpanded,
-      body: createFormData({
-        ...body,
-        file: [file.content, file.filename],
-        path,
-        name: name || path.split('/').at(0),
-        parentId,
-      }),
+      body: createFormData(
+        normalizeFormData({
+          file: [file.content, file.filename],
+          path,
+          name: name || path.split('/').at(0),
+          parentId,
+        }),
+      ),
     });
   }
 

--- a/packages/core/src/resources/Groups.ts
+++ b/packages/core/src/resources/Groups.ts
@@ -15,7 +15,7 @@ import type { CondensedProjectSchema, ProjectSchema } from './Projects';
 import type { SimpleUserSchema } from './Users';
 
 import { AccessLevel } from '../constants';
-import { RequestHelper, createFormData, endpoint } from '../infrastructure';
+import { RequestHelper, createFormData, endpoint, normalizeFormData } from '../infrastructure';
 
 export interface GroupStatisticsSchema {
   storage_size: number;
@@ -461,12 +461,14 @@ export class Groups<C extends boolean = false> extends BaseResource<C> {
       sudo,
       showExpanded,
       body: avatar
-        ? createFormData({
-            ...body,
-            name,
-            path,
-            avatar: [avatar.content, avatar.filename],
-          })
+        ? createFormData(
+            normalizeFormData({
+              ...body,
+              name,
+              path,
+              avatar: [avatar.content, avatar.filename],
+            }),
+          )
         : {
             ...body,
             name,
@@ -497,10 +499,12 @@ export class Groups<C extends boolean = false> extends BaseResource<C> {
       sudo,
       showExpanded,
       body: avatar
-        ? createFormData({
-            ...body,
-            avatar: [avatar.content, avatar.filename],
-          })
+        ? createFormData(
+            normalizeFormData({
+              ...body,
+              avatar: [avatar.content, avatar.filename],
+            }),
+          )
         : body,
     });
   }
@@ -632,10 +636,12 @@ export class Groups<C extends boolean = false> extends BaseResource<C> {
     return RequestHelper.put<{ avatar_url: string }>()(this, endpoint`groups/${groupId}/avatar`, {
       sudo,
       showExpanded,
-      body: createFormData({
-        ...body,
-        file: [content, filename],
-      }),
+      body: createFormData(
+        normalizeFormData({
+          ...body,
+          file: [content, filename],
+        }),
+      ),
     });
   }
 }

--- a/packages/core/src/resources/Helm.ts
+++ b/packages/core/src/resources/Helm.ts
@@ -40,7 +40,7 @@ export class Helm<C extends boolean = false> extends BaseResource<C> {
     chart: { content: Blob; filename: string },
     options?: ShowExpanded<E> & Sudo,
   ): Promise<GitlabAPIResponse<void, C, E, void>> {
-    const { sudo, showExpanded, ...body } = options || {};
+    const { sudo, showExpanded } = options || {};
 
     return RequestHelper.post<void>()(
       this,
@@ -49,7 +49,6 @@ export class Helm<C extends boolean = false> extends BaseResource<C> {
         sudo,
         showExpanded,
         body: createFormData({
-          ...body,
           chart,
         }),
       },

--- a/packages/core/src/resources/Issues.ts
+++ b/packages/core/src/resources/Issues.ts
@@ -26,6 +26,7 @@ import {
   endpoint,
   ensureRequiredParams,
   getPrefixedUrl,
+  normalizeFormData,
 } from '../infrastructure';
 
 export interface TimeStatsSchema extends Record<string, unknown> {

--- a/packages/core/src/resources/Issues.ts
+++ b/packages/core/src/resources/Issues.ts
@@ -634,10 +634,12 @@ export class Issues<C extends boolean = false> extends BaseResource<C> {
       {
         sudo,
         showExpanded,
-        body: createFormData({
-          ...body,
-          file: [metricImage.content, metricImage.filename],
-        }),
+        body: createFormData(
+          normalizeFormData({
+            ...body,
+            file: [metricImage.content, metricImage.filename],
+          }),
+        ),
       },
     );
   }

--- a/packages/core/src/resources/NuGet.ts
+++ b/packages/core/src/resources/NuGet.ts
@@ -8,6 +8,7 @@ import {
   endpoint,
   ensureRequiredParams,
   getPrefixedUrl,
+  normalizeFormData,
 } from '../infrastructure';
 
 export interface NuGetPackageIndexSchema extends Record<string, unknown> {
@@ -197,12 +198,14 @@ export class NuGet<C extends boolean = false> extends BaseResource<C> {
 
     return RequestHelper.put<void>()(this, endpoint`projects/${projectId}/packages/nuget`, {
       showExpanded,
-      body: createFormData({
-        ...body,
-        packageName,
-        packageVersion,
-        file: [packageFile.content, packageFile.filename],
-      }),
+      body: createFormData(
+        normalizeFormData({
+          ...body,
+          packageName,
+          packageVersion,
+          file: [packageFile.content, packageFile.filename],
+        }),
+      ),
     });
   }
 
@@ -220,12 +223,14 @@ export class NuGet<C extends boolean = false> extends BaseResource<C> {
       endpoint`projects/${projectId}/packages/nuget/symbolpackage`,
       {
         showExpanded,
-        body: createFormData({
-          ...body,
-          packageName,
-          packageVersion,
-          file: [packageFile.content, packageFile.filename],
-        }),
+        body: createFormData(
+          normalizeFormData({
+            ...body,
+            packageName,
+            packageVersion,
+            file: [packageFile.content, packageFile.filename],
+          }),
+        ),
       },
     );
   }

--- a/packages/core/src/resources/PipelineTriggerTokens.ts
+++ b/packages/core/src/resources/PipelineTriggerTokens.ts
@@ -14,7 +14,7 @@ import type {
 import type { ExpandedPipelineSchema } from './Pipelines';
 import type { SimpleUserSchema } from './Users';
 
-import { RequestHelper, createFormData, endpoint, reformatObjectOptions } from '../infrastructure';
+import { RequestHelper, createFormData, endpoint, normalizeFormData } from '../infrastructure';
 
 export interface PipelineTriggerTokenSchema extends Record<string, unknown> {
   id: number;
@@ -134,7 +134,9 @@ export class PipelineTriggerTokens<C extends boolean = false> extends BaseResour
           token,
           ref,
         },
-        body: variables ? createFormData(reformatObjectOptions(variables, 'variables')) : undefined,
+        body: variables
+          ? createFormData(normalizeFormData({ variables }, { decamelizeKeys: false }))
+          : undefined,
       },
     );
   }

--- a/packages/core/src/resources/ProjectImportExports.ts
+++ b/packages/core/src/resources/ProjectImportExports.ts
@@ -2,7 +2,7 @@ import { BaseResource } from '@gitbeaker/requester-utils';
 
 import type { AsStream, GitlabAPIResponse, ShowExpanded, Sudo } from '../infrastructure';
 
-import { RequestHelper, createFormData, endpoint } from '../infrastructure';
+import { RequestHelper, createFormData, endpoint, normalizeFormData } from '../infrastructure';
 
 export interface ExportStatusSchema extends Record<string, unknown> {
   id: number;
@@ -86,11 +86,13 @@ export class ProjectImportExports<C extends boolean = false> extends BaseResourc
     return RequestHelper.post<ImportStatusSchema>()(this, 'projects/import', {
       sudo,
       showExpanded,
-      body: createFormData({
-        ...body,
-        file: [file.content, file.filename],
-        path,
-      }),
+      body: createFormData(
+        normalizeFormData({
+          ...body,
+          file: [file.content, file.filename],
+          path,
+        }),
+      ),
     });
   }
 

--- a/packages/core/src/resources/ProjectMarkdownUploads.ts
+++ b/packages/core/src/resources/ProjectMarkdownUploads.ts
@@ -10,6 +10,7 @@ import {
   type Sudo,
   createFormData,
   endpoint,
+  normalizeFormData,
 } from '../infrastructure';
 import {
   MarkdownUploadCreatedSchema,
@@ -73,10 +74,12 @@ export class ProjectMarkdownUploads<C extends boolean = false> extends ResourceM
     return RequestHelper.post<MarkdownUploadCreatedSchema>()(this, endpoint`${projectId}/uploads`, {
       sudo,
       showExpanded,
-      body: createFormData({
-        ...body,
-        file: [file.content, file.filename],
-      }),
+      body: createFormData(
+        normalizeFormData({
+          ...body,
+          file: [file.content, file.filename],
+        }),
+      ),
     });
   }
 }

--- a/packages/core/src/resources/Projects.ts
+++ b/packages/core/src/resources/Projects.ts
@@ -19,7 +19,13 @@ import type { ProjectRemoteMirrorSchema } from './ProjectRemoteMirrors';
 import type { SimpleUserSchema } from './Users';
 
 import { AccessLevel } from '../constants';
-import { RequestHelper, createFormData, endpoint, getPrefixedUrl } from '../infrastructure';
+import {
+  RequestHelper,
+  createFormData,
+  endpoint,
+  getPrefixedUrl,
+  normalizeFormData,
+} from '../infrastructure';
 
 export type AccessLevelSettingState = 'disabled' | 'enabled' | 'private';
 
@@ -693,10 +699,12 @@ export class Projects<C extends boolean = false> extends BaseResource<C> {
       sudo,
       showExpanded,
       body: avatar
-        ? createFormData({
-            ...body,
-            avatar: [avatar.content, avatar.filename],
-          })
+        ? createFormData(
+            normalizeFormData({
+              ...body,
+              avatar: [avatar.content, avatar.filename],
+            }),
+          )
         : body,
     });
   }
@@ -770,10 +778,12 @@ export class Projects<C extends boolean = false> extends BaseResource<C> {
         sudo,
         showExpanded,
         body: avatar
-          ? createFormData({
-              ...body,
-              avatar: [avatar.content, avatar.filename],
-            })
+          ? createFormData(
+              normalizeFormData({
+                ...body,
+                avatar: [avatar.content, avatar.filename],
+              }),
+            )
           : body,
       },
     });

--- a/packages/core/src/resources/Topics.ts
+++ b/packages/core/src/resources/Topics.ts
@@ -15,6 +15,7 @@ import {
   RequestHelper,
   createFormData,
   endpoint,
+  normalizeFormData,
 } from '../infrastructure';
 
 export interface TopicSchema extends Record<string, unknown> {
@@ -58,11 +59,13 @@ export class Topics<C extends boolean = false> extends BaseResource<C> {
       sudo,
       showExpanded,
       body: avatar
-        ? createFormData({
-            ...body,
-            name,
-            avatar: [avatar.content, avatar.filename],
-          })
+        ? createFormData(
+            normalizeFormData({
+              ...body,
+              name,
+              avatar: [avatar.content, avatar.filename],
+            }),
+          )
         : body,
     });
   }
@@ -86,10 +89,12 @@ export class Topics<C extends boolean = false> extends BaseResource<C> {
       sudo,
       showExpanded,
       body: avatar
-        ? createFormData({
-            ...body,
-            avatar: [avatar.content, avatar.filename],
-          })
+        ? createFormData(
+            normalizeFormData({
+              ...body,
+              avatar: [avatar.content, avatar.filename],
+            }),
+          )
         : body,
     });
   }

--- a/packages/core/src/resources/Users.ts
+++ b/packages/core/src/resources/Users.ts
@@ -22,6 +22,7 @@ import {
   createFormData,
   endpoint,
   getPrefixedUrl,
+  normalizeFormData,
 } from '../infrastructure';
 
 export interface AsAdmin<A extends boolean = false> {
@@ -648,10 +649,12 @@ export class Users<C extends boolean = false> extends BaseResource<C> {
       sudo,
       showExpanded,
       body: avatar
-        ? createFormData({
-            ...body,
-            avatar: [avatar.content, avatar.filename],
-          })
+        ? createFormData(
+            normalizeFormData({
+              ...body,
+              avatar: [avatar.content, avatar.filename],
+            }),
+          )
         : body,
     });
   }

--- a/packages/core/src/templates/ResourceDiscussions.ts
+++ b/packages/core/src/templates/ResourceDiscussions.ts
@@ -17,7 +17,7 @@ import type {
 } from '../infrastructure';
 import type { SimpleUserSchema } from '../resources/Users';
 
-import { RequestHelper, createFormData, endpoint, reformatObjectOptions } from '../infrastructure';
+import { RequestHelper, createFormData, endpoint, normalizeFormData } from '../infrastructure';
 
 export interface DiscussionNotePositionBaseSchema extends Record<string, unknown> {
   base_sha: string;
@@ -155,11 +155,13 @@ export class ResourceDiscussions<C extends boolean = false> extends BaseResource
         sudo,
         showExpanded,
         body: position
-          ? createFormData({
-              ...bodyOptions,
-              body,
-              ...reformatObjectOptions(position, 'position', true),
-            })
+          ? createFormData(
+              normalizeFormData({
+                ...bodyOptions,
+                body,
+                position,
+              }),
+            )
           : {
               ...bodyOptions,
               body,

--- a/packages/core/src/templates/ResourceWikis.ts
+++ b/packages/core/src/templates/ResourceWikis.ts
@@ -14,7 +14,7 @@ import type {
   Sudo,
 } from '../infrastructure';
 
-import { RequestHelper, createFormData, endpoint } from '../infrastructure';
+import { RequestHelper, createFormData, endpoint, normalizeFormData } from '../infrastructure';
 
 export interface WikiSchema extends Record<string, unknown> {
   content: string;
@@ -146,10 +146,12 @@ export class ResourceWikis<C extends boolean = false> extends BaseResource<C> {
       {
         sudo,
         showExpanded,
-        body: createFormData({
-          ...body,
-          file: [file.content, file.filename],
-        }),
+        body: createFormData(
+          normalizeFormData({
+            ...body,
+            file: [file.content, file.filename],
+          }),
+        ),
       },
     );
   }

--- a/packages/core/test/unit/infrastructure/Utils.ts
+++ b/packages/core/test/unit/infrastructure/Utils.ts
@@ -313,6 +313,28 @@ describe('ensureRequiredParams', () => {
 });
 
 describe('normalizeFormData', () => {
+  it('should return empty object for empty input', () => {
+    const result = normalizeFormData({});
+
+    expect(result).toEqual({});
+  });
+
+  it('should maintain array property values, while still decamelizing their keys', () => {
+    const content = new Blob(['test'], { type: 'text/plain' });
+    const input = {
+      fileUpload: [content, 'test.txt'],
+      userName: 'john',
+      pwaIcon: [content, 'icon.png'],
+    };
+    const result = normalizeFormData(input);
+
+    expect(result).toEqual({
+      file_upload: [content, 'test.txt'],
+      user_name: 'john',
+      pwa_icon: [content, 'icon.png'],
+    });
+  });
+
   it('should convert keys to snake_case by default', () => {
     const input = { firstName: 'John', lastName: 'Doe', userId: 123 };
     const result = normalizeFormData(input);

--- a/packages/core/test/unit/infrastructure/Utils.ts
+++ b/packages/core/test/unit/infrastructure/Utils.ts
@@ -6,9 +6,10 @@ import {
   endpoint,
   ensureRequiredParams,
   getPrefixedUrl,
+  normalizeFormData,
   parseLinkHeader,
-  reformatObjectOptions,
 } from '../../../src/infrastructure';
+
 describe('createFormData', () => {
   it('should convert object key/values to formdata instance', () => {
     const data = { a: 5, b: 'test' };
@@ -104,56 +105,6 @@ describe('endpoint', () => {
     const url = endpoint`/projects/${projectPath}/something/${rawSegment}/items/${finalId}`;
 
     expect(url).toBe('/projects/group%2Fproject/something/raw/path/items/456');
-  });
-});
-
-describe('reformatObjectOptions', () => {
-  it('should convert simple nested object to be query parameter friendly', () => {
-    const data = {
-      a: {
-        b: 'test',
-      },
-    };
-
-    const formatted = reformatObjectOptions(data, 'test');
-
-    expect(formatted).toMatchObject({ 'test[a][b]': 'test' });
-  });
-
-  it('should convert nested object with "=" characters in the value', () => {
-    const data = {
-      a: {
-        b: '=5',
-      },
-    };
-
-    const formatted = reformatObjectOptions(data, 'test');
-
-    expect(formatted).toMatchObject({ 'test[a][b]': '=5' });
-  });
-
-  it('should not decamelize keys when decamelizeValues is false', () => {
-    const data = {
-      camelCaseKey: {
-        anotherCamelCase: 'test',
-      },
-    };
-
-    const formatted = reformatObjectOptions(data, 'test', false);
-
-    expect(formatted).toMatchObject({ 'test[camelCaseKey][anotherCamelCase]': 'test' });
-  });
-
-  it('should decamelize keys when decamelizeValues is true', () => {
-    const data = {
-      camelCaseKey: {
-        anotherCamelCase: 'test',
-      },
-    };
-
-    const formatted = reformatObjectOptions(data, 'test', true);
-
-    expect(formatted).toMatchObject({ 'test[camel_case_key][another_camel_case]': 'test' });
   });
 });
 
@@ -358,5 +309,82 @@ describe('ensureRequiredParams', () => {
     expect(() => ensureRequiredParams(params)).toThrow(
       'Missing required argument. Please supply a  in the options parameter.',
     );
+  });
+});
+
+describe('normalizeFormData', () => {
+  it('should convert keys to snake_case by default', () => {
+    const input = { firstName: 'John', lastName: 'Doe', userId: 123 };
+    const result = normalizeFormData(input);
+
+    expect(result).toEqual({
+      first_name: 'John',
+      last_name: 'Doe',
+      user_id: '123',
+    });
+  });
+
+  it('should preserve keys when decamelizeKeys is false', () => {
+    const input = { firstName: 'John', lastName: 'Doe', userId: 123 };
+    const result = normalizeFormData(input, { decamelizeKeys: false });
+
+    expect(result).toEqual({
+      firstName: 'John',
+      lastName: 'Doe',
+      userId: '123',
+    });
+  });
+
+  it('should handle arrays with bracket notation', () => {
+    const input = { tags: ['javascript', 'typescript'], items: [1, 2, 3] };
+    const result = normalizeFormData(input);
+
+    expect(result).toEqual({
+      'tags[0]': 'javascript',
+      'tags[1]': 'typescript',
+      'items[0]': '1',
+      'items[1]': '2',
+      'items[2]': '3',
+    });
+  });
+
+  it('should handle nested objects with index notation', () => {
+    const input = {
+      user: {
+        name: 'John',
+        profile: {
+          age: 30,
+          city: 'New York',
+        },
+      },
+    };
+    const result = normalizeFormData(input);
+
+    expect(result).toEqual({
+      'user[name]': 'John',
+      'user[profile][age]': '30',
+      'user[profile][city]': 'New York',
+    });
+  });
+
+  it('should handle mixed nested structures', () => {
+    const input = {
+      userDetails: {
+        preferences: ['dark', 'notifications'],
+        metadata: {
+          created: '2023-01-01',
+          tags: ['premium', 'verified'],
+        },
+      },
+    };
+    const result = normalizeFormData(input);
+
+    expect(result).toEqual({
+      'user_details[preferences][0]': 'dark',
+      'user_details[preferences][1]': 'notifications',
+      'user_details[metadata][created]': '2023-01-01',
+      'user_details[metadata][tags][0]': 'premium',
+      'user_details[metadata][tags][1]': 'verified',
+    });
   });
 });

--- a/packages/core/test/unit/resources/AlertManagement.ts
+++ b/packages/core/test/unit/resources/AlertManagement.ts
@@ -69,8 +69,8 @@ describe('Agents.uploadMetricImage', () => {
     await service.uploadMetricImage(1, 2, image, { urlText: 'text' });
 
     const expectedFormData = new FormData();
+    expectedFormData.append('url_text', 'text');
     expectedFormData.append('file', content, 'image.jpeg');
-    expectedFormData.append('urlText', 'text');
 
     expect(RequestHelper.post()).toHaveBeenCalledWith(
       service,

--- a/packages/core/test/unit/resources/ApplicationAppearance.ts
+++ b/packages/core/test/unit/resources/ApplicationAppearance.ts
@@ -61,7 +61,7 @@ describe('ApplicationAppearance.edit', () => {
     await service.edit({ pwaIcon: { content, filename: 'test.jpeg' } });
 
     const expectedFormData = new FormData();
-    expectedFormData.append('pwaIcon', content, 'test.jpeg');
+    expectedFormData.append('pwa_icon', content, 'test.jpeg');
 
     expect(RequestHelper.put()).toHaveBeenCalledWith(service, 'application/appearance', {
       body: expectedFormData,

--- a/packages/core/test/unit/resources/GroupImportExports.ts
+++ b/packages/core/test/unit/resources/GroupImportExports.ts
@@ -49,9 +49,9 @@ describe('GroupImportExport.import', () => {
     await service.import({ content, filename: 'test.tar.gz' }, 'path', { name: 'test' });
 
     const expectedFormData = new FormData();
-    expectedFormData.append('file', new File([content], 'test.tar.gz', { type: content.type }));
     expectedFormData.append('path', 'path');
     expectedFormData.append('name', 'test');
+    expectedFormData.append('file', new File([content], 'test.tar.gz', { type: content.type }));
 
     expect(RequestHelper.post()).toHaveBeenLastCalledWith(service, 'groups/import', {
       body: expectedFormData,

--- a/packages/core/test/unit/resources/ProjectImportExports.ts
+++ b/packages/core/test/unit/resources/ProjectImportExports.ts
@@ -59,8 +59,8 @@ describe('ProjectImportExport.import', () => {
 
     const expectedFormData = new FormData();
     expectedFormData.append('name', 'test');
-    expectedFormData.append('file', new File([content], 'test.tar.gz', { type: content.type }));
     expectedFormData.append('path', 'path');
+    expectedFormData.append('file', new File([content], 'test.tar.gz', { type: content.type }));
 
     expect(RequestHelper.post()).toHaveBeenLastCalledWith(service, 'projects/import', {
       body: expectedFormData,

--- a/packages/rest/test/e2e/nodejs/resources/Lint.ts
+++ b/packages/rest/test/e2e/nodejs/resources/Lint.ts
@@ -31,7 +31,12 @@ describe('Lint.lint', () => {
 
     expect(result).toMatchObject({
       valid: true,
-      merged_yaml: '',
+      merged_yaml: `---
+test:
+  stage: test
+  script:
+  - echo 1
+`,
     });
   });
 });

--- a/packages/rest/test/e2e/nodejs/resources/Projects.ts
+++ b/packages/rest/test/e2e/nodejs/resources/Projects.ts
@@ -77,10 +77,10 @@ describe('Projects.uploadForReference', () => {
     });
 
     expect(results).toMatchObject({
-      alt: '',
-      url: '',
-      full_path: '',
-      markdown: '',
+      alt: 'testfile.txt',
+      url: expect.stringMatching(/\/uploads\/[a-f0-9]+\/testfile\.txt$/),
+      full_path: expect.stringMatching(/\/uploads\/[a-f0-9]+\/testfile\.txt$/),
+      markdown: expect.stringMatching(/\[testfile\.txt\]\(\/uploads\/[a-f0-9]+\/testfile\.txt\)/),
     });
   });
 });


### PR DESCRIPTION
## Summary
When we create form data using the `createFormData` command, we have forgotten that it does not have its internals decamelized like standard body arguments. This results in form data submissions having the wrong field name and eventually breaking things down the line.

This PR ensures that all the content passed to `createFormdata` follows a specific format:

1. keys are decamelized by default (configurable)
2. nested objects are query formatted like: key[nested_key]: value