### PR TITLE
feat: Update MergeRequestDiscussions to use MergeRequestDiscussionSchema for type consistency

### DIFF
--- a/packages/core/src/resources/MergeRequestDiscussions.ts
+++ b/packages/core/src/resources/MergeRequestDiscussions.ts
@@ -25,6 +25,10 @@ export interface MergeRequestDiscussionNoteSchema extends DiscussionNoteSchema {
   position?: DiscussionNotePositionSchema;
 }
 
+export interface MergeRequestDiscussionSchema extends DiscussionSchema {
+  notes?: MergeRequestDiscussionNoteSchema[];
+}
+
 export type MergeRequestDiscussionNotePositionOptions = {
   lineRange?: {
     start?: {
@@ -51,7 +55,7 @@ export interface MergeRequestDiscussions<C extends boolean = false> extends Reso
     projectId: string | number,
     mergerequestId: string | number,
     options?: BaseRequestSearchParams & PaginationRequestOptions<P> & ShowExpanded<E> & Sudo,
-  ): Promise<GitlabAPIResponse<DiscussionSchema[], C, E, P>>;
+  ): Promise<GitlabAPIResponse<MergeRequestDiscussionSchema[], C, E, P>>;
 
   create<E extends boolean = false>(
     projectId: string | number,
@@ -63,7 +67,7 @@ export interface MergeRequestDiscussions<C extends boolean = false> extends Reso
       createdAt?: string;
     } & ShowExpanded<E> &
       Sudo,
-  ): Promise<GitlabAPIResponse<DiscussionSchema, C, E, void>>;
+  ): Promise<GitlabAPIResponse<MergeRequestDiscussionSchema, C, E, void>>;
 
   editNote<E extends boolean = false>(
     projectId: string | number,
@@ -87,14 +91,14 @@ export interface MergeRequestDiscussions<C extends boolean = false> extends Reso
     discussionId: string,
     resolve: boolean,
     options?: ShowExpanded<E> & Sudo,
-  ): Promise<GitlabAPIResponse<DiscussionSchema, C, E, void>>;
+  ): Promise<GitlabAPIResponse<MergeRequestDiscussionSchema, C, E, void>>;
 
   show<E extends boolean = false>(
     projectId: string | number,
     mergerequestId: string | number,
     discussionId: string,
     options?: ShowExpanded<E> & Sudo,
-  ): Promise<GitlabAPIResponse<DiscussionSchema, C, E, void>>;
+  ): Promise<GitlabAPIResponse<MergeRequestDiscussionSchema, C, E, void>>;
 }
 
 export class MergeRequestDiscussions<C extends boolean = false> extends ResourceDiscussions<C> {
@@ -109,10 +113,10 @@ export class MergeRequestDiscussions<C extends boolean = false> extends Resource
     discussionId: string,
     resolved: boolean,
     options?: ShowExpanded<E> & Sudo,
-  ): Promise<GitlabAPIResponse<DiscussionSchema, C, E, void>> {
+  ): Promise<GitlabAPIResponse<MergeRequestDiscussionSchema, C, E, void>> {
     const { sudo, showExpanded } = options || {};
 
-    return RequestHelper.put<DiscussionSchema>()(
+    return RequestHelper.put<MergeRequestDiscussionSchema>()(
       this,
       endpoint`${projectId}/merge_requests/${mergerequestId}/discussions/${discussionId}`,
       {


### PR DESCRIPTION
Changes:

- Adds a new `MergeRequestDiscussionSchema` that extends `DiscussionSchema` with `notes?: MergeRequestDiscussionNoteSchema[]`, so MR-specific note fields (`resolved_by`, `resolved_at`, `position`) are surfaced through the typed API.
- Updates `MergeRequestDiscussions.all`, `create`, `resolve`, and `show` (both interface and class) to return `MergeRequestDiscussionSchema` instead of the generic `DiscussionSchema`.

Per the GitLab MR Discussions API docs, notes returned from MR discussion endpoints include resolution metadata (`resolved_by`, `resolved_at`) and diff `position` data that aren't present on notes from other discussion resources. The library already modeled this via `MergeRequestDiscussionNoteSchema`, but the discussion-returning methods still typed their result as `DiscussionSchema`, so consumers like:

```ts
const discussions = await gitlab.MergeRequestDiscussions.all(projectId, mergeRequestIid);
```

only saw the generic `DiscussionNoteSchema` on `discussions[].notes`. This PR threads the MR-specific schema through so the types match the actual response shape.