### PR TITLE
chore: Ship ESM distributable only

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -570,8 +570,8 @@ workflows:
 
       # Unit tests (matrix approach)
       - run-package-tests:
-          name: test-unit-<< matrix.package_short >>
           matrix:
+            alias: [utils, core, rest, cli]
             parameters:
               package:
                 [
@@ -580,35 +580,35 @@ workflows:
                   '@gitbeaker/rest',
                   '@gitbeaker/cli',
                 ]
-              package_short: ['utils', 'core', 'rest', 'cli']
+          name: test-unit-<< matrix.alias >>
           package: << matrix.package >>
           test_type: 'unit'
           requires: [install]
 
       # Type tests (matrix approach)
       - run-package-tests:
-          name: test-types-<< matrix.package_short >>
           matrix:
+            alias: [utils, core, rest]
             parameters:
               package: ['@gitbeaker/requester-utils', '@gitbeaker/core', '@gitbeaker/rest']
-              package_short: ['utils', 'core', 'rest']
+          name: test-types-<< matrix.alias >>
           package: << matrix.package >>
           test_type: 'types'
           requires: [build]
 
       # Integration tests (matrix approach)
       - run-package-tests:
-          name: test-integration-<< matrix.package_short >>
           matrix:
+            alias: [rest, core]
             parameters:
               package: ['@gitbeaker/rest', '@gitbeaker/core']
-              package_short: ['rest', 'core']
               executor_type: ['playwright-executor', 'node-executor']
             exclude:
               - package: '@gitbeaker/core'
                 executor_type: 'playwright-executor'
               - package: '@gitbeaker/rest'
                 executor_type: 'node-executor'
+          name: test-integration-<< matrix.alias >>
           package: << matrix.package >>
           test_type: 'integration'
           executor_type: << matrix.executor_type >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -292,7 +292,7 @@ jobs:
             envsubst < scripts/startup.sh > scripts/startup_filled.sh
 
             # Create GCP instance with custom GitLab-ready image and auto-expiry
-            echo "Creating GCP instance using image: ${GITLAB_IMAGE_NAME}"
+            echo "Creating GCP instance '$CONTAINER_NAME' using image: ${GITLAB_IMAGE_NAME}"
             GCLOUD_OUTPUT=$(gcloud compute instances create $CONTAINER_NAME \
               --project gitbeaker \
               --machine-type=$GITLAB_MACHINE_TYPE \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,10 +9,10 @@ orbs:
 # ====================
 # ENVIRONMENT VARIABLES
 # ====================
-# Note: GITLAB_VERSION is fixed by the custom image (gitlab-ready-image-16) to 16.11.10-ce.0
+# Note: Custom image gitlab-ready-image-[major-version] will be created automatically if it doesn't exist
 x-environment: &default_environment
   GCP_ZONE: us-central1-c
-  GITLAB_VERSION: 16.11.10-ce.0 # Fixed by custom image
+  GITLAB_VERSION: 19.2.0-ce.0 # Custom image will be created automatically
   GITLAB_MACHINE_TYPE: e2-standard-4
   GITLAB_PERSONAL_ACCESS_TOKEN: gitbeaker
   GITLAB_ROOT_PASSWORD: gitbeaker
@@ -23,7 +23,7 @@ x-environment: &default_environment
 executors:
   node-executor:
     docker:
-      - image: cimg/node:22.22.2
+      - image: cimg/node:24.18.0
     resource_class: medium
     working_directory: ~/project
 
@@ -35,7 +35,7 @@ executors:
 
   gcp-executor:
     docker:
-      - image: cimg/gcp:2025.01
+      - image: cimg/gcp:2026.07.1
     resource_class: small
     working_directory: ~/project
 
@@ -115,6 +115,24 @@ commands:
           command: pnpm test:<< parameters.test_type >> --projects=<< parameters.package >>
           no_output_timeout: 30m
       - save_nx_cache
+
+  setup_gitlab_vars:
+    description: 'Set up GitLab-related environment variables'
+    steps:
+      - run:
+          name: Set GitLab image variables
+          command: |
+            # Extract major version number from GITLAB_VERSION (e.g., 19 from 19.2.0-ce.0)
+            GITLAB_MAJOR_VERSION=$(echo "${GITLAB_VERSION}" | cut -d. -f1)
+            GITLAB_IMAGE_NAME="gitlab-ready-image-${GITLAB_MAJOR_VERSION}"
+            
+            # Export to BASH_ENV so they're available in subsequent steps
+            echo "export GITLAB_MAJOR_VERSION=${GITLAB_MAJOR_VERSION}" >> $BASH_ENV
+            echo "export GITLAB_IMAGE_NAME=${GITLAB_IMAGE_NAME}" >> $BASH_ENV
+            
+            echo "GitLab version: ${GITLAB_VERSION}"
+            echo "GitLab major version: ${GITLAB_MAJOR_VERSION}"
+            echo "GitLab image name: ${GITLAB_IMAGE_NAME}"
 
 # ====================
 # JOBS
@@ -257,6 +275,37 @@ jobs:
     steps:
       - checkout
       - gcp_auth
+      - setup_gitlab_vars
+      - run:
+          name: Check and create GitLab image if needed
+          command: |
+            echo "Checking for required GitLab image: ${GITLAB_IMAGE_NAME}"
+            
+            # Check if the required image exists
+            if gcloud compute images describe "${GITLAB_IMAGE_NAME}" --project=gitbeaker --quiet >/dev/null 2>&1; then
+              echo "✅ GitLab image ${GITLAB_IMAGE_NAME} already exists"
+            else
+              echo "❌ GitLab image ${GITLAB_IMAGE_NAME} does not exist"
+              echo "🚀 Building new GitLab image..."
+              
+              # Install packer if not available
+              if ! command -v packer &> /dev/null; then
+                echo "Installing Packer..."
+                curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
+                sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
+                sudo apt-get update && sudo apt-get install packer
+              fi
+              
+              # Initialize and build the image
+              cd scripts
+              packer init gitlab-image-19.pkr.hcl
+              packer validate gitlab-image-19.pkr.hcl
+              
+              echo "Building GitLab image (this may take 5-10 minutes)..."
+              packer build gitlab-image-19.pkr.hcl
+              
+              echo "✅ GitLab image ${GITLAB_IMAGE_NAME} created successfully"
+            fi
       - run:
           name: Setup live GitLab instance
           command: |
@@ -268,9 +317,9 @@ jobs:
 
             # Create startup script
             envsubst < scripts/startup.sh > scripts/startup_filled.sh
-
+            
             # Create GCP instance with custom GitLab-ready image and auto-expiry
-            echo "Creating GCP instance..."
+            echo "Creating GCP instance using image: ${GITLAB_IMAGE_NAME}"
             GCLOUD_OUTPUT=$(gcloud compute instances create $CONTAINER_NAME \
               --project gitbeaker \
               --machine-type=$GITLAB_MACHINE_TYPE \
@@ -282,7 +331,7 @@ jobs:
               --max-run-duration=15m \
               --instance-termination-action=DELETE \
               --metadata-from-file startup-script=scripts/startup_filled.sh \
-              --image=gitlab-ready-image-16 \
+              --image=$GITLAB_IMAGE_NAME \
               --image-project=gitbeaker 2>&1)
 
             # Extract IP address from the created instance
@@ -427,6 +476,59 @@ jobs:
             else
               echo "No gitlab-env.txt file found - no GitLab instance to clean up"
             fi
+
+  # ====================
+  # CLEANUP OLD IMAGES
+  # ====================
+  cleanup-old-gitlab-images:
+    executor: gcp-executor
+    description: 'Clean up old GitLab images that dont match current version (optional job)'
+    environment: *default_environment
+    steps:
+      - checkout
+      - gcp_auth
+      - setup_gitlab_vars
+      - run:
+          name: Clean up old GitLab images
+          command: |
+            echo "Current GitLab version: ${GITLAB_VERSION}"
+            echo "Current image name: ${GITLAB_IMAGE_NAME}"
+            echo ""
+            
+            # Find all gitlab-ready-image-* images in the project
+            OLD_IMAGES=$(gcloud compute images list \
+              --project=gitbeaker \
+              --filter="name~^gitlab-ready-image-[0-9]+$" \
+              --format="value(name)" | grep -v "^${GITLAB_IMAGE_NAME}$" || true)
+            
+            if [ -z "$OLD_IMAGES" ]; then
+              echo "✅ No old GitLab images found to clean up"
+            else
+              echo "🧹 Found old GitLab images to clean up:"
+              echo "$OLD_IMAGES"
+              echo ""
+              
+              # Delete each old image
+              echo "$OLD_IMAGES" | while read -r image_name; do
+                if [ -n "$image_name" ]; then
+                  echo "🗑️  Deleting old image: $image_name"
+                  gcloud compute images delete "$image_name" \
+                    --project=gitbeaker \
+                    --quiet || echo "❌ Failed to delete $image_name"
+                fi
+              done
+              
+              echo ""
+              echo "✅ Cleanup completed"
+            fi
+            
+            # Show remaining GitLab images
+            echo ""
+            echo "📋 Remaining GitLab images:"
+            gcloud compute images list \
+              --project=gitbeaker \
+              --filter="name~^gitlab-ready-image-" \
+              --format="table(name,creationTimestamp,diskSizeGb)" || echo "No GitLab images found"
 
   # ====================
   # CODECOV UPLOAD
@@ -681,6 +783,20 @@ workflows:
             - test-integration-core
             - test-e2e-rest
             - test-e2e-cli
+          filters:
+            branches:
+              only: [main, next]
+
+      # Optional cleanup job (manual approval required)
+      - approve-cleanup-old-images:
+          type: approval
+          requires: [build]
+          filters:
+            branches:
+              only: [main, next]
+
+      - cleanup-old-gitlab-images:
+          requires: [approve-cleanup-old-images]
           filters:
             branches:
               only: [main, next]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,6 @@
 version: 2.1
 
 # ====================
-# ORBS
-# ====================
-orbs:
-  codecov: codecov/codecov@5.4.3
-
-# ====================
 # ENVIRONMENT VARIABLES
 # ====================
 # Note: Custom image gitlab-ready-image-[major-version] will be created automatically if it doesn't exist
@@ -125,14 +119,45 @@ commands:
             # Extract major version number from GITLAB_VERSION (e.g., 19 from 19.2.0-ce.0)
             GITLAB_MAJOR_VERSION=$(echo "${GITLAB_VERSION}" | cut -d. -f1)
             GITLAB_IMAGE_NAME="gitlab-ready-image-${GITLAB_MAJOR_VERSION}"
-            
+
             # Export to BASH_ENV so they're available in subsequent steps
             echo "export GITLAB_MAJOR_VERSION=${GITLAB_MAJOR_VERSION}" >> $BASH_ENV
             echo "export GITLAB_IMAGE_NAME=${GITLAB_IMAGE_NAME}" >> $BASH_ENV
-            
+
             echo "GitLab version: ${GITLAB_VERSION}"
             echo "GitLab major version: ${GITLAB_MAJOR_VERSION}"
             echo "GitLab image name: ${GITLAB_IMAGE_NAME}"
+
+  install_pnpm_if_playwright:
+    description: 'Install pnpm for Playwright executor (uses version from package.json)'
+    parameters:
+      executor_type:
+        type: string
+        description: 'Executor type to check (playwright-executor will trigger pnpm installation)'
+    steps:
+      - when:
+          condition:
+            equal: [ "playwright-executor", << parameters.executor_type >> ]
+          steps:
+            - run:
+                name: Install pnpm (Playwright executor only)
+                command: npm install -g pnpm@11.17.0  # Match package.json version
+
+  load_gitlab_environment:
+    description: 'Load GitLab environment variables for e2e tests'
+    steps:
+      - run:
+          name: Load GitLab environment
+          command: |
+            if [ -f gitlab-env.txt ]; then
+              source gitlab-env.txt
+              echo "export GITLAB_URL=$GITLAB_URL" >> $BASH_ENV
+              echo "export GITLAB_PERSONAL_ACCESS_TOKEN=$GITLAB_PERSONAL_ACCESS_TOKEN" >> $BASH_ENV
+              echo "export CONTAINER_NAME=$CONTAINER_NAME" >> $BASH_ENV
+              echo "✅ GitLab environment loaded"
+            else
+              echo "⚠️ No GitLab environment file found"
+            fi
 
 # ====================
 # JOBS
@@ -182,88 +207,37 @@ jobs:
       - save_nx_cache
 
   # ====================
-  # UNIT TESTS
+  # PARAMETERIZED TEST JOB
   # ====================
-  test-unit-utils:
-    executor: node-executor
+  run-package-tests:
+    executor: << parameters.executor_type >>
+    parameters:
+      package:
+        type: string
+        description: 'Package name (e.g., @gitbeaker/core)'
+      test_type:
+        type: string
+        description: 'Test type (unit, types, integration, e2e)'
+      executor_type:
+        type: string
+        default: 'node-executor'
+        description: 'Executor type to use'
+      requires_gitlab_env:
+        type: boolean
+        default: false
+        description: 'Whether this test requires GitLab environment'
     steps:
       - restore_workspace
+      - install_pnpm_if_playwright:
+          executor_type: << parameters.executor_type >>
+      - when:
+          condition: << parameters.requires_gitlab_env >>
+          steps:
+            - load_gitlab_environment
       - run_package_tests:
-          package: '@gitbeaker/requester-utils'
-          test_type: 'unit'
+          package: << parameters.package >>
+          test_type: << parameters.test_type >>
 
-  test-unit-core:
-    executor: node-executor
-    steps:
-      - restore_workspace
-      - run_package_tests:
-          package: '@gitbeaker/core'
-          test_type: 'unit'
-
-  test-unit-rest:
-    executor: node-executor
-    steps:
-      - restore_workspace
-      - run_package_tests:
-          package: '@gitbeaker/rest'
-          test_type: 'unit'
-
-  test-unit-cli:
-    executor: node-executor
-    steps:
-      - restore_workspace
-      - run_package_tests:
-          package: '@gitbeaker/cli'
-          test_type: 'unit'
-
-  # ====================
-  # TYPE TESTS
-  # ====================
-  test-types-utils:
-    executor: node-executor
-    steps:
-      - restore_workspace
-      - run_package_tests:
-          package: '@gitbeaker/requester-utils'
-          test_type: 'types'
-
-  test-types-core:
-    executor: node-executor
-    steps:
-      - restore_workspace
-      - run_package_tests:
-          package: '@gitbeaker/core'
-          test_type: 'types'
-
-  test-types-rest:
-    executor: node-executor
-    steps:
-      - restore_workspace
-      - run_package_tests:
-          package: '@gitbeaker/rest'
-          test_type: 'types'
-
-  # ====================
-  # INTEGRATION TESTS
-  # ====================
-  test-integration-rest:
-    executor: playwright-executor
-    steps:
-      - restore_workspace
-      - run:
-          name: Install pnpm
-          command: npm install -g pnpm@10.28.0
-      - run_package_tests:
-          package: '@gitbeaker/rest'
-          test_type: 'integration'
-
-  test-integration-core:
-    executor: node-executor
-    steps:
-      - restore_workspace
-      - run_package_tests:
-          package: '@gitbeaker/core'
-          test_type: 'integration'
 
   # ====================
   # LIVE TEST SETUP
@@ -280,14 +254,14 @@ jobs:
           name: Check and create GitLab image if needed
           command: |
             echo "Checking for required GitLab image: ${GITLAB_IMAGE_NAME}"
-            
+
             # Check if the required image exists
             if gcloud compute images describe "${GITLAB_IMAGE_NAME}" --project=gitbeaker --quiet >/dev/null 2>&1; then
               echo "✅ GitLab image ${GITLAB_IMAGE_NAME} already exists"
             else
               echo "❌ GitLab image ${GITLAB_IMAGE_NAME} does not exist"
               echo "🚀 Building new GitLab image..."
-              
+
               # Install packer if not available
               if ! command -v packer &> /dev/null; then
                 echo "Installing Packer..."
@@ -295,15 +269,15 @@ jobs:
                 sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
                 sudo apt-get update && sudo apt-get install packer
               fi
-              
+
               # Initialize and build the image
               cd scripts
               packer init gitlab-image-19.pkr.hcl
               packer validate gitlab-image-19.pkr.hcl
-              
+
               echo "Building GitLab image (this may take 5-10 minutes)..."
               packer build gitlab-image-19.pkr.hcl
-              
+
               echo "✅ GitLab image ${GITLAB_IMAGE_NAME} created successfully"
             fi
       - run:
@@ -317,7 +291,7 @@ jobs:
 
             # Create startup script
             envsubst < scripts/startup.sh > scripts/startup_filled.sh
-            
+
             # Create GCP instance with custom GitLab-ready image and auto-expiry
             echo "Creating GCP instance using image: ${GITLAB_IMAGE_NAME}"
             GCLOUD_OUTPUT=$(gcloud compute instances create $CONTAINER_NAME \
@@ -411,47 +385,6 @@ jobs:
           paths:
             - gitlab-env.txt
 
-  # ====================
-  # E2E TESTS
-  # ====================
-  test-e2e-rest:
-    executor: playwright-executor
-    description: 'Run REST API e2e tests against live GitLab instance'
-    steps:
-      - restore_workspace
-      - run:
-          name: Load GitLab environment
-          command: |
-            if [ -f gitlab-env.txt ]; then
-              source gitlab-env.txt
-              echo "export GITLAB_URL=$GITLAB_URL" >> $BASH_ENV
-              echo "export GITLAB_PERSONAL_ACCESS_TOKEN=$GITLAB_PERSONAL_ACCESS_TOKEN" >> $BASH_ENV
-              echo "export CONTAINER_NAME=$CONTAINER_NAME" >> $BASH_ENV
-            fi
-      - run:
-          name: Install pnpm
-          command: npm install -g pnpm@10.28.0
-      - run_package_tests:
-          package: '@gitbeaker/rest'
-          test_type: 'e2e'
-
-  test-e2e-cli:
-    executor: node-executor
-    description: 'Run CLI e2e tests against live GitLab instance'
-    steps:
-      - restore_workspace
-      - run:
-          name: Load GitLab environment
-          command: |
-            if [ -f gitlab-env.txt ]; then
-              source gitlab-env.txt
-              echo "export GITLAB_URL=$GITLAB_URL" >> $BASH_ENV
-              echo "export GITLAB_PERSONAL_ACCESS_TOKEN=$GITLAB_PERSONAL_ACCESS_TOKEN" >> $BASH_ENV
-              echo "export CONTAINER_NAME=$CONTAINER_NAME" >> $BASH_ENV
-            fi
-      - run_package_tests:
-          package: '@gitbeaker/cli'
-          test_type: 'e2e'
 
   # ====================
   # TEARDOWN
@@ -494,20 +427,20 @@ jobs:
             echo "Current GitLab version: ${GITLAB_VERSION}"
             echo "Current image name: ${GITLAB_IMAGE_NAME}"
             echo ""
-            
+
             # Find all gitlab-ready-image-* images in the project
             OLD_IMAGES=$(gcloud compute images list \
               --project=gitbeaker \
               --filter="name~^gitlab-ready-image-[0-9]+$" \
               --format="value(name)" | grep -v "^${GITLAB_IMAGE_NAME}$" || true)
-            
+
             if [ -z "$OLD_IMAGES" ]; then
               echo "✅ No old GitLab images found to clean up"
             else
               echo "🧹 Found old GitLab images to clean up:"
               echo "$OLD_IMAGES"
               echo ""
-              
+
               # Delete each old image
               echo "$OLD_IMAGES" | while read -r image_name; do
                 if [ -n "$image_name" ]; then
@@ -517,11 +450,11 @@ jobs:
                     --quiet || echo "❌ Failed to delete $image_name"
                 fi
               done
-              
+
               echo ""
               echo "✅ Cleanup completed"
             fi
-            
+
             # Show remaining GitLab images
             echo ""
             echo "📋 Remaining GitLab images:"
@@ -637,28 +570,44 @@ workflows:
       - format:
           requires: [install]
 
-      # Unit tests (parallel)
-      - test-unit-utils:
-          requires: [install]
-      - test-unit-core:
-          requires: [install]
-      - test-unit-rest:
-          requires: [install]
-      - test-unit-cli:
+      # Unit tests (matrix approach)
+      - run-package-tests:
+          name: test-unit-<< matrix.package_short >>
+          matrix:
+            parameters:
+              package: ['@gitbeaker/requester-utils', '@gitbeaker/core', '@gitbeaker/rest', '@gitbeaker/cli']
+              package_short: ['utils', 'core', 'rest', 'cli']
+          package: << matrix.package >>
+          test_type: 'unit'
           requires: [install]
 
-      # Type tests (parallel)
-      - test-types-utils:
-          requires: [build]
-      - test-types-core:
-          requires: [build]
-      - test-types-rest:
+      # Type tests (matrix approach)
+      - run-package-tests:
+          name: test-types-<< matrix.package_short >>
+          matrix:
+            parameters:
+              package: ['@gitbeaker/requester-utils', '@gitbeaker/core', '@gitbeaker/rest']
+              package_short: ['utils', 'core', 'rest']
+          package: << matrix.package >>
+          test_type: 'types'
           requires: [build]
 
-      # Integration tests (parallel)
-      - test-integration-rest:
-          requires: [build]
-      - test-integration-core:
+      # Integration tests (matrix approach)
+      - run-package-tests:
+          name: test-integration-<< matrix.package_short >>
+          matrix:
+            parameters:
+              package: ['@gitbeaker/rest', '@gitbeaker/core']
+              package_short: ['rest', 'core']
+              executor_type: ['playwright-executor', 'node-executor']
+            exclude:
+              - package: '@gitbeaker/core'
+                executor_type: 'playwright-executor'
+              - package: '@gitbeaker/rest'
+                executor_type: 'node-executor'
+          package: << matrix.package >>
+          test_type: 'integration'
+          executor_type: << matrix.executor_type >>
           requires: [build]
 
       # Live test setup (manual for PRs, auto for main/next)
@@ -683,25 +632,42 @@ workflows:
               ignore: [main, next]
 
       # E2E tests
-      - test-e2e-rest:
+      - run-package-tests:
+          name: test-e2e-rest
+          package: '@gitbeaker/rest'
+          test_type: 'e2e'
+          executor_type: 'playwright-executor'
+          requires_gitlab_env: true
           requires: [setup-e2e-tests]
           filters:
             branches:
               only: [main, next]
-      - test-e2e-rest:
+
+      - run-package-tests:
           name: test-e2e-rest-manual
+          package: '@gitbeaker/rest'
+          test_type: 'e2e'
+          executor_type: 'playwright-executor'
+          requires_gitlab_env: true
           requires: [setup-e2e-tests-manual]
           filters:
             branches:
               ignore: [main, next]
 
-      - test-e2e-cli:
+      - run-package-tests:
+          name: test-e2e-cli
+          package: '@gitbeaker/cli'
+          test_type: 'e2e'
+          requires_gitlab_env: true
           requires: [setup-e2e-tests]
           filters:
             branches:
               only: [main, next]
-      - test-e2e-cli:
+      - run-package-tests:
           name: test-e2e-cli-manual
+          package: '@gitbeaker/cli'
+          test_type: 'e2e'
+          requires_gitlab_env: true
           requires: [setup-e2e-tests-manual]
           filters:
             branches:
@@ -790,7 +756,7 @@ workflows:
       # Optional cleanup job (manual approval required)
       - approve-cleanup-old-images:
           type: approval
-          requires: [build]
+          requires: [setup-e2e-tests]
           filters:
             branches:
               only: [main, next]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -212,9 +212,9 @@ jobs:
   run-package-tests:
     executor: << parameters.executor_type >>
     parameters:
-      package:
+      package_short:
         type: string
-        description: 'Package name (e.g., @gitbeaker/core)'
+        description: 'Short package name (e.g., core, rest, cli, requester-utils)'
       test_type:
         type: string
         description: 'Test type (unit, types, integration, e2e)'
@@ -235,7 +235,7 @@ jobs:
           steps:
             - load_gitlab_environment
       - run_package_tests:
-          package: << parameters.package >>
+          package: '@gitbeaker/<< parameters.package_short >>'
           test_type: << parameters.test_type >>
 
   # ====================
@@ -571,45 +571,36 @@ workflows:
       # Unit tests (matrix approach)
       - run-package-tests:
           matrix:
-            alias: [utils, core, rest, cli]
             parameters:
-              package:
-                [
-                  '@gitbeaker/requester-utils',
-                  '@gitbeaker/core',
-                  '@gitbeaker/rest',
-                  '@gitbeaker/cli',
-                ]
-          name: test-unit-<< matrix.alias >>
-          package: << matrix.package >>
+              package_short: ['requester-utils', 'core', 'rest', 'cli']
+          name: test-unit-<< matrix.package_short >>
+          package_short: << matrix.package_short >>
           test_type: 'unit'
           requires: [install]
 
       # Type tests (matrix approach)
       - run-package-tests:
           matrix:
-            alias: [utils, core, rest]
             parameters:
-              package: ['@gitbeaker/requester-utils', '@gitbeaker/core', '@gitbeaker/rest']
-          name: test-types-<< matrix.alias >>
-          package: << matrix.package >>
+              package_short: ['requester-utils', 'core', 'rest']
+          name: test-types-<< matrix.package_short >>
+          package_short: << matrix.package_short >>
           test_type: 'types'
           requires: [build]
 
       # Integration tests (matrix approach)
       - run-package-tests:
           matrix:
-            alias: [rest, core]
             parameters:
-              package: ['@gitbeaker/rest', '@gitbeaker/core']
+              package_short: ['rest', 'core']
               executor_type: ['playwright-executor', 'node-executor']
             exclude:
-              - package: '@gitbeaker/core'
+              - package_short: 'core'
                 executor_type: 'playwright-executor'
-              - package: '@gitbeaker/rest'
+              - package_short: 'rest'
                 executor_type: 'node-executor'
-          name: test-integration-<< matrix.alias >>
-          package: << matrix.package >>
+          name: test-integration-<< matrix.package_short >>
+          package_short: << matrix.package_short >>
           test_type: 'integration'
           executor_type: << matrix.executor_type >>
           requires: [build]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -272,13 +272,10 @@ jobs:
               # Initialize and build the image
               cd scripts
               packer init gitlab-image-19.pkr.hcl
-              packer validate gitlab-image-19.pkr.hcl
-
-              # Set credentials for Packer
-              export PACKER_GCP_CREDENTIALS="$(echo $GCLOUD_SERVICE_KEY | base64 -d)"
+              packer validate -var "gcp_credentials=$(echo $GCLOUD_SERVICE_KEY | base64 -d)" gitlab-image-19.pkr.hcl
 
               echo "Building GitLab image (this may take 5-10 minutes)..."
-              packer build gitlab-image-19.pkr.hcl
+              packer build -var "gcp_credentials=$(echo $GCLOUD_SERVICE_KEY | base64 -d)" gitlab-image-19.pkr.hcl
 
               echo "✅ GitLab image ${GITLAB_IMAGE_NAME} created successfully"
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -274,6 +274,9 @@ jobs:
               packer init gitlab-image-19.pkr.hcl
               packer validate gitlab-image-19.pkr.hcl
 
+              # Set credentials for Packer
+              export PACKER_GCP_CREDENTIALS="$(echo $GCLOUD_SERVICE_KEY | base64 -d)"
+
               echo "Building GitLab image (this may take 5-10 minutes)..."
               packer build gitlab-image-19.pkr.hcl
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -629,7 +629,7 @@ workflows:
       # E2E tests
       - run-package-tests:
           name: test-e2e-rest
-          package: '@gitbeaker/rest'
+          package_short: 'rest'
           test_type: 'e2e'
           executor_type: 'playwright-executor'
           requires_gitlab_env: true
@@ -640,7 +640,7 @@ workflows:
 
       - run-package-tests:
           name: test-e2e-rest-manual
-          package: '@gitbeaker/rest'
+          package_short: 'rest'
           test_type: 'e2e'
           executor_type: 'playwright-executor'
           requires_gitlab_env: true
@@ -651,7 +651,7 @@ workflows:
 
       - run-package-tests:
           name: test-e2e-cli
-          package: '@gitbeaker/cli'
+          package_short: 'cli'
           test_type: 'e2e'
           requires_gitlab_env: true
           requires: [setup-e2e-tests]
@@ -660,7 +660,7 @@ workflows:
               only: [main, next]
       - run-package-tests:
           name: test-e2e-cli-manual
-          package: '@gitbeaker/cli'
+          package_short: 'cli'
           test_type: 'e2e'
           requires_gitlab_env: true
           requires: [setup-e2e-tests-manual]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,11 +137,11 @@ commands:
     steps:
       - when:
           condition:
-            equal: [ "playwright-executor", << parameters.executor_type >> ]
+            equal: ['playwright-executor', << parameters.executor_type >>]
           steps:
             - run:
                 name: Install pnpm (Playwright executor only)
-                command: npm install -g pnpm@11.17.0  # Match package.json version
+                command: npm install -g pnpm@11.17.0 # Match package.json version
 
   load_gitlab_environment:
     description: 'Load GitLab environment variables for e2e tests'
@@ -237,7 +237,6 @@ jobs:
       - run_package_tests:
           package: << parameters.package >>
           test_type: << parameters.test_type >>
-
 
   # ====================
   # LIVE TEST SETUP
@@ -384,7 +383,6 @@ jobs:
           root: .
           paths:
             - gitlab-env.txt
-
 
   # ====================
   # TEARDOWN
@@ -575,7 +573,13 @@ workflows:
           name: test-unit-<< matrix.package_short >>
           matrix:
             parameters:
-              package: ['@gitbeaker/requester-utils', '@gitbeaker/core', '@gitbeaker/rest', '@gitbeaker/cli']
+              package:
+                [
+                  '@gitbeaker/requester-utils',
+                  '@gitbeaker/core',
+                  '@gitbeaker/rest',
+                  '@gitbeaker/cli',
+                ]
               package_short: ['utils', 'core', 'rest', 'cli']
           package: << matrix.package >>
           test_type: 'unit'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ version: 2.1
 # Note: Custom image gitlab-ready-image-[major-version] will be created automatically if it doesn't exist
 x-environment: &default_environment
   GCP_ZONE: us-central1-c
-  GITLAB_VERSION: 19.2.0-ce.0 # Custom image will be created automatically
+  GITLAB_VERSION: 19.2.0-ce.0
   GITLAB_MACHINE_TYPE: e2-standard-4
   GITLAB_PERSONAL_ACCESS_TOKEN: gitbeaker
   GITLAB_ROOT_PASSWORD: gitbeaker
@@ -141,7 +141,7 @@ commands:
           steps:
             - run:
                 name: Install pnpm (Playwright executor only)
-                command: npm install -g pnpm@11.17.0 # Match package.json version
+                command: npm install -g pnpm@11.17.0
 
   load_gitlab_environment:
     description: 'Load GitLab environment variables for e2e tests'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -704,7 +704,7 @@ workflows:
       - codecov-upload:
           requires:
             - build
-            - test-unit-utils
+            - test-unit-requester-utils
             - test-unit-core
             - test-unit-rest
             - test-unit-cli
@@ -717,11 +717,11 @@ workflows:
       - release-canary:
           requires:
             - build
-            - test-unit-utils
+            - test-unit-requester-utils
             - test-unit-core
             - test-unit-rest
             - test-unit-cli
-            - test-types-utils
+            - test-types-requester-utils
             - test-types-core
             - test-types-rest
             - test-integration-rest
@@ -733,11 +733,11 @@ workflows:
       - release-production:
           requires:
             - build
-            - test-unit-utils
+            - test-unit-requester-utils
             - test-unit-core
             - test-unit-rest
             - test-unit-cli
-            - test-types-utils
+            - test-types-requester-utils
             - test-types-core
             - test-types-rest
             - test-integration-rest

--- a/.docker/docker-compose.yml
+++ b/.docker/docker-compose.yml
@@ -5,7 +5,7 @@ x-common-variables: &common-variables
 
 services:
   gitlab:
-    image: gitlab/gitlab-ce:19.0.1-ce.0
+    image: gitlab/gitlab-ce:19.2.0-ce.0
     container_name: gitlab
     restart: unless-stopped
     hostname: gitlab

--- a/README.md
+++ b/README.md
@@ -50,16 +50,14 @@
 
 ## Table of Contents
 
+- [Table of Contents](#table-of-contents)
 - [Features](#features)
 - [Packages](#packages)
-- [Usage](./packages/rest/README.md#usage)
-- [FAQ](./docs/FAQ.md)
 - [Contributors](#contributors)
-- [Changelog](./CHANGELOG.md)
 
 ## Features
 
-- **Complete** - All features of GitLab's exposed APIs are covered up to version [16.5](https://docs.gitlab.com/16.5/ee/api/api_resources.html). See [here](./packages/core/README.md#supported-apis) for the full list.
+- **Complete** - All features of GitLab's exposed APIs are covered up to version [19.0](https://docs.gitlab.com/19.0/ee/api/api_resources.html). See [here](./packages/core/README.md#supported-apis) for the full list.
 - **Universal** - Works in all modern browsers, [Node.js](https://nodejs.org/), [Deno](https://deno.land/) and [Bun](https://bun.com/) and supports [CLI](https://www.npmjs.com/package/@gitbeaker/cli) usage.
 - **Tested** - All libraries have > 80% test coverage.
 - **Typed** - All libraries have extensive TypeScript declarations.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -24,6 +24,7 @@
     "cli",
     "gitbeaker"
   ],
+  "type": "module",
   "bin": {
     "gb": "dist/index.mjs",
     "gitbeaker": "dist/index.mjs"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -24,18 +24,13 @@
     "core",
     "gitbeaker"
   ],
-  "types": "./dist/index.d.ts",
+  "type": "module",
+  "types": "./dist/index.d.mts",
   "exports": {
     "./map.json": "./dist/map.json",
     ".": {
-      "import": {
-        "types": "./dist/index.d.mts",
-        "default": "./dist/index.mjs"
-      },
-      "require": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      }
+      "types": "./dist/index.d.mts",
+      "default": "./dist/index.mjs"
     }
   },
   "files": [
@@ -44,7 +39,7 @@
   "scripts": {
     "build": "pnpm run build:self && pnpm run build:map",
     "build:map": "tsx scripts/generate.ts",
-    "build:self": "tsdown src/index.ts --format esm,cjs --dts --treeshake",
+    "build:self": "tsdown src/index.ts --format esm --dts --treeshake",
     "test:types": "tsc",
     "test:integration": "vitest run --config vitest.config.mjs test/integration",
     "test:unit": "vitest run --config vitest.config.mjs test/unit",

--- a/packages/requester-utils/package.json
+++ b/packages/requester-utils/package.json
@@ -23,24 +23,19 @@
     "utils",
     "gitbeaker"
   ],
-  "types": "./dist/index.d.ts",
+  "type": "module",
+  "types": "./dist/index.d.mts",
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/index.d.mts",
-        "default": "./dist/index.mjs"
-      },
-      "require": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      }
+      "types": "./dist/index.d.mts",
+      "default": "./dist/index.mjs"
     }
   },
   "files": [
     "dist"
   ],
   "scripts": {
-    "build": "tsdown src/index.ts --format esm,cjs --dts --treeshake",
+    "build": "tsdown src/index.ts --format esm --dts --treeshake",
     "test:types": "tsc",
     "test:unit": "vitest run --config vitest.config.mjs test/unit",
     "lint": "oxlint src test scripts",

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -25,24 +25,19 @@
     "browser",
     "gitbeaker"
   ],
-  "types": "./dist/index.d.ts",
+  "type": "module",
+  "types": "./dist/index.d.mts",
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/index.d.mts",
-        "default": "./dist/index.mjs"
-      },
-      "require": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      }
+      "types": "./dist/index.d.mts",
+      "default": "./dist/index.mjs"
     }
   },
   "files": [
     "dist"
   ],
   "scripts": {
-    "build": "tsdown src/index.ts --format esm,cjs --dts --treeshake",
+    "build": "tsdown src/index.ts --format esm --dts --treeshake",
     "test:types": "tsc",
     "test:e2e:browser": "playwright test --project=e2e",
     "test:e2e:nodejs": "vitest run --config vitest.config.mjs test/e2e/nodejs",

--- a/packages/rest/test/e2e/browser/General.ts
+++ b/packages/rest/test/e2e/browser/General.ts
@@ -1,5 +1,8 @@
 import { expect, test as it } from '@playwright/test';
 import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const { describe } = it;
 

--- a/packages/rest/test/e2e/browser/General.ts
+++ b/packages/rest/test/e2e/browser/General.ts
@@ -1,8 +1,5 @@
 import { expect, test as it } from '@playwright/test';
-import path from 'path';
 import { fileURLToPath } from 'url';
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const { describe } = it;
 
@@ -242,7 +239,7 @@ describe('Browser Import', () => {
   ].sort();
 
   it('should import the Gitbeaker library though the global gitbeaker', async ({ page }) => {
-    const filepath = path.resolve(__dirname, '..', '..', 'assets', 'test-import.html');
+    const filepath = fileURLToPath(new URL('../../assets/test-import.html', import.meta.url));
 
     await page.goto(`file://${filepath}`);
 

--- a/packages/rest/test/e2e/browser/resources/Projects.ts
+++ b/packages/rest/test/e2e/browser/resources/Projects.ts
@@ -1,13 +1,10 @@
 import { expect, test as it } from '@playwright/test';
-import path from 'path';
 import { fileURLToPath } from 'url';
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const { describe } = it;
 
 const { GITLAB_PERSONAL_ACCESS_TOKEN = '', GITLAB_URL = '', TEST_ID = Date.now() } = process.env;
-const htmlFilePath = path.resolve(__dirname, '..', '..', '..', 'assets', 'test-import.html');
+const htmlFilePath = fileURLToPath(new URL('../../../assets/test-import.html', import.meta.url));
 
 describe('Projects API', () => {
   it('should create a project', async ({ page }) => {

--- a/packages/rest/test/e2e/browser/resources/Projects.ts
+++ b/packages/rest/test/e2e/browser/resources/Projects.ts
@@ -1,5 +1,8 @@
 import { expect, test as it } from '@playwright/test';
 import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const { describe } = it;
 

--- a/packages/rest/test/integration/browser/General.ts
+++ b/packages/rest/test/integration/browser/General.ts
@@ -1,5 +1,8 @@
 import { expect, test as it } from '@playwright/test';
 import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const { describe } = it;
 

--- a/packages/rest/test/integration/browser/General.ts
+++ b/packages/rest/test/integration/browser/General.ts
@@ -1,8 +1,5 @@
 import { expect, test as it } from '@playwright/test';
-import path from 'path';
 import { fileURLToPath } from 'url';
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const { describe } = it;
 
@@ -244,7 +241,7 @@ describe('Browser Import', () => {
   it('should import all resources in the Gitbeaker library though the global gitbeaker ', async ({
     page,
   }) => {
-    const filepath = path.resolve(__dirname, '..', '..', 'assets', 'test-import.html');
+    const filepath = fileURLToPath(new URL('../../assets/test-import.html', import.meta.url));
 
     await page.goto(`file://${filepath}`);
 

--- a/scripts/build-gitlab-image.sh
+++ b/scripts/build-gitlab-image.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+# Build GitLab ready image using Packer
+# This script creates a GCP compute image with GitLab pre-installed for faster CI startup
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+echo -e "${GREEN}🚀 Building GitLab Ready Image...${NC}"
+
+# Check if packer is installed
+if ! command -v packer &> /dev/null; then
+    echo -e "${RED}❌ Packer is not installed. Please install it first:${NC}"
+    echo "   brew install packer"
+    echo "   or download from: https://www.packer.io/downloads"
+    exit 1
+fi
+
+# Check if gcloud is authenticated
+if ! gcloud auth list --filter=status:ACTIVE --format="value(account)" &> /dev/null; then
+    echo -e "${RED}❌ Not authenticated with gcloud. Please run:${NC}"
+    echo "   gcloud auth login"
+    echo "   gcloud config set project gitbeaker"
+    exit 1
+fi
+
+# Verify project access
+current_project=$(gcloud config get-value project 2>/dev/null)
+if [ "$current_project" != "gitbeaker" ]; then
+    echo -e "${YELLOW}⚠️  Current project is '$current_project', setting to 'gitbeaker'${NC}"
+    gcloud config set project gitbeaker
+fi
+
+# Initialize and validate packer
+echo -e "${GREEN}🔧 Initializing Packer...${NC}"
+cd "$(dirname "$0")"
+packer init gitlab-image-19.pkr.hcl
+
+echo -e "${GREEN}✅ Validating Packer configuration...${NC}"
+packer validate gitlab-image-19.pkr.hcl
+
+# Build the image
+echo -e "${GREEN}🏗️  Building GitLab image (this may take 5-10 minutes)...${NC}"
+packer build gitlab-image-19.pkr.hcl
+
+echo -e "${GREEN}✅ Image build complete!${NC}"
+echo ""
+echo -e "${GREEN}📋 Next steps:${NC}"
+echo "1. Update .circleci/config.yml to use the new image:"
+echo "   --image=gitlab-ready-image-19 \\"
+echo ""
+echo "2. Verify the image works:"
+echo "   gcloud compute images describe gitlab-ready-image-19 --project=gitbeaker"
+echo ""
+echo "3. Test with a temporary VM:"
+echo "   gcloud compute instances create test-gitlab-image \\"
+echo "     --image=gitlab-ready-image-19 \\"
+echo "     --project=gitbeaker \\"
+echo "     --zone=us-central1-c"
+echo ""
+echo -e "${YELLOW}💡 Don't forget to delete test VMs when done testing!${NC}"

--- a/scripts/gitlab-image-19.pkr.hcl
+++ b/scripts/gitlab-image-19.pkr.hcl
@@ -11,15 +11,15 @@ packer {
 }
 
 source "googlecompute" "gitlab" {
-  project_id           = "gitbeaker"
-  source_image_family  = "debian-12"
-  source_image_project = "debian-cloud"
-  zone                 = "us-central1-c"
-  image_name          = "gitlab-ready-image-19"
-  image_description   = "Debian 12 with Docker and GitLab CE 19.2.0 pre-installed for CI/CD"
-  machine_type        = "e2-medium"
-  disk_size           = 25
-  disk_type           = "pd-ssd"
+  project_id              = "gitbeaker"
+  source_image_family     = "debian-12"
+  source_image_project_id = "debian-cloud"
+  zone                    = "us-central1-c"
+  image_name             = "gitlab-ready-image-19"
+  image_description      = "Debian 12 with Docker and GitLab CE 19.2.0 pre-installed for CI/CD"
+  machine_type           = "e2-medium"
+  disk_size              = 25
+  disk_type              = "pd-ssd"
   
   // Add labels for tracking
   image_labels = {

--- a/scripts/gitlab-image-19.pkr.hcl
+++ b/scripts/gitlab-image-19.pkr.hcl
@@ -19,6 +19,7 @@ source "googlecompute" "gitlab" {
   machine_type           = "e2-medium"
   disk_size              = 25
   disk_type              = "pd-ssd"
+  ssh_username           = "packer"
 
   // Add labels for tracking
   image_labels = {

--- a/scripts/gitlab-image-19.pkr.hcl
+++ b/scripts/gitlab-image-19.pkr.hcl
@@ -1,0 +1,105 @@
+// Packer script to create gitlab-ready-image-19
+// This creates a GCP compute image with Docker and GitLab pre-installed for faster CI startup
+
+packer {
+  required_plugins {
+    googlecompute = {
+      version = ">= 1.1.1"
+      source  = "github.com/hashicorp/googlecompute"
+    }
+  }
+}
+
+source "googlecompute" "gitlab" {
+  project_id           = "gitbeaker"
+  source_image_family  = "debian-12"
+  source_image_project = "debian-cloud"
+  zone                 = "us-central1-c"
+  image_name          = "gitlab-ready-image-19"
+  image_description   = "Debian 12 with Docker and GitLab CE 19.2.0 pre-installed for CI/CD"
+  machine_type        = "e2-medium"
+  disk_size           = 25
+  disk_type           = "pd-ssd"
+  
+  // Add labels for tracking
+  image_labels = {
+    environment = "ci"
+    gitlab_version = "19-2-0-ce-0"
+    created_by = "packer"
+    purpose = "gitlab-testing"
+  }
+}
+
+build {
+  sources = ["source.googlecompute.gitlab"]
+  
+  provisioner "shell" {
+    inline = [
+      // Update system
+      "echo 'Updating system packages...'",
+      "sudo apt-get update",
+      "sudo DEBIAN_FRONTEND=noninteractive apt-get upgrade -y",
+      
+      // Install essential tools
+      "echo 'Installing essential tools...'",
+      "sudo DEBIAN_FRONTEND=noninteractive apt-get install -y curl jq wget gnupg2 software-properties-common apt-transport-https ca-certificates",
+      
+      // Install Docker
+      "echo 'Installing Docker...'",
+      "sudo DEBIAN_FRONTEND=noninteractive apt-get install -y docker.io",
+      
+      // Configure Docker
+      "echo 'Configuring Docker...'",
+      "sudo systemctl enable docker",
+      "sudo systemctl start docker",
+      "sudo usermod -aG docker $USER",
+      
+      // Wait for Docker to be ready
+      "echo 'Waiting for Docker to be ready...'",
+      "sleep 10",
+      "sudo docker info",
+      
+      // Pre-pull GitLab image (this is the main optimization - saves ~5-10 minutes on startup)
+      "echo 'Pre-pulling GitLab CE image...'",
+      "sudo docker pull gitlab/gitlab-ce:19.2.0-ce.0",
+      
+      // Verify the image was pulled
+      "echo 'Verifying GitLab image...'",
+      "sudo docker images | grep gitlab",
+      
+      // Clean up package cache to reduce image size
+      "echo 'Cleaning up...'",
+      "sudo apt-get autoremove -y",
+      "sudo apt-get autoclean",
+      "sudo rm -rf /var/lib/apt/lists/*",
+      
+      // Create a simple verification script
+      "echo 'Creating verification script...'",
+      "sudo tee /opt/verify-gitlab-image.sh << 'EOF'",
+      "#!/bin/bash",
+      "echo '=== GitLab Ready Image Verification ==='",
+      "echo 'Docker version:'",
+      "docker --version",
+      "echo ''",
+      "echo 'Docker status:'",
+      "systemctl is-active docker",
+      "echo ''",
+      "echo 'GitLab images:'",
+      "docker images | grep gitlab",
+      "echo ''",
+      "echo 'Disk usage:'",
+      "df -h /",
+      "EOF",
+      "sudo chmod +x /opt/verify-gitlab-image.sh",
+      
+      // Final verification
+      "echo 'Running final verification...'",
+      "sudo /opt/verify-gitlab-image.sh"
+    ]
+  }
+  
+  // Add post-processor to output image details
+  post-processor "manifest" {
+    output = "gitlab-image-19-manifest.json"
+  }
+}

--- a/scripts/gitlab-image-19.pkr.hcl
+++ b/scripts/gitlab-image-19.pkr.hcl
@@ -1,4 +1,3 @@
-// Packer script to create gitlab-ready-image-19
 // This creates a GCP compute image with Docker and GitLab pre-installed for faster CI startup
 
 packer {
@@ -13,14 +12,14 @@ packer {
 source "googlecompute" "gitlab" {
   project_id              = "gitbeaker"
   source_image_family     = "debian-12"
-  source_image_project_id = "debian-cloud"
+  source_image_project_id = ["debian-cloud"]
   zone                    = "us-central1-c"
   image_name             = "gitlab-ready-image-19"
   image_description      = "Debian 12 with Docker and GitLab CE 19.2.0 pre-installed for CI/CD"
   machine_type           = "e2-medium"
   disk_size              = 25
   disk_type              = "pd-ssd"
-  
+
   // Add labels for tracking
   image_labels = {
     environment = "ci"
@@ -32,47 +31,47 @@ source "googlecompute" "gitlab" {
 
 build {
   sources = ["source.googlecompute.gitlab"]
-  
+
   provisioner "shell" {
     inline = [
       // Update system
       "echo 'Updating system packages...'",
       "sudo apt-get update",
       "sudo DEBIAN_FRONTEND=noninteractive apt-get upgrade -y",
-      
+
       // Install essential tools
       "echo 'Installing essential tools...'",
       "sudo DEBIAN_FRONTEND=noninteractive apt-get install -y curl jq wget gnupg2 software-properties-common apt-transport-https ca-certificates",
-      
+
       // Install Docker
       "echo 'Installing Docker...'",
       "sudo DEBIAN_FRONTEND=noninteractive apt-get install -y docker.io",
-      
+
       // Configure Docker
       "echo 'Configuring Docker...'",
       "sudo systemctl enable docker",
       "sudo systemctl start docker",
       "sudo usermod -aG docker $USER",
-      
+
       // Wait for Docker to be ready
       "echo 'Waiting for Docker to be ready...'",
       "sleep 10",
       "sudo docker info",
-      
+
       // Pre-pull GitLab image (this is the main optimization - saves ~5-10 minutes on startup)
       "echo 'Pre-pulling GitLab CE image...'",
       "sudo docker pull gitlab/gitlab-ce:19.2.0-ce.0",
-      
+
       // Verify the image was pulled
       "echo 'Verifying GitLab image...'",
       "sudo docker images | grep gitlab",
-      
+
       // Clean up package cache to reduce image size
       "echo 'Cleaning up...'",
       "sudo apt-get autoremove -y",
       "sudo apt-get autoclean",
       "sudo rm -rf /var/lib/apt/lists/*",
-      
+
       // Create a simple verification script
       "echo 'Creating verification script...'",
       "sudo tee /opt/verify-gitlab-image.sh << 'EOF'",
@@ -91,13 +90,13 @@ build {
       "df -h /",
       "EOF",
       "sudo chmod +x /opt/verify-gitlab-image.sh",
-      
+
       // Final verification
       "echo 'Running final verification...'",
       "sudo /opt/verify-gitlab-image.sh"
     ]
   }
-  
+
   // Add post-processor to output image details
   post-processor "manifest" {
     output = "gitlab-image-19-manifest.json"

--- a/scripts/gitlab-image-19.pkr.hcl
+++ b/scripts/gitlab-image-19.pkr.hcl
@@ -20,6 +20,7 @@ source "googlecompute" "gitlab" {
   disk_size              = 25
   disk_type              = "pd-ssd"
   ssh_username           = "packer"
+  credentials_json        = env("PACKER_GCP_CREDENTIALS")
 
   // Add labels for tracking
   image_labels = {

--- a/scripts/gitlab-image-19.pkr.hcl
+++ b/scripts/gitlab-image-19.pkr.hcl
@@ -9,6 +9,12 @@ packer {
   }
 }
 
+variable "gcp_credentials" {
+  type        = string
+  description = "GCP service account credentials JSON"
+  sensitive   = true
+}
+
 source "googlecompute" "gitlab" {
   project_id              = "gitbeaker"
   source_image_family     = "debian-12"
@@ -20,7 +26,7 @@ source "googlecompute" "gitlab" {
   disk_size              = 25
   disk_type              = "pd-ssd"
   ssh_username           = "packer"
-  credentials_json        = "${env.PACKER_GCP_CREDENTIALS}"
+  credentials_json        = var.gcp_credentials
 
   // Add labels for tracking
   image_labels = {

--- a/scripts/gitlab-image-19.pkr.hcl
+++ b/scripts/gitlab-image-19.pkr.hcl
@@ -20,7 +20,7 @@ source "googlecompute" "gitlab" {
   disk_size              = 25
   disk_type              = "pd-ssd"
   ssh_username           = "packer"
-  credentials_json        = env("PACKER_GCP_CREDENTIALS")
+  credentials_json        = "${env.PACKER_GCP_CREDENTIALS}"
 
   // Add labels for tracking
   image_labels = {

--- a/scripts/startup.sh
+++ b/scripts/startup.sh
@@ -1,14 +1,50 @@
 #!/bin/bash
-# Install Docker
-apt-get update
-apt-get install -y docker.io
-# Start Docker service
-systemctl start docker
-systemctl enable docker
+echo "=== GitLab Startup Script ==="
+echo "Starting GitLab using pre-pulled image from custom VM image..."
 
-# Pull and run Docker container
-set +H
+# Docker should already be installed and running from the custom image
+# Verify Docker is running
+if ! systemctl is-active --quiet docker; then
+  echo "Docker not running, starting it..."
+  systemctl start docker
+  sleep 5
+fi
 
-docker run -d -p 80:80 -e GITLAB_ROOT_PASSWORD=$GITLAB_ROOT_PASSWORD -e PERSONAL_ACCESS_TOKEN=$GITLAB_PERSONAL_ACCESS_TOKEN -e GITLAB_OMNIBUS_CONFIG="gitlab_rails['monitoring_whitelist'] = ['0.0.0.0/0', '172.17.0.1'];" docker.io/gitlab/gitlab-ce:$GITLAB_VERSION /bin/sh -c "printf '#!/usr/bin/env ruby \nu = User.first \nu.admin = true \nu.save! \nt = PersonalAccessToken.new({ user: u, name: \"gitbeaker\", scopes: [\"api\", \"read_user\"]})  \nt.expires_at = 365.days.from_now \nt.set_token(ENV[\"PERSONAL_ACCESS_TOKEN\"]) \nt.save!' > /opt/gitlab/embedded/service/gitlab-rails/db/fixtures/production/40_access_token.rb && /assets/wrapper"
+# Verify GitLab image is available (should be pre-pulled in custom image)
+if docker images | grep -q "gitlab/gitlab-ce:$GITLAB_VERSION"; then
+  echo "✅ GitLab image gitlab/gitlab-ce:$GITLAB_VERSION found (pre-pulled)"
+else
+  echo "⚠️  GitLab image not found, pulling it now..."
+  docker pull gitlab/gitlab-ce:$GITLAB_VERSION
+fi
 
-set -H
+# Run GitLab container using the same pattern as docker-compose.yml
+echo "Starting GitLab container..."
+
+docker run -d -p 80:80 \
+  --name gitlab-instance \
+  --hostname gitlab \
+  --privileged \
+  --shm-size=256m \
+  -e GITLAB_ROOT_PASSWORD=$GITLAB_ROOT_PASSWORD \
+  -e GITLAB_PERSONAL_ACCESS_TOKEN=$GITLAB_PERSONAL_ACCESS_TOKEN \
+  -e GITLAB_OMNIBUS_CONFIG="external_url 'http://localhost'; gitlab_rails['monitoring_whitelist'] = ['0.0.0.0/0']; postgresql['shared_buffers'] = '256MB'; postgresql['max_worker_processes'] = 8; prometheus_monitoring['enable'] = false; alertmanager['enable'] = false; node_exporter['enable'] = false; redis_exporter['enable'] = false; postgres_exporter['enable'] = false; gitlab_exporter['enable'] = false;" \
+  --entrypoint /bin/sh \
+  gitlab/gitlab-ce:$GITLAB_VERSION \
+  -c "cat > /opt/gitlab/embedded/service/gitlab-rails/db/fixtures/production/40_access_token.rb << 'EOF'
+#!/usr/bin/env ruby
+u = User.first
+u.admin = true
+u.save!
+token = PersonalAccessToken.new({
+  user: u,
+  name: \"gitbeaker\",
+  scopes: [\"api\", \"read_user\", \"read_repository\", \"write_repository\"]
+})
+token.expires_at = 365.days.from_now
+token.set_token(ENV[\"GITLAB_PERSONAL_ACCESS_TOKEN\"])
+token.save!
+EOF
+exec /assets/init-container"
+
+echo "✅ GitLab startup script completed"


### PR DESCRIPTION
With the backport [support](https://socket.dev/blog/require-esm-backported-to-node-js-20) to node 20+ for allowing the requiring of ESM packages, I don't see the need to continue releasing both versions. This should cut the release size in 1/2 🙌 

Additionally, updated the cicd script to leverage parameterized, and improve the startup script 