### PR TITLE
feat: Add system and system_action to WebhookMergeRequestEventSchema

### DIFF
--- a/packages/core/src/resources/Webhooks.ts
+++ b/packages/core/src/resources/Webhooks.ts
@@ -72,6 +72,10 @@ export type ReviewerState =
   | 'review_started'
   | 'unapproved';
 
+export type MergeRequestSystemAction =
+  | 'approvals_reset_on_push'
+  | 'code_owner_approvals_reset_on_push';
+
 export type WebhookUserSchema = {
   email: string;
 } & Pick<SimpleUserSchema, 'id' | 'name' | 'username' | 'avatar_url'>;
@@ -367,6 +371,8 @@ export interface WebhookMergeRequestEventSchema extends BaseWebhookEventSchema {
     labels: WebhookLabelSchema[] | null;
     action: string;
     detailed_merge_status: string;
+    system: boolean;
+    system_action?: MergeRequestSystemAction;
   };
   labels: WebhookLabelSchema[] | null;
   changes: {


### PR DESCRIPTION
GitLab merge request webhooks include `object_attributes.system` (always present) and `object_attributes.system_action` (present only on system-initiated events, e.g. approval resets on push), but neither is declared on `WebhookMergeRequestEventSchema`. This PR adds both.

- `system: boolean` mirrors the existing `system: boolean` already present in the note webhook schemas.
- `system_action?` is an optional, documented two-value union (`approvals_reset_on_push` | `code_owner_approvals_reset_on_push`), exposed as an exported `MergeRequestSystemAction` type mirroring the neighbouring `ReviewerState` type.

Ref: [GitLab webhook events — merge request events](https://docs.gitlab.com/user/project/integrations/webhook_events/#merge-request-events)